### PR TITLE
Multisite disable adjustments

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -201,8 +201,16 @@ def overrideEnvironmentVars(vars_scope):
     #Used for multisite
     if 'SPLUNK_SITE' in os.environ or 'site' in vars_scope["splunk"]:
         vars_scope["splunk"]["site"] = os.environ.get('SPLUNK_SITE', vars_scope["splunk"].get("site"))
-        vars_scope["splunk"]["all_sites"] = os.environ.get('SPLUNK_ALL_SITES', vars_scope["splunk"].get("all_sites"))
-        vars_scope["splunk"]["multisite_master"] = os.environ.get('SPLUNK_MULTISITE_MASTER', vars_scope["splunk"].get("multisite_master"))
+
+        all_sites = os.environ.get('SPLUNK_ALL_SITES', vars_scope["splunk"].get("all_sites"))
+        if all_sites:
+            vars_scope["splunk"]["all_sites"] = all_sites
+
+        multisite_master = os.environ.get('SPLUNK_MULTISITE_MASTER', vars_scope["splunk"].get("multisite_master"))
+        if multisite_master:
+            vars_scope["splunk"]["multisite_master"] = multisite_master
+
+        vars_scope["splunk"]["multisite_master_port"] = os.environ.get('SPLUNK_MULTISITE_MASTER_PORT', vars_scope["splunk"].get("multisite_master_port", 8089))
         vars_scope["splunk"]["multisite_replication_factor_origin"] = os.environ.get('SPLUNK_MULTISITE_REPLICATION_FACTOR_ORIGIN', vars_scope["splunk"].get("multisite_replication_factor_origin", 1))
         vars_scope["splunk"]["multisite_replication_factor_total"] = os.environ.get('SPLUNK_MULTISITE_REPLICATION_FACTOR_TOTAL', vars_scope["splunk"].get("multisite_replication_factor_total", 1))
         vars_scope["splunk"]["multisite_search_factor_origin"] = os.environ.get('SPLUNK_MULTISITE_SEARCH_FACTOR_ORIGIN', vars_scope["splunk"].get("multisite_search_factor_origin", 1))

--- a/multisite.yml
+++ b/multisite.yml
@@ -11,3 +11,7 @@
           tasks_from: setup_multisite.yml 
         when:
           - splunk.role is defined
+        vars:
+          - splunk_install: false
+          - splunk_upgrade: false
+          - first_run: false

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -27,10 +27,13 @@
     - splunk.allow_upgrade | bool
 
 - include_tasks: remove_first_login.yml
+  when:
+    - splunk_upgrade or splunk_install
 
 - include_tasks: install_java.yml
   when:
     - java_version is defined
+    - splunk_upgrade or splunk_install
 
 # This needs to be done before any encrypted passkeys are generated
 - include_tasks: set_splunk_secret.yml
@@ -43,28 +46,43 @@
 
 - include_tasks: pre_splunk_start_commands.yml
   ignore_errors: true
+  when:
+    - splunk_upgrade or splunk_install
 
 - include_tasks: enable_s2s_port.yml
   when:
     - splunk.s2s_enable is defined
     - splunk.s2s_enable | bool
+    - splunk_upgrade or splunk_install
 
 - include_tasks: enable_service.yml
-  when: splunk.enable_service and ansible_system is match("Linux")
+  when:
+    - splunk.enable_service and ansible_system is match("Linux")
+    - splunk_upgrade or splunk_install
 
 - include_tasks: enable_ssl_on_gui.yml
   when:
     - splunk.http_enableSSL is defined
     - splunk.http_enableSSL | bool
+    - splunk_upgrade or splunk_install
 
 - include_tasks: set_any_generic_config.yml
   when:
     - "'conf' in splunk"
+    - splunk_upgrade or splunk_install
 
 - include_tasks: start_splunk.yml
+  when:
+    - splunk_upgrade or splunk_install
 
 - include_tasks: set_certificate_prefix.yml
+  when:
+    - splunk_upgrade or splunk_install
 
 - include_tasks: clean_user_seed.yml
+  when:
+    - splunk_upgrade or splunk_install
 
 - include_tasks: add_splunk_license.yml
+  when:
+    - splunk_upgrade or splunk_install

--- a/roles/splunk_indexer/tasks/main.yml
+++ b/roles/splunk_indexer/tasks/main.yml
@@ -26,6 +26,5 @@
   when:
       - splunk.site is defined
       - splunk.multisite_master is defined
-      - splunk.multisite_master_port is defined
 
 - include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -32,6 +32,5 @@
   when:
       - splunk.site is defined
       - splunk.multisite_master is defined
-      - splunk.multisite_master_port is defined
 
 - include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml


### PR DESCRIPTION
Whats going on is we want to call the multisite.yml separately, so the workflow would look like this
1) Bring up site A
2) Bring up site B
3) Run multisite

When doing this, I want to have some parameters already defined for sites A and B that multisite would need. However, I don't want to trigger the multisite play itself, because some pieces of infrastructure might not be available.  When we start up the multisite play, the role will automatically try to include a bunch of splunk_common roles, many of which I don't want, so I added something in there to skip the unnecessary ones.  If there is a better method of doing that than what I've done in here, I'm happy to rewrite this.