### PR TITLE
avoid variable reuse when downloading post tasks

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -78,7 +78,7 @@
         dest: "{{ config.defaults_dir + '/splunk_ansible_post_tasks.yml' }}"
       ignore_errors: yes
       no_log: true
-      register: downloaded_post_plays
+      register: downloaded_post_plays_linux
 
     # the win_get_url module is for windows only
     - name: Download post-setup playbooks
@@ -92,7 +92,7 @@
         dest: "{{ config.defaults_dir + '\\splunk_ansible_post_tasks.yml' }}"
       ignore_errors: yes
       no_log: true
-      register: downloaded_post_plays
+      register: downloaded_post_plays_win
 
     - name: Run post-setup playbooks
       include_tasks: "{{ lookup('first_found', post_locations_to_look) }}"
@@ -102,6 +102,7 @@
       vars:
         post_locations_to_look:
           - "{{ ansible_post_tasks }}"
-          - "{% if downloaded_post_plays.dest is defined %}{{ downloaded_post_plays.dest }}{% endif %}"
+          - "{% if downloaded_post_plays_linux.dest is defined %}{{ downloaded_post_plays_linux.dest }}{% endif %}"
+          - "{% if downloaded_post_plays_win.dest is defined %}{{ downloaded_post_plays_win.dest }}{% endif %}"
           - "{{ config.defaults_dir + '/splunk_ansible_post_tasks.yml' }}"
           - "{{ config.defaults_dir + '\\splunk_ansible_post_tasks.yml' }}"


### PR DESCRIPTION
Hello!

I've been using the splunk-ansible code along with the docker-splunk image in order to setup heavy forwarders. While trying to do some small config tweaks as part of post-install tasks I quickly ran into the following failed output:

```
TASK [Download post-setup playbooks] *******************************************
task path: /opt/ansible/site.yml:77
ok: [localhost] => {"changed": false, "dest": "/tmp/splunk_ansible_post_tasks.yml", "gid": 999, "group": "splunk", "mode": "0644", "msg": "file already exists", "owner": "splunk", "size": 370, "state": "file", "uid": 999, "url": "https://path/to/tasks.yml"}

TASK [Run post-setup playbooks] ************************************************
task path: /opt/ansible/site.yml:108
fatal: [localhost]: FAILED! => {"reason": "an error occurred while trying to read the file '/opt/ansible': [Errno 21] Is a directory: '/opt/ansible'"}
	to retry, use: --limit @/opt/container_artifact/ansible-retry/site.retry
```

While the above error is unclear, after further exploration, it seems that the post-install tasks are running into [this](https://github.com/ansible/ansible/issues/4297) issue and the registered variable is essentially getting nulled out by the skipped Windows task. This PR moves to registering two differently named variables and acting upon each as part of the `post_locations_to_look` list.
