### PR TITLE
Fix failure condition for cluster bundle distribution

### DIFF
--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -49,12 +49,11 @@
   command: "{{ splunk.exec }} apply cluster-bundle -auth admin:{{ splunk.password }} --skip-validation --answer-yes"
   register: splunk_cluster_bundle_result
   failed_when: >
-    ("No new bundle will be pushed" not in splunk_cluster_bundle_result.stderr)
-    and ("Rolling restart of the peers" not in splunk_cluster_bundle_result.stderr)
-    and ("Applying bundle" not in splunk_cluster_bundle_result.stdout)
-    and ("Applying new" not in splunk_cluster_bundle_result.stdout)
-  changed_when:
-    - splunk_cluster_bundle_result.stdout.find('Applying') != -1
-    - splunk_cluster_bundle_result.stdout.find('bundle') != -1
+    ((splunk_cluster_bundle_result.stdout is not search("[Aa]pply")
+      or ("bundle" not in splunk_cluster_bundle_result.stdout)))
+    and ("already" not in splunk_cluster_bundle_result.stderr)
+  changed_when: >
+    (splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
+    and (splunk_cluster_bundle_result.stdout.find('bundle') != -1)
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -56,7 +56,4 @@
     (splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
     and (splunk_cluster_bundle_result.stdout.find('bundle') != -1)
 
-- debug: var=splunk_cluster_bundle_result.stdout
-- debug: var=splunk_cluster_bundle_result.stderr
-
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -49,11 +49,14 @@
   command: "{{ splunk.exec }} apply cluster-bundle -auth admin:{{ splunk.password }} --skip-validation --answer-yes"
   register: splunk_cluster_bundle_result
   failed_when: >
-    ((splunk_cluster_bundle_result.stdout is not search("[Aa]pply")
-      or ("bundle" not in splunk_cluster_bundle_result.stdout)))
+    ((splunk_cluster_bundle_result.stdout is not search("[Aa]pply"))
+      or ("bundle" not in splunk_cluster_bundle_result.stdout))
     and ("already" not in splunk_cluster_bundle_result.stderr)
   changed_when: >
     (splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
     and (splunk_cluster_bundle_result.stdout.find('bundle') != -1)
+
+- debug: var=splunk_cluster_bundle_result.stdout
+- debug: var=splunk_cluster_bundle_result.stderr
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -45,6 +45,7 @@
 - name: Flush restart handlers
   meta: flush_handlers
 
+# Fails if a cluster bundle did not already exist and yet we did not apply a new bundle
 - name: Apply the cluster bundle to the Splunk cluster master
   command: "{{ splunk.exec }} apply cluster-bundle -auth admin:{{ splunk.password }} --skip-validation --answer-yes"
   register: splunk_cluster_bundle_result


### PR DESCRIPTION
Change the "failure" condition to check if the cluster bundle did NOT already exist and the normal stdout terms "applying, bundle" are not present.

Change the "changed_when" condition to check the same.