### PR TITLE
Task/enable ssl on gui

### DIFF
--- a/docs/USING_DEFAULTS.md
+++ b/docs/USING_DEFAULTS.md
@@ -22,9 +22,18 @@ splunk:
     exec: /opt/splunk/bin/splunk
     pid: /opt/splunk/var/run/splunk/splunkd.pid
     password: "{{ splunk_password | default('invalid_password') }}"
+    # This will be the secret that Splunk will use to encrypt/decrypt.
+    # secret: <secret>
     svc_port: 8089
     s2s_port: 9997
+    # s2s_enable opens the s2s_port for splunktcp ingestion.
+    s2s_enable: 0
     http_port: 8000
+    # This will turn on SSL on the GUI and sets the path to the certificate to be used.
+    http_enableSSL: 0
+    # http_enableSSL_cert:
+    # http_enableSSL_privKey:
+    # http_enableSSL_privKey_password:
     hec_port: 8088
     hec_disabled: 0
     hec_enableSSL: 1

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -152,7 +152,12 @@ def getDefaultSplunkVariables(inv):
     vars_scope["splunk"]["secret"] = getValueFromDEFAULTS("splunk.secret")
     vars_scope["splunk"]["svc_port"] = os.environ.get('SPLUNK_SVC_PORT') or getValueFromDEFAULTS("splunk.svc_port", casting=int) or 8089
     vars_scope["splunk"]["s2s_port"] = os.environ.get('SPLUNK_S2S_PORT') or getValueFromDEFAULTS("splunk.s2s_port", casting=int) or 9997
+    vars_scope["splunk"]["s2s_enable"] = os.environ.get('SPLUNK_S2S_ENABLE') or getValueFromDEFAULTS("splunk.s2s_enable", casting=int) or 0
     vars_scope["splunk"]["http_port"] = getValueFromDEFAULTS("splunk.http_port", casting=int) or 8000
+    vars_scope["splunk"]["http_enableSSL"] = getValueFromDEFAULTS("splunk.http_enableSSL", casting=int) or 0
+    vars_scope["splunk"]["http_enableSSL_cert"] = getValueFromDEFAULTS("splunk.http_enableSSL_cert")
+    vars_scope["splunk"]["http_enableSSL_privKey"] = getValueFromDEFAULTS("splunk.http_enableSSL_privKey")
+    vars_scope["splunk"]["http_enableSSL_privKey_password"] = getValueFromDEFAULTS("splunk.http_enableSSL_privKey_password")
     vars_scope["splunk"]["hec_port"] = getValueFromDEFAULTS("splunk.hec_port", casting=int) or 8088
     vars_scope["splunk"]["hec_disabled"] = getValueFromDEFAULTS("splunk.hec_disabled", casting=int) or 0
     vars_scope["splunk"]["hec_enableSSL"] = getValueFromDEFAULTS("splunk.hec_enableSSL", casting=int) or 1

--- a/roles/splunk_common/tasks/enable_ssl_on_gui.yml
+++ b/roles/splunk_common/tasks/enable_ssl_on_gui.yml
@@ -1,0 +1,37 @@
+---
+- name: Enable Web SSL 
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "enableSplunkWebSSL"
+    value: "True"
+
+- name: Set Web certificate path
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "serverCert"
+    value: "{{ splunk.http_enableSSL_cert }}"
+  when:
+    - splunk.http_enableSSL_cert is defined
+    - splunk.http_enableSSL_cert
+
+- name: Set Web private key path
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "privKeyPath"
+    value: "{{ splunk.http_enableSSL_privKey }}"
+  when:
+    - splunk.http_enableSSL_privKey is defined
+    - splunk.http_enableSSL_privKey
+
+- name: Set Web private key password
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "sslPassword"
+    value: "{{ splunk.http_enableSSL_privKey_password }}"
+  when:
+    - splunk.http_enableSSL_privKey_password is defined
+    - splunk.http_enableSSL_privKey_password

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -12,6 +12,9 @@
     - first_run | bool
 
 - include_tasks: enable_s2s_port.yml
+  when:
+    - splunk.s2s_enable is defined
+    - splunk.s2s_enable | bool
 
 - include_tasks: enable_service.yml
   when: splunk.enable_service and ansible_system is match("Linux")
@@ -20,6 +23,11 @@
   when:
     - splunk.secret is defined
     - splunk.secret
+
+- include_tasks: enable_ssl_on_gui.yml
+  when:
+    - splunk.http_enableSSL is defined
+    - splunk.http_enableSSL | bool
 
 - include_tasks: start_splunk.yml
 


### PR DESCRIPTION
- Added ssl on GUI task
- Don't open s2s by default
- Added some defaults to the doc.

By default the s2s port should be closed, only if requested it should be opened.
SSL should be parameterised so that it can be opened by config even before Splunk starts.