### PR TITLE
Apply shcluster bundle optional

### DIFF
--- a/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
+++ b/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
@@ -20,3 +20,8 @@
   retries: "{{ retry_num }}"
   delay: 3
   ignore_errors: true
+
+- debug: 
+    msg: "WARNING: Applying shcluster bundle failed - proceeding anyways..."
+  when: 
+    - shcluster_bundle.rc != 0

--- a/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
+++ b/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
@@ -17,5 +17,6 @@
   until: shcluster_bundle.rc == 0 or "Found zero deployable apps" in shcluster_bundle.stderr
   changed_when: shcluster_bundle.rc == 0
   failed_when: shcluster_bundle.rc != 0 and "Found zero deployable apps" not in shcluster_bundle.stderr
-  retries: 3
-  delay: 5
+  retries: "{{ retry_num }}"
+  delay: 3
+  ignore_errors: true


### PR DESCRIPTION
This is too restrictive in it not ignoring errors and fails too quickly, as well.

1. Ignoring errors, as this failing should cause an entire cluster to fail to boot. This can cause race conditions with the deployer, captain and searchers.
2. Using `retry_num` for `retries` and setting `delay: 3` to match other plays within this repo.