### PR TITLE
Task/add generic conf

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -29,6 +29,8 @@
     - splunk.http_enableSSL is defined
     - splunk.http_enableSSL | bool
 
+- include_tasks: set_any_generic_config.yml
+
 - include_tasks: start_splunk.yml
 
 - include_tasks: clean_user_seed.yml

--- a/roles/splunk_common/tasks/set_any_generic_config.yml
+++ b/roles/splunk_common/tasks/set_any_generic_config.yml
@@ -1,0 +1,8 @@
+---
+- include_tasks: set_config_file.yml
+  vars:
+    conf_file: "{{ item.key }}.conf"
+    conf_stanzas: "{{ item.value }}"
+  when:
+    - (item.value | length > 0)
+  with_dict: "{{ splunk.conf }}"

--- a/roles/splunk_common/tasks/set_config_file.yml
+++ b/roles/splunk_common/tasks/set_config_file.yml
@@ -1,0 +1,21 @@
+---
+- name: Create {{ conf_file }} if not existing
+  copy:
+    dest: "{{ splunk.home }}/etc/system/local/{{ conf_file}}"
+    mode: u=rw,g=,o=
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    content: ""
+    force: no
+
+- include_tasks: set_config_stanza.yml
+  vars:
+    stanza_name: "{{ stanza.key }}"
+    stanza_settings: "{{ stanza.value }}"
+  when:
+    - stanza.value is defined
+    - stanza.value
+    - (stanza.value | length > 0)
+  with_dict: "{{ conf_stanzas }}"
+  loop_control:
+    loop_var: stanza

--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -1,0 +1,20 @@
+---
+#- name: "Create section {{ stanza_name }} if not existing"
+#  lineinfile:
+#    path: "{{ splunk.home }}/etc/system/local/{{ conf_file}}"
+#    create: True
+#    line: "[{{ stanza_name }}]"
+#    regexp: "^{{ stanza_name }}"
+#    state: present
+
+- name: "Set options in {{ stanza_name }}"
+  ini_file:
+    path: "{{ splunk.home }}/etc/system/local/{{ conf_file}}"
+    section: "{{ stanza_name }}"
+    option: "{{ stanza_setting.key }}"
+    value: "{{ stanza_setting.value }}"
+    allow_no_value: True
+    state: present
+  with_dict: "{{ stanza_settings }}"
+  loop_control:
+    loop_var: stanza_setting


### PR DESCRIPTION
This task allows for any generic configuration file to be added, using any generic section and settings.
Combined with the cascaded configuration in PR #29 this virtually allows any scenario to be covered.

For example:
```
splunk:
    conf:
        deploymentclient:
            target-broker:deploymentServer:
                targetUri: "<deploymentServer>:8089"
        inputs:
            monitor:///var/log/messages:
                disabled: False
                index: main
```