### PR TITLE
Fixing shell used for pipefail

### DIFF
--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -44,6 +44,8 @@
 
 - name: Check app contents
   shell: "set -o pipefail && tar --exclude='*/*/*' --exclude='*.*' -tf /tmp/app.spl | awk -F'/' '{ print$1 }' | uniq"
+  args:
+    executable: /bin/bash
   register: app_contents
   when: "'splunkbase.splunk.com' not in app_url"
 


### PR DESCRIPTION
I broke something with recent linting fixes - it looks like the default shell (/bin/sh) used by the `shell` module doesn't support the `set -o` option. Changing it to explicitly used bash instead. 

Solution provided by https://github.com/ansible/ansible/issues/12903, although I guess it's more of a "hopefully Ansible will fix this one day" type deal. 