### PR TITLE
Task/check first run

### DIFF
--- a/roles/splunk_common/tasks/check_first_run.yml
+++ b/roles/splunk_common/tasks/check_first_run.yml
@@ -1,0 +1,8 @@
+---
+- name: Check if Splunk is running for the first time
+  stat: path="{{ splunk.build_location}}"
+  register: splunk_build_location
+
+- name: Set first run fact
+  set_fact:
+    first_run: "{{ splunk_build_location.stat.exists == True }}"

--- a/roles/splunk_common/tasks/clean_user_seed.yml
+++ b/roles/splunk_common/tasks/clean_user_seed.yml
@@ -1,0 +1,7 @@
+---
+- name: Remove user-seed.conf
+  file:
+    dest: "{{ splunk.home }}/etc/system/local/user-seed.conf"
+    state: "absent"
+  notify:
+    - Restart the splunkd service

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -1,0 +1,19 @@
+---
+- name: Install Splunk
+  unarchive:
+    src: "{{ splunk.build_location }}"
+    dest: "{{ splunk.opt }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    remote_src: "{{ splunk.build_remote_src }}"
+  when: ansible_system is match("Linux")
+
+- name: Install Splunk (Windows)
+  command: "msiexec /I {{ splunk.build_location }} AGREETOLICENSE=yes LAUNCHSPLUNK=0 INSTALLDIR=C:\\\\opt\\\\splunk /passive /qn"
+  when: ansible_system is match("CYGWIN*|Win32NT")
+
+- name: Remove installer
+  file:
+    dest: "{{ splunk.build_location }}"
+    state: "absent"
+  ignore_errors: yes

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -1,28 +1,15 @@
 ---
-- name: Install Splunk
-  unarchive:
-    src: "{{ splunk.build_location }}"
-    dest: "{{ splunk.opt }}"
-    owner: "{{ splunk.user }}"
-    group: "{{ splunk.group }}"
-    remote_src: "{{ splunk.build_remote_src }}"
-  when: ansible_system is match("Linux")
+- include_tasks: check_first_run.yml
 
-- name: Install Splunk (Windows)
-  command: "msiexec /I {{ splunk.build_location }} AGREETOLICENSE=yes LAUNCHSPLUNK=0 INSTALLDIR=C:\\\\opt\\\\splunk /passive /qn"
-  when: ansible_system is match("CYGWIN*|Win32NT")
+- include_tasks: install_splunk.yml
+  when:
+    - first_run is defined
+    - first_run | bool
 
-- name: Generate user-seed.conf
-  ini_file:
-    dest: "{{ splunk.home }}/etc/system/local/user-seed.conf"
-    section: user_info
-    option: "{{ item.opt }}"
-    value: "{{ item.val }}"
-  with_items:
-    - { opt: 'USERNAME', val: 'admin' }
-    - { opt: 'PASSWORD', val: '{{ splunk.password }}' }
-  loop_control:
-    label: "{{ item.opt }}"
+- include_tasks: set_user_seed.yml
+  when:
+    - first_run is defined
+    - first_run | bool
 
 - include_tasks: enable_s2s_port.yml
 
@@ -31,12 +18,17 @@
 
 - include_tasks: set_splunk_secret.yml
   when:
-      - splunk.secret is defined
-      - splunk.secret
+    - splunk.secret is defined
+    - splunk.secret
 
 - include_tasks: start_splunk.yml
 
+- include_tasks: clean_user_seed.yml
+
 - include_tasks: add_splunk_license.yml
+  when:
+    - first_run is defined
+    - first_run | bool
 
 - include_tasks: install_app.yml
   vars:

--- a/roles/splunk_common/tasks/set_user_seed.yml
+++ b/roles/splunk_common/tasks/set_user_seed.yml
@@ -1,0 +1,12 @@
+---
+- name: Generate user-seed.conf
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/user-seed.conf"
+    section: user_info
+    option: "{{ item.opt }}"
+    value: "{{ item.val }}"
+  with_items:
+    - { opt: 'USERNAME', val: 'admin' }
+    - { opt: 'PASSWORD', val: '{{ splunk.password }}' }
+  loop_control:
+    label: "{{ item.opt }}"


### PR DESCRIPTION
- Check for first run
- Make install separate task
- Cleanup installer
- Make user seed separate task
- Cleanup user seed after startup
- Only apply license upon first install.

This allows for a more speedy restart of a container.
In addition to this. The user seed file normally gets removed after starting Splunk. However if Splunk gets restarted it will leave any user seed file. Leaving the admin password exposed through the /conf-user-seed REST API.