### PR TITLE
Bugfix/ess app install

### DIFF
--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -10,3 +10,5 @@
 - include_tasks: push_apps_to_indexers.yml
   when:
     - splunk.apps_location
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -11,4 +11,4 @@
   when:
     - splunk.apps_location
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -23,7 +23,7 @@
   register: app_source
 
 - name: Move generic app
-  command: "mv {{ app_url }} /tmp/app.spl" 
+  command: "cp {{ app_url }} /tmp/app.spl" 
   when: app_source.stat.exists
 
 - name: Download generic app

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -17,35 +17,65 @@
     - splunkbase_token != None
   no_log: "{{ hide_password }}"
 
-- name: Download generic Splunk app
+- name: Check app source
+  stat: 
+    path: "{{ app_url }}"
+  register: app_source
+
+- name: Move generic app
+  command: "mv {{ app_url }} /tmp/app.spl" 
+  when: app_source.stat.exists
+
+- name: Download generic app
   get_url:
     url: "{{ app_url }}"
     dest: /tmp/app.spl
     mode: 0777
+    timeout: 120
+    validate_certs: no
+    force: yes
   register: 
   when:
     - "'splunkbase.splunk.com' not in app_url"
-    - app_url is search("http")
+    - app_url is match("^(https?|file)://.*")
   ignore_errors: true
 
-# Some premium apps require installation via untar command, instead of the traditionally-accepted app installation means (example below):
-# command: "{{ splunk.exec }} install app {% if 'http' in app_url %}/tmp/app.spl{% else %}{{ app_url }}{% endif %} -auth admin:{{ splunk.password }}"
-- name: Install generic Splunk app
+# Some premium apps require installation via untar command, while others can be installed normally.
+# We'll need to verify the contents of the package to see if it's a premium app
+
+- name: Check app contents
+  shell: "tar --exclude='*/*/*' --exclude='*.*' -tf /tmp/app.spl | awk -F'/' '{ print$1 }' | uniq"
+  register: app_contents
+
+- name: Install app via extraction
   unarchive:
     src: "{% if 'http' in app_url %}/tmp/app.spl{% else %}{{ app_url }}{% endif %}"
     dest: "{{ splunk.app_paths.default }}"
     remote_src: true
   become: yes
   become_user: "{{ splunk.user }}"
-  ignore_errors: true
   no_log: "{{ hide_password }}"
+  when: "'itsi' in app_contents.stdout_lines"
   notify:
     - Restart the splunkd service
+
+- name: Install app via REST
+  uri:
+    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    method: POST
+    user: admin
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    body: "name=/tmp/app.spl&update=true&filename=true"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: [ 200, 201 ]
+    timeout: 30
+  when: "'itsi' not in app_contents.stdout_lines"
+  no_log: "{{ hide_password }}"
 
 - name: Remove downloaded app
   file:
     dest: /tmp/app.spl
     state: absent
-  when:
-    - '"/tmp/app.spl" is file'
   ignore_errors: true

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -46,6 +46,7 @@
 - name: Check app contents
   shell: "tar --exclude='*/*/*' --exclude='*.*' -tf /tmp/app.spl | awk -F'/' '{ print$1 }' | uniq"
   register: app_contents
+  when: "'splunkbase.splunk.com' not in app_url"
 
 - name: Install app via extraction
   unarchive:
@@ -55,7 +56,9 @@
   become: yes
   become_user: "{{ splunk.user }}"
   no_log: "{{ hide_password }}"
-  when: "'itsi' in app_contents.stdout_lines"
+  when: 
+    - "'splunkbase.splunk.com' not in app_url"
+    - "'itsi' in app_contents.stdout_lines"
   notify:
     - Restart the splunkd service
 
@@ -71,7 +74,9 @@
       Content-Type: "application/x-www-form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 30
-  when: "'itsi' not in app_contents.stdout_lines"
+  when: 
+    - "'splunkbase.splunk.com' not in app_url"
+    - "'itsi' not in app_contents.stdout_lines"
   no_log: "{{ hide_password }}"
 
 - name: Remove downloaded app

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -45,5 +45,3 @@
 - include_tasks: clean_user_seed.yml
 
 - include_tasks: add_splunk_license.yml
-
-- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -29,4 +29,4 @@
   when:
     - splunk.apps_location
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -28,3 +28,5 @@
 - include_tasks: push_apps_to_search_heads.yml
   when:
     - splunk.apps_location
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -12,3 +12,5 @@
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when: 
     - splunk.apps_location
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -13,4 +13,4 @@
   when: 
     - splunk.apps_location
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_indexer/tasks/main.yml
+++ b/roles/splunk_indexer/tasks/main.yml
@@ -13,3 +13,5 @@
   when: 
     - splunk.apps_location
     - not splunk.indexer_cluster
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_indexer/tasks/main.yml
+++ b/roles/splunk_indexer/tasks/main.yml
@@ -14,4 +14,4 @@
     - splunk.apps_location
     - not splunk.indexer_cluster
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_license_master/tasks/main.yml
+++ b/roles/splunk_license_master/tasks/main.yml
@@ -4,3 +4,5 @@
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
     - splunk.apps_location
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_license_master/tasks/main.yml
+++ b/roles/splunk_license_master/tasks/main.yml
@@ -5,4 +5,4 @@
   when:
     - splunk.apps_location
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -20,3 +20,5 @@
   when:
     - splunk.apps_location
     - not splunk.search_head_cluster
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -21,4 +21,4 @@
     - splunk.apps_location
     - not splunk.search_head_cluster
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -11,4 +11,4 @@
   when:
     - splunk.apps_location
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -10,3 +10,5 @@
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
     - splunk.apps_location
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -69,4 +69,4 @@
   notify:
     - Restart the splunkd service
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -68,3 +68,5 @@
   ignore_errors: true
   notify:
     - Restart the splunkd service
+
+- include_tasks: check_for_required_restarts.yml

--- a/roles/splunk_upgrade/tasks/main.yml
+++ b/roles/splunk_upgrade/tasks/main.yml
@@ -9,4 +9,4 @@
   - splunk.role is defined
   - splunk.role != 'splunk_universal_forwarder'
 
-- include_tasks: check_for_required_restarts.yml
+- include_tasks: ../../splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_upgrade/tasks/main.yml
+++ b/roles/splunk_upgrade/tasks/main.yml
@@ -8,3 +8,5 @@
   when:
   - splunk.role is defined
   - splunk.role != 'splunk_universal_forwarder'
+
+- include_tasks: check_for_required_restarts.yml


### PR DESCRIPTION
Tweaking app installation so it abides by the following:
* Splunkbase apps get installed via apps/local endpoint
* ESS gets installed via apps/local endpoint
* ITSI gets installed via untar operation
* All other apps get installed via apps/local endpoint

Basically, the logic here uses the `tar -t` flag to check the contents of the downloaded package to see what's inside. If itsi (or any future apps that require special installation practices) exist, ansible will extract instead of hit the REST endpoint.