### PR TITLE
Adding wildcard license

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -96,6 +96,10 @@ def getDefaultVars():
     defaultVars["splunk"]["indexer_cluster"] = True if os.environ.get('SPLUNK_CLUSTER_MASTER_URL', False) else False
     defaultVars["splunk"]["search_head_cluster"] = True if os.environ.get('SPLUNK_SEARCH_HEAD_CAPTAIN_URL', False) else False
     defaultVars["splunk"]["license_uri"] = os.environ.get('SPLUNK_LICENSE_URI', None)
+    if defaultVars["splunk"]["license_uri"] and '*' in defaultVars["splunk"]["license_uri"]:
+        defaultVars["splunk"]["wildcard_license"] = True
+    else:
+        defaultVars["splunk"]["wildcard_license"] = False
     defaultVars["splunk"]["nfr_license"] = os.environ.get('SPLUNK_NFR_LICENSE', '/tmp/nfr_enterprise.lic')
     defaultVars["splunk"]["ignore_license"] = os.environ.get('SPLUNK_IGNORE_LICENSE', False)
     defaultVars["splunk"]["license_download_dest"] = os.environ.get('SPLUNK_LICENSE_INSTALL_PATH', '/tmp/splunk.lic')

--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -20,6 +20,7 @@
   when:
     - not (splunk.ignore_license | bool)
     - splunk.role == "splunk_license_master" or not splunk.license_master_included
+    - not (splunk.wildcard_license | bool)
   ignore_errors: true
   with_first_found:
     - files:
@@ -29,6 +30,21 @@
       skip: true
   loop_control:
     loop_var: license_file
+  notify:
+    - Restart the splunkd service
+  no_log: "{{ hide_password }}"
+
+- name: Apply wildcard licenses
+  command: "{{ splunk.exec }} add licenses {{ item }} -auth admin:{{ splunk.password }}"
+  with_fileglob:
+    - "{{ splunk.license_uri }}"
+  ignore_errors: true
+  become: yes
+  become_user: "{{ splunk.user }}"
+  when:
+    - not (splunk.ignore_license | bool)
+    - splunk.role == "splunk_license_master" or not splunk.license_master_included
+    - splunk.wildcard_license | bool
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"


### PR DESCRIPTION
Verified that it succesfully adds multiple licenses using a wildcard. 

For example, add splunk_license_uri=/opt/*.lic and ansible will look for all files that match the pattern.