### PR TITLE
Suppress errors when ansible_post_tasks is a file path

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -9,6 +9,7 @@
       when:
         - ansible_pre_tasks is defined
         - ansible_pre_tasks is not none
+        - ansible_pre_tasks is match("^(http|https|file)://.*")
         - ansible_system is match("Linux")
       get_url:
         url: "{{ ansible_pre_tasks }}"
@@ -22,6 +23,7 @@
       when:
         - ansible_pre_tasks is defined
         - ansible_pre_tasks is not none
+        - ansible_pre_tasks is match("^(http|https|file)://.*")
         - ansible_system is not match("Linux")
       win_get_url:
         url: "{{ ansible_pre_tasks }}"
@@ -72,7 +74,7 @@
         - ansible_post_tasks is defined
         - ansible_post_tasks is not none
         - ansible_system is match("Linux")
-        - ansible_post_tasks is match("^(http|https)://.*")
+        - ansible_post_tasks is match("^(http|https|file)://.*")
       get_url:
         url: "{{ ansible_post_tasks }}"
         dest: "{{ config.defaults_dir + '/splunk_ansible_post_tasks.yml' }}"
@@ -86,7 +88,7 @@
         - ansible_post_tasks is defined
         - ansible_post_tasks is not none
         - ansible_system is not match("Linux")
-        - ansible_post_tasks is match("^(http|https)://.*")
+        - ansible_post_tasks is match("^(http|https|file)://.*")
       win_get_url:
         url: "{{ ansible_post_tasks }}"
         dest: "{{ config.defaults_dir + '\\splunk_ansible_post_tasks.yml' }}"

--- a/site.yml
+++ b/site.yml
@@ -72,6 +72,7 @@
         - ansible_post_tasks is defined
         - ansible_post_tasks is not none
         - ansible_system is match("Linux")
+        - ansible_post_tasks is match("^(http|https)://.*")
       get_url:
         url: "{{ ansible_post_tasks }}"
         dest: "{{ config.defaults_dir + '/splunk_ansible_post_tasks.yml' }}"
@@ -85,6 +86,7 @@
         - ansible_post_tasks is defined
         - ansible_post_tasks is not none
         - ansible_system is not match("Linux")
+        - ansible_post_tasks is match("^(http|https)://.*")
       win_get_url:
         url: "{{ ansible_post_tasks }}"
         dest: "{{ config.defaults_dir + '\\splunk_ansible_post_tasks.yml' }}"


### PR DESCRIPTION
Only run tasks "Download pre-setup playbooks" when ansible_post_tasks is a web URL (suppress errors when it is a file path)