### PR TITLE
add more comments and make the conditionals simpler

### DIFF
--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -45,16 +45,36 @@
 - name: Flush restart handlers
   meta: flush_handlers
 
-# Fails if a cluster bundle did not already exist and yet we did not apply a new bundle
+# Fails if a cluster bundle did not already exist and yet we did not apply a new bundle.
+# The failed condition is basically eventHasError && bundleNotAlreadyExists. 
+# The changed condition is basically !eventHasError && bundleNotAlreadyExists.
+#
+# Stderr/Stdout cases are:
+# 1) The cluster bundle already exists on the indexers. Then stderr will contain the message
+# "...bundle already exists" and we should *not* mark the play as either failed or changed.
+#
+# 2) The cluster bundle does not exist on the indexers but an error occurred during bundle
+# application. Then stderr will NOT contain the word "already" and stdout will contain an error
+# message such as "Error occurred when applying cluster bundle", "sh: invalid operation, exit code 1"
+# or no message at all.
+#
+# 3) The cluster bundle does not exist and we successfully applied the cluster bundle. Then stdout
+# will contain something to the effect of "Applying new bundle. Restarting indexers..". Thus, we
 - name: Apply the cluster bundle to the Splunk cluster master
   command: "{{ splunk.exec }} apply cluster-bundle -auth admin:{{ splunk.password }} --skip-validation --answer-yes"
   register: splunk_cluster_bundle_result
   failed_when: >
     ((splunk_cluster_bundle_result.stdout is not search("[Aa]pply"))
-      or ("bundle" not in splunk_cluster_bundle_result.stdout))
+      or ("bundle" not in splunk_cluster_bundle_result.stdout)
+      or (splunk_cluster_bundle_result.stdout is search("[Ee]rror")))
     and ("already" not in splunk_cluster_bundle_result.stderr)
   changed_when: >
-    (splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
-    and (splunk_cluster_bundle_result.stdout.find('bundle') != -1)
+    ((splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
+      and ("bundle" in splunk_cluster_bundle_result.stdout)
+      and (splunk_cluster_bundle_result.stdout is not search("[Ee]rror")))
+    and ("already" not in splunk_cluster_bundle_result.stderr)
+
+- debug: var=splunk_cluster_bundle_result.stdout
+- debug: var=splunk_cluster_bundle_result.stderr
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml


### PR DESCRIPTION
This PR adds comments to the failure condition for the task of pushing cluster bundle to indexers. It also makes the conditionals easier to understand.

The two debug statements at the end make debugging easier and also serve to show the result of the bundle pushing. We register the result anyways so we might as well print it.