### PR TITLE
Added fetching environ values for s2s and svc port

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -148,8 +148,8 @@ def getDefaultSplunkVariables(inv):
     vars_scope["splunk"]["pid"] = os.environ.get('SPLUNK_PID') or getValueFromDEFAULTS(
         "splunk.pid") or "{splunk_home_path}/var/run/splunk/splunkd.pid".format(splunk_home_path=splunk_home)
     vars_scope["splunk"]["password"] = getSplunkPassword()
-    vars_scope["splunk"]["svc_port"] = getValueFromDEFAULTS("splunk.svc_port", casting=int) or 8089
-    vars_scope["splunk"]["s2s_port"] = getValueFromDEFAULTS("splunk.s2s_port", casting=int) or 9997
+    vars_scope["splunk"]["svc_port"] = os.environ.get('SPLUNK_SVC_PORT') or getValueFromDEFAULTS("splunk.svc_port", casting=int) or 8089
+    vars_scope["splunk"]["s2s_port"] = os.environ.get('SPLUNK_S2S_PORT') or getValueFromDEFAULTS("splunk.s2s_port", casting=int) or 9997
     vars_scope["splunk"]["http_port"] = getValueFromDEFAULTS("splunk.http_port", casting=int) or 8000
     vars_scope["splunk"]["hec_port"] = getValueFromDEFAULTS("splunk.hec_port", casting=int) or 8088
     vars_scope["splunk"]["hec_disabled"] = getValueFromDEFAULTS("splunk.hec_disabled", casting=int) or 0


### PR DESCRIPTION
This is a change required to resolve https://github.com/splunk/docker-splunk/issues/23. 

We simply need to grab these environment variables and feed them into the Ansible dynamic inventory.