### PR TITLE
Added an extra condition to run a Splunk license

### DIFF
--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -33,6 +33,7 @@
   command: "{{ splunk.exec }} add licenses {{ splunk_license_local_path }} -auth admin:{{ splunk.password }}"
   when:
     - splunk.license_uri is defined
+    - splunk_license_local_path is defined and splunk_license_local_path != ""
     - splunk.role == "splunk_license_master" or not splunk.license_master_included
   ignore_errors: true
   notify: 


### PR DESCRIPTION
When no license uri is passed in, "Apply Splunk License" task still runs and shows up as a red text while the actual error is being ignored. Added an extra check to avoid this behavior as requested by a user. 

