### PR TITLE
Revert to "http" when ssl is disabled

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ Particularly when bringing up distributed Splunk topologies, there is a need for
 While developing new playbooks that require remote Splunk-to-Splunk connectivity, we employ the use of `retry` and `delay` options for tasks. For instance, in this example below, we add indexers as search peers of individual search head. To overcome error-prone networking, we have retry counts with delays embedded in the task. There are also break-early conditions that maintain idempotency so we can progress if successful:
 ```
 - name: Set all indexers as search peers
-  command: "{{ splunk.exec }} add search-server https://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
+  command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ groups['splunk_indexer'] }}"

--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -16,7 +16,7 @@
 
 - name: Set indexer discovery
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-server"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-server"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_common/tasks/check_for_required_restarts.yml
+++ b/roles/splunk_common/tasks/check_for_required_restarts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check for required restarts
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/messages/restart_required?output_mode=json"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/messages/restart_required?output_mode=json"
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -3,12 +3,12 @@
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/indexerdiscovery
 - name: Setup indexer discovery for index-clustering
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=indexer_discovery:splunk-indexer&pass4SymmKey={{ splunk.shc.secret }}&master_uri=https://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }}"
+    body: "name=indexer_discovery:splunk-indexer&pass4SymmKey={{ splunk.shc.secret }}&master_uri={{ cert_prefix }}://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }}"
     headers:
       Content-Type: "application/x-www-form-urlencoded"
     status_code: 201,409
@@ -22,7 +22,7 @@
 
 - name: Setup tcpout group for index-clustering
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -39,7 +39,7 @@
 
 - name: Setup default tcpout group for index-clustering
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs/tcpout"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs/tcpout"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -70,7 +70,7 @@
 # NOTE: If this task is called or used, it will disable all local indexing!
 - name: Disable indexing on the current node
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-outputs"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install Splunkbase app
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -65,7 +65,7 @@
 
 - name: Install app via REST
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -1,4 +1,18 @@
 ---
+- name: Construct new build url if ssl is disabled
+  set_fact:
+    new_build_location: "{{ splunk.build_location | replace('https', 'http') }}"
+  when:
+  - splunk.build_location | regex_search("^(http).*")
+  - cert_prefix is defined
+  - cert_prefix == "http"
+
+- name: Adjust current build url
+  set_fact:
+    splunk:
+      build_location: "{{ splunk.build_location | combine(new_build_location,recursive=True) }}"
+  when: new_build_location is defined
+
 - name: Download Splunk package (Windows)
   get_url:
     url: "{{ splunk.build_location }}"
@@ -24,7 +38,7 @@
   when: ansible_system is match("Linux")
   register: install_result
   until: install_result is succeeded
-  retries: "{{ retry_num }}"
+  retries: 3
   delay: 3
 
 - name: Install Splunk (Windows)

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -38,7 +38,7 @@
   when: ansible_system is match("Linux")
   register: install_result
   until: install_result is succeeded
-  retries: 3
+  retries: "{{ retry_num }}"
   delay: 3
 
 - name: Install Splunk (Windows)

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -63,6 +63,8 @@
 
 - include_tasks: start_splunk.yml
 
+- include_tasks: set_certificate_prefix.yml
+
 - include_tasks: clean_user_seed.yml
 
 - include_tasks: add_splunk_license.yml

--- a/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create ITSI admin role
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/itsi/authorization/roles"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/itsi/authorization/roles"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -22,7 +22,7 @@
 
 - name: Create ITSI admin user
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/itsi/authentication/users/admin"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/itsi/authentication/users/admin"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -1,7 +1,7 @@
 ---
 - name: Enable HEC services
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/splunk_httpinput/data/inputs/http/http/enable"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/splunk_httpinput/data/inputs/http/http/enable"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -14,7 +14,7 @@
 
 - name: Create new HEC token
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/splunk_httpinput/data/inputs/http"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/splunk_httpinput/data/inputs/http"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -29,7 +29,7 @@
   no_log: "{{ hide_password }}"
 
 - name: Enable HEC new-token
-  command: "{{ splunk.exec }} http-event-collector enable -name splunk_hec_token -uri https://127.0.0.1:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  command: "{{ splunk.exec }} http-event-collector enable -name splunk_hec_token -uri {{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   ignore_errors: true
@@ -37,7 +37,7 @@
   no_log: "{{ hide_password }}"
 
 - name: Enable SSL for HEC new-token
-  command: "{{ splunk.exec }} http-event-collector update -uri https://127.0.0.1:{{ splunk.svc_port }} -enable-ssl {{ splunk.hec_enableSSL }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  command: "{{ splunk.exec }} http-event-collector update -uri {{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }} -enable-ssl {{ splunk.hec_enableSSL }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   ignore_errors: true

--- a/roles/splunk_common/tasks/set_as_license_slave.yml
+++ b/roles/splunk_common/tasks/set_as_license_slave.yml
@@ -5,7 +5,7 @@
     splunk_instance_address: "{{ license_master_host }}"
 
 - name: Set node as license slave
-  command: "{{ splunk.exec }} edit licenser-localslave -master_uri https://{{ license_master_host }}:{{ splunk.svc_port }} -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} edit licenser-localslave -master_uri {{ cert_prefix }}://{{ license_master_host }}:{{ splunk.svc_port }} -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   register: linux_set_lic_slave

--- a/roles/splunk_common/tasks/set_certificate_prefix.yml
+++ b/roles/splunk_common/tasks/set_certificate_prefix.yml
@@ -1,0 +1,17 @@
+---
+- name: "Test basic https endpoint"
+  uri:
+    url: "https://127.0.0.1:{{ splunk.svc_port }}/services/properties"
+    method: GET
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    status_code: 200,404
+    timeout: 10
+  register: ssl_enabled
+  ignore_errors: true
+
+# If the https call failed, we will revert to http and continue REST with normal error handling
+- name: "Set url prefix for future REST calls"
+  set_fact:
+    cert_prefix: "{% if ssl_enabled.status == 200 %}https{% else %}http{% endif %}"

--- a/roles/splunk_common/tasks/wait_for_splunk_instance.yml
+++ b/roles/splunk_common/tasks/wait_for_splunk_instance.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check Splunk instance is running
   uri:
-    url: https://{{ splunk_instance_address }}:{{ splunk.svc_port }}/services/server/info?output_mode=json
+    url: "{{ cert_prefix }}://{{ splunk_instance_address }}:{{ splunk.svc_port }}/services/server/info?output_mode=json"
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"

--- a/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
+++ b/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
@@ -12,7 +12,7 @@
   with_items: "{{ installed_apps }}"
 
 - name: Apply shcluster bundle
-  command: "{{ splunk.exec }} apply shcluster-bundle -target https://{{ groups['splunk_search_head_captain'][0] }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} --answer-yes"
+  command: "{{ splunk.exec }} apply shcluster-bundle -target {{ cert_prefix }}://{{ groups['splunk_search_head_captain'][0] }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} --answer-yes"
   become: yes
   become_user: "{{ splunk.user }}"
   no_log: "{{ hide_password }}"

--- a/roles/splunk_indexer/tasks/indexer_clustering.yml
+++ b/roles/splunk_indexer/tasks/indexer_clustering.yml
@@ -4,7 +4,7 @@
     splunk_instance_address: "{{ cluster_master_host }}"
 
 - name: Set current node as indexer cluster peer
-  command: "{{ splunk.exec }} edit cluster-config -mode slave -master_uri 'https://{{ cluster_master_host }}:{{ splunk.svc_port }}' -replication_port {{ splunk.idxc.replication_port }} -secret '{{ splunk.idxc.secret }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} edit cluster-config -mode slave -master_uri '{{ cert_prefix }}://{{ cluster_master_host }}:{{ splunk.svc_port }}' -replication_port {{ splunk.idxc.replication_port }} -secret '{{ splunk.idxc.secret }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   register: task_result

--- a/roles/splunk_search_head/tasks/peer_cluster_master.yml
+++ b/roles/splunk_search_head/tasks/peer_cluster_master.yml
@@ -5,7 +5,7 @@
 
 # http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/SHCandindexercluster#Integrate_with_a_single-site_indexer_cluster
 - name: Set cluster master as a search peer
-  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri https://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }} -replication_port {{ splunk.idxc.replication_port }} -secret '{{ splunk.idxc.secret }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ cert_prefix }}://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }} -replication_port {{ splunk.idxc.replication_port }} -secret '{{ splunk.idxc.secret }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_cluster_master_as_peer

--- a/roles/splunk_search_head/tasks/peer_indexers.yml
+++ b/roles/splunk_search_head/tasks/peer_indexers.yml
@@ -4,7 +4,7 @@
     splunk_instance_address: "{{ groups['splunk_indexer'][0] }}"
 
 - name: Set all indexers as search peers
-  command: "{{ splunk.exec }} add search-server https://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
+  command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ groups['splunk_indexer'] }}"

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -17,7 +17,7 @@
     splunk_instance_address: "{{ groups['splunk_deployer'][0] }}"
 
 - name: Initialize SHC cluster config
-  command: "{{ splunk.exec }} init shcluster-config -auth '{{ splunk.admin_user }}:{{ splunk.password }}' -mgmt_uri 'https://{{ ansible_hostname }}:{{ splunk.svc_port }}' -replication_port {{ splunk.shc.replication_port }} -replication_factor {{ shc_replication_factor }} -conf_deploy_fetch_url 'https://{{ groups['splunk_deployer'][0] }}:{{ splunk.svc_port }}' -secret '{{ splunk.shc.secret }}' -shcluster_label '{{ splunk.shc.label }}'"
+  command: "{{ splunk.exec }} init shcluster-config -auth '{{ splunk.admin_user }}:{{ splunk.password }}' -mgmt_uri '{{ cert_prefix }}://{{ ansible_hostname }}:{{ splunk.svc_port }}' -replication_port {{ splunk.shc.replication_port }} -replication_factor {{ shc_replication_factor }} -conf_deploy_fetch_url '{{ cert_prefix }}://{{ groups['splunk_deployer'][0] }}:{{ splunk.svc_port }}' -secret '{{ splunk.shc.secret }}' -shcluster_label '{{ splunk.shc.label }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   register: task_result
@@ -31,7 +31,7 @@
 
 - name: Set desired preferred captaincy
   uri:
-    url: "https://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-server/shclustering"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-server/shclustering"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -54,7 +54,7 @@
     splunk_instance_address: "{{ groups['splunk_deployer'][0] }}"
 
 - name: Boostrap SHC captain
-  command: "{{ splunk.exec }} bootstrap shcluster-captain -servers_list '{% for host in groups['splunk_search_head'] %}https://{{ host }}:{{ splunk.svc_port }}{% if not loop.last %},{% endif %}{% endfor %}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} bootstrap shcluster-captain -servers_list '{% for host in groups['splunk_search_head'] %}{{ cert_prefix }}://{{ host }}:{{ splunk.svc_port }}{% if not loop.last %},{% endif %}{% endfor %}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   when: splunk_search_head_captain | bool


### PR DESCRIPTION
Replaced hard-coded "https" prefixes with the "cert_prefix" fact. We try a simple https request and revert the prefix to "http" if it fails.