### PR TITLE
Bugfix/deployment app install

### DIFF
--- a/roles/splunk_deployment_server/tasks/create_deployment_apps.yml
+++ b/roles/splunk_deployment_server/tasks/create_deployment_apps.yml
@@ -1,4 +1,10 @@
 ---
+
+- include_tasks: install_deployment_apps.yml
+  vars:
+    app_url: "{{ item }}"
+  loop: "{{ splunk.apps_location }}"
+
 - include_tasks: ../../../roles/splunk_common/tasks/find_installed_apps.yml
 
 # TODO: Might be better to use synchronize here, but we'll need rsync installed
@@ -10,3 +16,19 @@
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ installed_apps }}"
+
+# In order to support SplunkBase app installations, they must go through the services/apps/local REST API.
+# This puts them in ${SPLUNK_HOME}/etc/apps/ by default, and for the deployment server they should go in
+# ${SPLUNK_HOME}/etc/deployment-apps. This task simply removes the apps we "accidentally" installed
+- name: Remove installed apps
+  file:
+    path: "{{ splunk.app_paths.default }}/{{ item }}"
+    state: absent
+  become: yes
+  become_user: "{{ splunk.user }}"
+  with_items: "{{ installed_apps }}"
+  notify:
+    - Restart the splunkd service
+
+- name: Flush restart handlers
+  meta: flush_handlers

--- a/roles/splunk_deployment_server/tasks/generate_server_classes.yml
+++ b/roles/splunk_deployment_server/tasks/generate_server_classes.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check for existing serverclass.conf
+  stat:
+    path: "{{ splunk.home }}/etc/system/local/serverclass.conf"
+  register: serverclass_conf
+
 - name: Define all serverClass
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/serverclass.conf"
@@ -7,6 +12,7 @@
     value: "*"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
+  when: not serverclass_conf.stat.exists
 
 - name: Define all:app serverClass
   ini_file:
@@ -17,3 +23,4 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     allow_no_value: true
+  when: not serverclass_conf.stat.exists

--- a/roles/splunk_deployment_server/tasks/install_deployment_apps.yml
+++ b/roles/splunk_deployment_server/tasks/install_deployment_apps.yml
@@ -1,0 +1,52 @@
+---
+# This manner in which we support app installation on deployment server will NOT support ES/ITSI/premium apps 
+- name: Install Splunkbase app
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    body: "name={{ app_url | urlencode() }}&update=true&filename=true&auth={{ splunkbase_token }}"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: [ 200, 201 ]
+    timeout: 300
+  when:
+    - "'splunkbase.splunk.com' in app_url"
+    - splunkbase_token is defined
+    - splunkbase_token != None
+  no_log: "{{ hide_password }}"
+
+- name: Check app source
+  stat:
+    path: "{{ app_url }}"
+  register: app_source
+
+- name: Move generic app
+  command: "cp {{ app_url }} /tmp/app.spl"
+  when: app_source.stat.exists
+
+- name: Download generic app
+  get_url:
+    url: "{{ app_url }}"
+    dest: /tmp/app.spl
+    mode: 0777
+    timeout: 120
+    validate_certs: no
+    force: yes
+  when:
+    - "'splunkbase.splunk.com' not in app_url"
+    - app_url is match("^(https?|file)://.*")
+  ignore_errors: true
+
+- name: Install app via extraction
+  unarchive:
+    src: "{% if 'http' in app_url %}/tmp/app.spl{% else %}{{ app_url }}{% endif %}"
+    dest: "{{ splunk.app_paths.deployment }}"
+    remote_src: true
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: "{{ hide_password }}"
+  when:
+    - "'splunkbase.splunk.com' not in app_url"

--- a/roles/splunk_deployment_server/tasks/main.yml
+++ b/roles/splunk_deployment_server/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml
 
-- include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
-  when:
-    - splunk.apps_location
-
 - include_tasks: create_deployment_apps.yml
   when:
     - splunk.apps_location


### PR DESCRIPTION
Made some changes to reflect the request here: https://github.com/splunk/splunk-ansible/issues/158

TLDR:
- For the deployment server, we are no longer able to install premium apps (ESS, ITSI). I figured if the deployment server is traditionally used to manage forwarders, this is probably ok.
- Apps passed in via URL or volume-mounted tarballs will get unarchived directly into `$SPLUNK_HOME/etc/deployment-apps/`
- Apps passed in via SplunkBase URL will get installed into `$SPLUNK_HOME/etc/apps`, moved to `$SPLUNK_HOME/etc/deployment-apps`, then removed from `$SPLUNK_HOME/etc/apps`. At the moment, I don't believe there's currently a way to perform a direct-download without going through the Splunk server REST API :( 
- A serverclass.conf will get created with `serverClass:all`/`serverClass:all:app:*` if and only if there is not an existing one in `$SPLUNK_HOME/etc/system/local/serverclass.conf`. The structure of the serverclass.conf is a bit difficult to map to an easy-to-understand default.yml IMO and this should allow users to use the custom-conf option to create their own custom serverclass.conf. Additionally, it should also be possible to mount a `serverclass.conf` and drop it into the system/local location of the container. This may be more practical for those migrating their existing deployment server into our new container (without going through Ansible to create the contents of the file itself).
