### PR TITLE
Add conf to any directory

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -1,7 +1,8 @@
 ## Navigation
 
 * [Spec](#spec)
-* [Sample](#sample)
+  * [Configuration files](#configuration-files)
+* [Example](#example)
 
 ---
 
@@ -301,6 +302,48 @@ splunk:
   tar_dir: <str>
   * Name of directory for the Splunk tar
   * Default: splunk
+  
+  conf: <dict>
+    (filename):
+      directory: <str - filepath>
+      * Path in filesystem to create `.conf` file
+      * Default: /opt/splunk/etc/system/local
+
+      content: <dict>
+        (section name): <dict>
+          (name) : (value)
+            * Key-value pairs in configuration file
+```
+
+### Configuration files
+
+The `default.yml` file can be used to specify multiple named configuration files.
+
+`conf` accepts a dictionary where keys are names of `.conf` files and values contain the `directory` and `contents`. Files will be created in the directory specified in `directory` or the default directory (`/opt/splunk/etc/system/local`) if none are provided. `content` accepts a dictionary where keys are section names and values are key-value pairs to be listed in the configuration file.
+  
+  
+The following example generates `user-prefs.conf` in `/opt/splunk/etc/users/admin/user-prefs/local`
+```
+splunk:
+  conf:
+    user-prefs:
+      directory: /opt/splunk/etc/users/admin/user-prefs/local
+      content:
+        general:
+          default_namespace : appboilerplate
+          search_use_advanced_editor : true
+          search_line_numbers : false
+          search_auto_format : false
+          search_syntax_highlighting : dark
+```
+
+```
+[general]
+default_namespace = appboilerplate
+search_use_advanced_editor = true
+search_line_numbers = false
+search_auto_format = false
+search_syntax_highlighting = dark
 ```
 
 ---

--- a/roles/splunk_common/tasks/set_any_generic_config.yml
+++ b/roles/splunk_common/tasks/set_any_generic_config.yml
@@ -2,7 +2,8 @@
 - include_tasks: set_config_file.yml
   vars:
     conf_file: "{{ item.key }}.conf"
-    conf_stanzas: "{{ item.value }}"
+    conf_directory: "{% if item.value.directory is defined %}{{ item.value.directory }}{% else %}{{ splunk.home }}/etc/system/local{% endif %}"
+    conf_stanzas: "{{ item.value.content }}"
   when:
     - (item.value | length > 0)
   with_dict: "{{ splunk.conf }}"

--- a/roles/splunk_common/tasks/set_any_generic_config.yml
+++ b/roles/splunk_common/tasks/set_any_generic_config.yml
@@ -2,7 +2,7 @@
 - include_tasks: set_config_file.yml
   vars:
     conf_file: "{{ item.key }}.conf"
-    conf_directory: "{% if item.value.directory is defined %}{{ item.value.directory }}{% else %}{{ splunk.home }}/etc/system/local{% endif %}"
+    conf_directory: "{{ item.value.directory | default(splunk.home + '/etc/system/local', true) }}"
     conf_stanzas: "{{ item.value.content }}"
   when:
     - (item.value | length > 0)

--- a/roles/splunk_common/tasks/set_config_file.yml
+++ b/roles/splunk_common/tasks/set_config_file.yml
@@ -1,7 +1,15 @@
 ---
+- name: Create {{ conf_directory }} directory if not existing
+  file:
+    path: "{{ conf_directory }}"
+    state: directory
+  when: conf_directory is defined
+  become: yes
+  become_user: "{{ splunk.user }}"
+
 - name: Create {{ conf_file }} if not existing
   copy:
-    dest: "{{ splunk.home }}/etc/system/local/{{ conf_file }}"
+    dest: "{{ conf_directory }}/{{ conf_file }}"
     mode: u=rw,g=,o=
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"

--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -1,7 +1,7 @@
 ---
 #- name: "Create section {{ stanza_name }} if not existing"
 #  lineinfile:
-#    path: "{{ splunk.home }}/etc/system/local/{{ conf_file }}"
+#    path: "{{ splunk.home }}/etc/system/local/{{ conf_file}}"
 #    create: True
 #    line: "[{{ stanza_name }}]"
 #    regexp: "^{{ stanza_name }}"
@@ -9,7 +9,7 @@
 
 - name: "Set options in {{ stanza_name }}"
   ini_file:
-    path: "{{ splunk.home }}/etc/system/local/{{ conf_file }}"
+    path: "{{ conf_directory }}/{{ conf_file }}"
     section: "{{ stanza_name }}"
     option: "{{ stanza_setting.key }}"
     value: "{{ stanza_setting.value }}"

--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -1,7 +1,7 @@
 ---
 #- name: "Create section {{ stanza_name }} if not existing"
 #  lineinfile:
-#    path: "{{ splunk.home }}/etc/system/local/{{ conf_file}}"
+#    path: "{{ splunk.home }}/etc/system/local/{{ conf_file }}"
 #    create: True
 #    line: "[{{ stanza_name }}]"
 #    regexp: "^{{ stanza_name }}"


### PR DESCRIPTION
for https://github.com/splunk/docker-splunk/issues/94 and https://github.com/splunk/docker-splunk/issues/93

In `default.yml` the directory to create `.conf` files can be specified under `directory`. If none, the default directory will be used `/opt/splunk/etc/system/local`

Example `default.yml`
```
splunk:
  conf:
    user-prefs:
      directory: /opt/splunk/etc/users/admin/user-prefs/local
      content:
        general:
          default_namespace : appboilerplate
          search_use_advanced_editor : true
          search_line_numbers : false
          search_auto_format : false
          search_syntax_highlighting : dark
```
Created `.conf` file in `/opt/splunk/etc/users/admin/user-prefs/local`
```
[general]
default_namespace = appboilerplate
search_use_advanced_editor = true
search_line_numbers = false
search_auto_format = false
search_syntax_highlighting = dark
```