### PR TITLE
ensure defaults dir exists before pulling pre/post tasks

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -12,6 +12,13 @@
       when:
         - ansible_hostname == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or splunk.role == "splunk_search_head_captain"
 
+    - name: Create defaults dir
+      file:
+        path: "{{config.defaults_dir}}"
+        state: directory
+        owner: ansible
+        group: ansible
+
     # the get_url module is for linux only
     - name: Download pre-setup playbooks
       when:


### PR DESCRIPTION
When using the docker-splunk image and trying to pull down post-tasks, I encountered the issue where `/tmp/defaults` doesn't actually exist on the system so ansible fails to pull. This PR adds a step to ensure the configured directory is present.