### PR TITLE
Fixing play names for pre/post playbooks

### DIFF
--- a/execute_adhoc_plays.yml
+++ b/execute_adhoc_plays.yml
@@ -7,7 +7,8 @@
 - name: Fetch adhoc playbooks
   get_url:
     url: "{{ playbook }}"
-    dest: "{{ config.defaults_dir + '/playbook.yml' }}"
+    dest: "{{ config.defaults_dir '/' + playbook|basename }}"
+    force: yes
   ignore_errors: yes
   register: downloaded_plays
 
@@ -17,4 +18,4 @@
     play_locations:
       - "{{ playbook }}"
       - "{% if downloaded_plays.dest is defined %}{{ downloaded_plays.dest }}{% endif %}"
-      - "{{ config.defaults_dir + '/playbook.yml' }}"
+      - "{{ config.defaults_dir + '/' + playbook|basename }}"

--- a/execute_adhoc_plays.yml
+++ b/execute_adhoc_plays.yml
@@ -7,7 +7,7 @@
 - name: Fetch adhoc playbooks
   get_url:
     url: "{{ playbook }}"
-    dest: "{{ config.defaults_dir '/' + playbook|basename }}"
+    dest: "{{ config.defaults_dir + '/' + playbook|basename }}"
     force: yes
   ignore_errors: yes
   register: downloaded_plays

--- a/roles/splunk_cluster_master/tasks/initialize_multisite_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_multisite_master.yml
@@ -8,7 +8,7 @@
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 
 - name: Set the multisite master
-  command: "{{ splunk.exec }} edit cluster-config -mode master -multisite true -available_sites {{splunk.all_sites}} -site {{splunk.site}} -site_replication_factor origin:{{splunk.multisite_replication_factor_origin}},total:{{splunk.multisite_replication_factor_total}} -site_search_factor origin:{{splunk.multisite_search_factor_origin}},total:{{splunk.multisite_search_factor_total}} -auth {{splunk.admin_user}}:{{splunk.password}} -secret {{splunk.idxc.secret}}"
+  command: "{{ splunk.exec }} edit cluster-config -mode master -multisite true -available_sites {{ splunk.all_sites }} -site {{ splunk.site }} -site_replication_factor origin:{{ splunk.multisite_replication_factor_origin }},total:{{ splunk.multisite_replication_factor_total }} -site_search_factor origin:{{ splunk.multisite_search_factor_origin }},total:{{ splunk.multisite_search_factor_total }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.secret }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_multisite_master

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -21,7 +21,9 @@
 - name: "Reload daemons via systemctl - Linux (systemd)"
   become: yes
   become_user: "root"
-  command: "systemctl daemon-reload"
+  systemd:
+    name: daemon-reload
+    state: restarted
   when: ansible_system is match("Linux") and pid1.stdout.find('systemd') != -1
 
 - name: "Start splunkd as systemd service - Linux"

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -23,7 +23,7 @@
     - splunk.apps_location
 
 - name: Execute Splunk commands
-  command: "{{splunk.exec}} {{ item }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  command: "{{ splunk.exec }} {{ item }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ splunk.cmd }}"

--- a/roles/splunk_indexer/tasks/setup_multisite_indexer.yml
+++ b/roles/splunk_indexer/tasks/setup_multisite_indexer.yml
@@ -8,7 +8,7 @@
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 
 - name: Setup Peers with Associated Site
-  command: "{{ splunk.exec }} edit cluster-config -mode slave -site {{ splunk.site }} -master_uri {{multisite_master_uri}} -replication_port {{splunk.idxc.replication_port}} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{splunk.idxc.secret}}"
+  command: "{{ splunk.exec }} edit cluster-config -mode slave -site {{ splunk.site }} -master_uri {{ multisite_master_uri }} -replication_port {{ splunk.idxc.replication_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.secret }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: task_result

--- a/roles/splunk_search_head/tasks/setup_multisite_search_head.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite_search_head.yml
@@ -8,7 +8,7 @@
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 
 - name: Setup SHC
-  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{splunk.shc.secret}}"
+  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.secret }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_new_master
@@ -22,7 +22,7 @@
   no_log: "{{ hide_password }}"
 
 - name: Setup SHC with Associated Site
-  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{splunk.shc.secret}}"
+  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.secret }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_associated_site

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -26,7 +26,7 @@
       license_uri: null
       wildcard_license: false
       build_remote_src: true
-      build_location: /tmp/splunk.tgz
+      build_location: ${SPLUNK_INSTALLER}
       ignore_license: true
       apps_location: null
       app_paths:

--- a/roles/splunk_universal_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/default/playbook.yml
@@ -26,7 +26,7 @@
       license_master_included: false
       license_uri: null
       build_remote_src: true
-      build_location: /tmp/splunk.tgz
+      build_location: ${SPLUNK_INSTALLER}
       apps_location: null
       admin_user: admin
       app_paths:


### PR DESCRIPTION
There's some interesting behavior with `include_tasks`. From my testing, it seems like when Ansible loads the tasks dynamically from this module, it seems to cache/store the tasks based on filename. So it's possible to have a pre-playbook named `/tmp/defaults/playbook.yml` that gets included, executed, then immediately deleted. But if the contents of `/tmp/defaults/playbook.yml` changes (in the case of post-playbook), the next subsequent run of `include_tasks: /tmp/defaults/playbook.yml` actually runs the former (deleted) plays.

Changing this here so that when we do save playbooks, we use the user-provided filenames. There is still a corner-case in which this will break, which is when a user provides multiple files with the same name (but different contents), ex. `SPLUNK_ANSIBLE_PRE_TASKS=file:///example.yml` and `SPLUNK_ANSIBLE_POST_TASKS=file:///example.yml`