### PR TITLE
Handling idempotency of splunk add forward-server

### DIFF
--- a/roles/splunk_common/tasks/add_forward_server.yml
+++ b/roles/splunk_common/tasks/add_forward_server.yml
@@ -1,0 +1,14 @@
+---
+- name: "Enable forwarding to {{ role }}"
+  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth admin:{{ splunk.password }}"
+  with_items: "{{ groups[role] }}"
+  when: "role in groups"
+  register: forward_status
+  until: forward_status.rc == 0 or 'forwarded-server already present' in forward_status.stderr
+  failed_when: 
+    - forward_status.rc != 0
+    - "'forwarded-server already present' not in forward_status.stderr"
+  retries: "{{ retry_num }}"
+  delay: 3
+  notify:
+    - Restart the splunkd service

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -1,24 +1,10 @@
 ---
 - include_tasks: ../../../roles/splunk_common/tasks/set_as_hec_receiver.yml
 
-- name: Configure forwarding to indexers
-  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth admin:{{ splunk.password }}"
-  with_items: "{{ groups['splunk_indexer'] }}"
-  when: "'splunk_indexer' in groups"
-  register: forward_to_indexers
-  until: forward_to_indexers.rc == 0
-  retries: "{{ retry_num }}"
-  delay: 3
-  notify:
-    - Restart the splunkd service
+- include_tasks: ../../../roles/splunk_common/tasks/add_forward_server.yml
+  vars:
+    role: splunk_indexer
 
-- name: Configure forwarding to standalones
-  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth admin:{{ splunk.password }}"
-  with_items: "{{ groups['splunk_standalone'] }}"
-  when: "'splunk_standalone' in groups"
-  register: forward_to_standalones
-  until: forward_to_standalones.rc == 0
-  retries: "{{ retry_num }}"
-  delay: 3
-  notify:
-    - Restart the splunkd service
+- include_tasks: ../../../roles/splunk_common/tasks/add_forward_server.yml
+  vars:
+    role: splunk_standalone

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -67,27 +67,13 @@
 
 # Setup forwarding server
 # http://docs.splunk.com/Documentation/Splunk/latest/Forwarding/Deployanixdfmanually
-- name: Set the current node as a Splunk universal forwarder (discover indexer)
-  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth admin:{{ splunk.password }}"
-  with_items: "{{ groups['splunk_indexer'] }}"
-  register: task_result
-  until: task_result.rc == 0 or "forwarded-server already present" in task_result.stderr
-  retries: "{{retry_num}}"
-  delay: "{{ delay_num }}"
-  when: "'splunk_indexer' in groups"
-  notify:
-    - Restart the splunkd service
+- include_tasks: ../../splunk_common/tasks/add_forward_server.yml
+  vars:
+    role: splunk_indexer
 
-- name: Set the current node as a Splunk universal forwarder (discover standalone)
-  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth admin:{{ splunk.password }}"
-  with_items: "{{ groups['splunk_standalone'] }}"
-  register: task_result
-  until: task_result.rc == 0 or "forwarded-server already present" in task_result.stderr
-  retries: "{{ retry_num }}"
-  delay: "{{ delay_num }}"
-  when: "'splunk_standalone' in groups"
-  notify:
-    - Restart the splunkd service
+- include_tasks: ../../splunk_common/tasks/add_forward_server.yml
+  vars:
+    role: splunk_standalone
 
 # Setup monitoring
 # http://docs.splunk.com/Documentation/Splunk/latest/Data/MonitorfilesanddirectoriesusingtheCLI
@@ -100,6 +86,9 @@
   retries: "{{ retry_num }}"
   delay: "{{ delay_num }}"
   when: splunk.add is defined
+  failed_when:
+    - task_result.rc != 0
+    - "'already exists' not in task_result.stderr"
   ignore_errors: true
   notify:
     - Restart the splunkd service


### PR DESCRIPTION
See discussion here: https://github.com/splunk/docker-splunk/issues/32

There's likely other areas where this should be addressed, most likely things that involve the Splunk CLI. 

Tested with the following compose: [1uf1so_uf_volumes.yaml.tar.gz](https://github.com/splunk/splunk-ansible/files/2480770/1uf1so_uf_volumes.yaml.tar.gz)
```
# Bring up both standalone + uf
SPLUNK_PASSWORD=helloworld docker-compose -f 1uf1so_uf_volumes.yaml up -d
# Wait for containers to hit steady state, kill the uf
docker rm -f uf1
# Recreate the uf, should re-use existing volumes
SPLUNK_PASSWORD=helloworld docker-compose -f 1uf1so_uf_volumes.yaml up -d
```