### PR TITLE
Enable smartstore functionality

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -282,6 +282,13 @@ def obfuscate_vars(inventory):
         inventory["all"]["vars"]["splunk"]["shc"]["secret"] = stars
     if inventory["all"]["vars"]["splunk"].get("idxc") and inventory["all"]["vars"]["splunk"]["idxc"].get("secret"):
         inventory["all"]["vars"]["splunk"]["idxc"]["secret"] = stars
+    if inventory["all"]["vars"]["splunk"].get("smartstore", False):
+        for index in range(0, len(inventory["all"]["vars"]["splunk"]["smartstore"])):
+            if inventory["all"]["vars"]["splunk"]["smartstore"][index].get("s3", False):
+                if inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"].get("access_key", False):
+                    inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"]["access_key"] = stars
+                if inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"].get("secret_key", False):
+                    inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"]["secret_key"] = stars
     return inventory
 
 def create_parser():

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -169,6 +169,7 @@ def getDefaultSplunkVariables(inv):
     vars_scope["splunk"]["idxc"]["replication_factor"] = getValueFromDEFAULTS("splunk.idxc.replication_factor", casting=int) or 3
     vars_scope["splunk"]["idxc"]["replication_port"] = getValueFromDEFAULTS("splunk.idxc.replication_port", casting=int) or 4001
     vars_scope["splunk"]["enable_service"] = os.environ.get('SPLUNK_ENABLE_SERVICE') or False
+    vars_scope["splunk"]["smartstore"] = getValueFromDEFAULTS("splunk.smartstore")
 
     vars_scope["splunk"]["app_paths"] = {}
     if PLATFORM == "linux":
@@ -245,7 +246,7 @@ def getRandomString():
 def push_defaults(url=None):
     '''
     This method accepts a url argument, but that argument can be None.  If it is None, then we load from a file
-    In this way, we manage two different methods of loading the default file (which contains potentially sentive
+    In this way, we manage two different methods of loading the default file (which contains potentially sensitive
     information
     '''
     if url:
@@ -324,6 +325,7 @@ def main():
     DEFAULTS = push_defaults(url)
 
     getSplunkInventory(inventory)
+
     if args.write_to_file:
         with open(os.path.join(HERE, "ansible_inventory.json"), "w") as outfile:
             json.dump(obfuscate_vars(inventory), outfile, sort_keys=True,indent=4, ensure_ascii=False)

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -30,6 +30,7 @@
     - { key: "remote.s3.secret_key", value: "{{ index.s3.secret_key }}" }
     - { key: "remote.s3.endpoint", value: "{{ index.s3.endpoint }}" }
   when: index.s3 is defined
+  no_log: true
         
 - name: Write paths for the index
   ini_file:

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -2,7 +2,7 @@
 - name: Add stanza for the index specified
   ini_file:
     dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
-    section: "{{ index.index }}"
+    section: "{{ index.indexName }}"
     option: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -34,12 +34,12 @@
 - name: Write paths for the index
   ini_file:
     dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
-    section: "{{ index.index }}"
+    section: "{{ index.indexName }}"
     option: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
     - { key: "homePath", value: "{{ index.homePath }}" }
     - { key: "thawedPath", value: "{{ index.thawedPath }}" }
     - { key: "coldPath", value: "{{ index.coldPath }}" }
