### PR TITLE
GitHub issue 140

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -199,6 +199,7 @@ def overrideEnvironmentVars(vars_scope):
     vars_scope["splunk"]["http_enableSSL_cert"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_CERT', vars_scope["splunk"]["http_enableSSL_cert"])
     vars_scope["splunk"]["http_enableSSL_privKey"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_PRIVKEY', vars_scope["splunk"]["http_enableSSL_privKey"])
     vars_scope["splunk"]["http_enableSSL_privKey_password"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_PRIVKEY_PASSWORD', vars_scope["splunk"]["http_enableSSL_privKey_password"])
+    vars_scope["splunk"]["http_port"] = os.environ.get('SPLUNK_HTTP_PORT', vars_scope["splunk"]["http_port"])
     #Used for multisite
     if 'SPLUNK_SITE' in os.environ or 'site' in vars_scope["splunk"]:
         vars_scope["splunk"]["site"] = os.environ.get('SPLUNK_SITE', vars_scope["splunk"].get("site"))

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -62,6 +62,12 @@
     - splunk.enable_service and ansible_system is match("Linux")
     - first_run
 
+- include_tasks: set_http_port.yml
+  when:
+    - "'http_port' in splunk"
+    - splunk.http_port | int != 8000
+    - first_run
+
 - include_tasks: enable_ssl_on_gui.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -66,7 +66,6 @@
   when:
     - "'http_port' in splunk"
     - splunk.http_port | int != 8000
-    - first_run
 
 - include_tasks: enable_ssl_on_gui.yml
   when:

--- a/roles/splunk_common/tasks/set_http_port.yml
+++ b/roles/splunk_common/tasks/set_http_port.yml
@@ -1,0 +1,7 @@
+---
+- name: Set HTTP Port
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "httpport"
+    value: "{{ splunk.http_port }}"

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -53,7 +53,7 @@
       http_enableSSL_cert: null
       http_enableSSL_privKey: null
       http_enableSSL_privKey_password: null
-      http_port: 8000
+      http_port: 8080
       idxc:
         enable: false
         label: idxc_label

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -53,6 +53,7 @@
       http_enableSSL_cert: null
       http_enableSSL_privKey: null
       http_enableSSL_privKey_password: null
+      # http_port changed from 8000 to 8080 to test custom http port functionality
       http_port: 8080
       idxc:
         enable: false


### PR DESCRIPTION
Resolves https://github.com/splunk/splunk-ansible/issues/140 and https://github.com/splunk/docker-splunk/issues/179. 

Adds a new task which amends web.conf when user-specified http_port in default.yml is not 8000. Molecule test playbook.yml in splunk_standalone role also changed to validate.