### PR TITLE
Update oracle 8 link

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -106,7 +106,8 @@ def getDefaultVars():
     # Check required Java installation
     if os.environ.get("JAVA_VERSION", "").lower() in ['oracle:8', 'openjdk:8']:
         defaultVars["java_version"] = os.environ.get("JAVA_VERSION", "")
-        defaultVars["java_oracle_url"] = os.environ.get("JAVA_ORACLE_URL", None)
+        defaultVars["java_oracle_url"] = os.environ.get("JAVA_ORACLE_URL", "https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz")
+        defaultVars["java_update_version"] = re.search("jdk-8u(\d+)-linux-x64.tar.gz", defaultVars["java_oracle_url"]).group(1)
 
     # Lower indexer search/replication factor when indexer hosts less than 3
     if inventory.has_key("splunk_indexer") and inventory["splunk_indexer"].has_key("hosts") and len(inventory["splunk_indexer"]["hosts"]) < 3:

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -107,7 +107,10 @@ def getDefaultVars():
     if os.environ.get("JAVA_VERSION", "").lower() in ['oracle:8', 'openjdk:8']:
         defaultVars["java_version"] = os.environ.get("JAVA_VERSION", "")
         defaultVars["java_oracle_url"] = os.environ.get("JAVA_ORACLE_URL", "https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz")
-        defaultVars["java_update_version"] = re.search("jdk-8u(\d+)-linux-x64.tar.gz", defaultVars["java_oracle_url"]).group(1)
+                try:
+            defaultVars["java_update_version"] = re.search("jdk-8u(\d+)-linux-x64.tar.gz", defaultVars["java_oracle_url"]).group(1)
+        except:
+            raise Exception("Invalid Java download URL format")
 
     # Lower indexer search/replication factor when indexer hosts less than 3
     if inventory.has_key("splunk_indexer") and inventory["splunk_indexer"].has_key("hosts") and len(inventory["splunk_indexer"]["hosts"]) < 3:

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -106,6 +106,7 @@ def getDefaultVars():
     # Check required Java installation
     if os.environ.get("JAVA_VERSION", "").lower() in ['oracle:8', 'openjdk:8']:
         defaultVars["java_version"] = os.environ.get("JAVA_VERSION", "")
+        defaultVars["java_oracle_url"] = os.environ.get("JAVA_ORACLE_URL", None)
 
     # Lower indexer search/replication factor when indexer hosts less than 3
     if inventory.has_key("splunk_indexer") and inventory["splunk_indexer"].has_key("hosts") and len(inventory["splunk_indexer"]["hosts"]) < 3:

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download the Java distribution
   get_url:
-    url: https://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz
+    url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
     headers:
-        Cookie: oraclelicense=accept-securebackup-cookie
+      Cookie: oraclelicense=accept-securebackup-cookie
     dest: /opt/container_artifact
   when:
     - ansible_distribution == 'Debian'
@@ -13,7 +13,7 @@
 
 - name: Untar the Java distribution
   unarchive:
-    src: /opt/container_artifact/jdk-8u191-linux-x64.tar.gz 
+    src: /opt/container_artifact/jdk-8u201-linux-x64.tar.gz
     dest: /opt/container_artifact
   when:
     - ansible_distribution == 'Debian'
@@ -22,7 +22,7 @@
   become_user: root
 
 - name: Create alternatives for installed JDK Java binary
-  shell: update-alternatives --install /usr/bin/java java /opt/container_artifact/jdk1.8.0_191/bin/java 100
+  shell: update-alternatives --install /usr/bin/java java /opt/container_artifact/jdk1.8.0_201/bin/java 100
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -30,7 +30,7 @@
   become_user: root
 
 - name: Create alternatives for installed JDK Javac binary
-  shell: update-alternatives --install /usr/bin/javac javac /opt/container_artifact/jdk1.8.0_191/bin/javac 100
+  shell: update-alternatives --install /usr/bin/javac javac /opt/container_artifact/jdk1.8.0_201/bin/javac 100
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -38,7 +38,7 @@
   become_user: root
 
 - name: Set Java 
-  shell: update-alternatives --set java /opt/container_artifact/jdk1.8.0_191/bin/java
+  shell: update-alternatives --set java /opt/container_artifact/jdk1.8.0_201/bin/java
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -46,7 +46,7 @@
   become_user: root
 
 - name: Set Javac 
-  shell: update-alternatives --set javac /opt/container_artifact/jdk1.8.0_191/bin/javac
+  shell: update-alternatives --set javac /opt/container_artifact/jdk1.8.0_201/bin/javac
   when:
     - ansible_distribution == 'Debian'
   become: yes

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download the Java distribution
   get_url:
-    url: https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
+    url: "{{ java_oracle_url | default('https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz', true) }}"
     headers:
       Cookie: oraclelicense=accept-securebackup-cookie
     dest: /opt/container_artifact

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -5,6 +5,11 @@
     headers:
       Cookie: oraclelicense=accept-securebackup-cookie
     dest: /opt/container_artifact
+    timeout: 30
+  register: download_result
+  until: download_result.status_code == 200
+  retries: 5
+  delay: 10
   when:
     - ansible_distribution == 'Debian'
   become: yes

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download the Java distribution
   get_url:
-    url: "{{ java_oracle_url | default('https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz', true) }}"
+    url: "{{ java_oracle_url }}"
     headers:
       Cookie: oraclelicense=accept-securebackup-cookie
     dest: /opt/container_artifact
@@ -13,7 +13,7 @@
 
 - name: Untar the Java distribution
   unarchive:
-    src: /opt/container_artifact/jdk-8u201-linux-x64.tar.gz
+    src: "/opt/container_artifact/jdk-8u{{ java_update_version }}-linux-x64.tar.gz"
     dest: /opt/container_artifact
   when:
     - ansible_distribution == 'Debian'
@@ -22,7 +22,7 @@
   become_user: root
 
 - name: Create alternatives for installed JDK Java binary
-  shell: update-alternatives --install /usr/bin/java java /opt/container_artifact/jdk1.8.0_201/bin/java 100
+  shell: "update-alternatives --install /usr/bin/java java /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/java 100"
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -30,7 +30,7 @@
   become_user: root
 
 - name: Create alternatives for installed JDK Javac binary
-  shell: update-alternatives --install /usr/bin/javac javac /opt/container_artifact/jdk1.8.0_201/bin/javac 100
+  shell: "update-alternatives --install /usr/bin/javac javac /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/javac 100"
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -38,7 +38,7 @@
   become_user: root
 
 - name: Set Java 
-  shell: update-alternatives --set java /opt/container_artifact/jdk1.8.0_201/bin/java
+  shell: "update-alternatives --set java /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/java"
   when:
     - ansible_distribution == 'Debian'
   become: yes
@@ -46,10 +46,9 @@
   become_user: root
 
 - name: Set Javac 
-  shell: update-alternatives --set javac /opt/container_artifact/jdk1.8.0_201/bin/javac
+  shell: "update-alternatives --set javac /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/javac"
   when:
     - ansible_distribution == 'Debian'
   become: yes
   become_method: sudo
   become_user: root
-


### PR DESCRIPTION
Updated the link for downloading Java Oracle 8. The old one stopped working and gets 404 error. You can see this when doing `make sample-compose-up` with the `1so_java.yaml` test scenario in docker-splunk. 