### PR TITLE
Fixing logic of check_first_run.yml

### DIFF
--- a/roles/splunk_common/tasks/change_splunk_directory_owner.yml
+++ b/roles/splunk_common/tasks/change_splunk_directory_owner.yml
@@ -1,5 +1,6 @@
 ---
-- file:
+- name: Update Splunk directory owner
+  file:
     path: "{{ splunk.home }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"

--- a/roles/splunk_common/tasks/check_first_run.yml
+++ b/roles/splunk_common/tasks/check_first_run.yml
@@ -1,8 +1,9 @@
 ---
-- name: Check if Splunk is running for the first time
-  stat: path="{{ splunk.build_location}}"
-  register: splunk_build_location
+- name: Check for existing installation
+  stat: 
+    path: "{{ splunk.exec }}"
+  register: pre_existing_splunk
 
 - name: Set first run fact
   set_fact:
-    first_run: "{{ splunk_build_location.stat.exists == True }}"
+    first_run: "{{ not pre_existing_splunk.stat.exists | default(True) }}"


### PR DESCRIPTION
Fixing the logic here. Previously, when SPLUNK_BUILD_URL is used as a run-time environment variable, we used to pull the build dynamically and run Splunk using that tgz. The first-run logic here seems to have broken that feature.

Also opening this up for discussion, but I'm wondering if we need to check whether or not this was a first-time run at all? The only case where this seems to matter is if an existing container died and was restarted - in this situation, we can probably save time + avoid some setup steps. However, if we make an effort to enforce idempotency, that may be redundant.