### PR TITLE
Supporting app install from direct link or Splunkbase

### DIFF
--- a/roles/splunk_common/tasks/install_app.yml
+++ b/roles/splunk_common/tasks/install_app.yml
@@ -11,7 +11,6 @@
       Content-Type: "application/x-www-form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 300
-  ignore_errors: yes
   when:
     - "'splunkbase.splunk.com' not in app_url"
 
@@ -27,7 +26,6 @@
       Content-Type: "application/x-www-form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 300
-  ignore_errors: yes
   when:
     - "'splunkbase.splunk.com' in app_url"
     - splunkbase_token is defined

--- a/roles/splunk_common/tasks/install_app.yml
+++ b/roles/splunk_common/tasks/install_app.yml
@@ -1,0 +1,34 @@
+---
+- name: Install generic Splunk app
+  uri:
+    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    method: POST
+    user: admin
+    password: "{{ splunk.password }}"
+    validate_certs: False
+    body: "name={{ app_url | urlencode() }}&update=true&filename=true"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: [ 200, 201 ]
+    timeout: 300
+  ignore_errors: yes
+  when:
+    - "'splunkbase.splunk.com' not in app_url"
+
+- name: Install Splunkbase app
+  uri:
+    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    method: POST
+    user: admin
+    password: "{{ splunk.password }}"
+    validate_certs: False
+    body: "name={{ app_url | urlencode() }}&update=true&filename=true&auth={{ splunkbase_token }}"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: [ 200, 201 ]
+    timeout: 300
+  ignore_errors: yes
+  when:
+    - "'splunkbase.splunk.com' in app_url"
+    - splunkbase_token is defined
+    - splunkbase_token != None

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -32,3 +32,8 @@
 - include_tasks: start_splunk.yml
 
 - include_tasks: add_splunk_license.yml
+
+- include_tasks: install_app.yml
+  vars:
+    app_url: "{{ item }}"
+  loop: "{{ splunk.apps_location }}"

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -31,6 +31,12 @@
   command: "{{ splunk.exec }} start --accept-license --answer-yes --no-prompt"
 
 - include_tasks: ../../splunk_common/tasks/enable_s2s_port.yml
+
+- include_tasks: ../../splunk_common/tasks/install_app.yml
+  vars:
+    app_url: "{{ item }}"
+  loop: "{{ splunk.apps_location }}"
+
 - include_tasks: setup_docker_monitoring.yml
   when:
     - docker_monitoring


### PR DESCRIPTION
Tested this with the following:
```
docker run -d -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld -e SPLUNK_APPS_URL=https://splunkbase.splunk.com/app/978/release/1.1/download -e SPLUNKBASE_USERNAME=<redacted> -e SPLUNKBASE_PASSWORD=<redacted> -p 8000 splunk-debian-9

docker run -d -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld -e SPLUNK_APPS_URL=http://internal-url.com/app.tgz -p 8000 splunk-debian-9
```

Additionally, this supports creating a default.yml with a Splunkbase token with the following command:
```
docker run -it -e SPLUNKBASE_USERNAME=<redacted> -e SPLUNKBASE_PASSWORD=<redacted> splunk-debian-9 create-defaults
```
Note that Splunkbase tokens DO expire, so not sure if this is a valid use-case or not.