-  when: index.index != "default"
+  when: index.indexName != "default"
 

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -1,0 +1,45 @@
+---
+- name: Add stanza for the index specified
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "{{ index.index }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { key: "remotePath", value: "volume:{{ index.remoteName }}/$_index_name" }
+    - { key: "repFactor", value: "auto" }
+
+- name: Add path for the remote specified
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "volume:{{ index.remoteName }}"
+    option: "{{ item.key }}"
+    value:  "{{ item.value }}"
+  with_items:
+    - { key: "storageType", value: "remote" }
+    - { key: "path", value: "{{ index.scheme }}://{{ index.remoteLocation }}" }
+
+- name: Write AWS credentials for the remote specified
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "volume:{{ index.remoteName }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { key: "remote.s3.access_key", value: "{{ index.s3.access_key }}" }
+    - { key: "remote.s3.secret_key", value: "{{ index.s3.secret_key }}" }
+    - { key: "remote.s3.endpoint", value: "{{ index.s3.endpoint }}" }
+  when: index.s3 is defined
+        
+- name: Write paths for the index
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "{{ index.index }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { key: "homePath", value: "{{ index.homePath }}" }
+    - { key: "thawedPath", value: "{{ index.thawedPath }}" }
+    - { key: "coldPath", value: "{{ index.coldPath }}" }
+  when: index.index != "default"
+

--- a/roles/splunk_cluster_master/tasks/enable_smartstore.yml
+++ b/roles/splunk_cluster_master/tasks/enable_smartstore.yml
@@ -1,12 +1,4 @@
 ---
-- name: Create indexes.conf conditionally
-  copy:
-    content: ""
-    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
-    force: no
-    owner: "{{ splunk.user }}"
-    group: "{{ splunk.group }}"
-
 - name: Configure each index
   include_tasks: configure_indexes.yml
   loop: "{{ splunk.smartstore }}"

--- a/roles/splunk_cluster_master/tasks/enable_smartstore.yml
+++ b/roles/splunk_cluster_master/tasks/enable_smartstore.yml
@@ -1,0 +1,14 @@
+---
+- name: Create indexes.conf conditionally
+  copy:
+    content: ""
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    force: no
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+
+- name: Configure each index
+  include_tasks: configure_indexes.yml
+  loop: "{{ splunk.smartstore }}"
+  loop_control:
+    loop_var: index

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -53,6 +53,8 @@
     and ("Rolling restart of the peers" not in splunk_cluster_bundle_result.stderr)
     and ("Applying bundle" not in splunk_cluster_bundle_result.stdout)
     and ("Applying new" not in splunk_cluster_bundle_result.stdout)
-  changed_when: splunk_cluster_bundle_result.stdout.find('Applying bundle') != -1
+  changed_when:
+    - splunk_cluster_bundle_result.stdout.find('Applying') != -1
+    - splunk_cluster_bundle_result.stdout.find('bundle') != -1
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -30,6 +30,9 @@
   register: set_indexer_discovery
   changed_when: set_indexer_discovery.status == 201
 
+- include_tasks: enable_smartstore.yml
+  when: splunk.smartstore
+
 - name: Set the current node as a Splunk indexer cluster master
   command: "{{ splunk.exec }} edit cluster-config -mode master -replication_factor {{ splunk.idxc.replication_factor }} -search_factor {{ splunk.idxc.search_factor }} -secret '{{ splunk.idxc.secret }}' -cluster_label '{{ splunk.idxc.label }}' -auth 'admin:{{ splunk.password }}'"
   register: task_result

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -52,6 +52,7 @@
     ("No new bundle will be pushed" not in splunk_cluster_bundle_result.stderr)
     and ("Rolling restart of the peers" not in splunk_cluster_bundle_result.stderr)
     and ("Applying bundle" not in splunk_cluster_bundle_result.stdout)
+    and ("Applying new" not in splunk_cluster_bundle_result.stdout)
   changed_when: splunk_cluster_bundle_result.stdout.find('Applying bundle') != -1
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml

--- a/roles/splunk_indexer/tasks/indexer_clustering.yml
+++ b/roles/splunk_indexer/tasks/indexer_clustering.yml
@@ -10,5 +10,5 @@
   retries: "{{ retry_num }}"
   delay: 3
   ignore_errors: yes
-  notify:
+  notify: 
     - Restart the splunkd service


### PR DESCRIPTION
- Add Ansible plays to write remote/index config to indexes.conf
- Change environ.py to read smartstore config from default.yml and propagate to Ansible
- Supports multiple indexes using a simple remote