### PR TITLE
Splunk Product Name Regex

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -55,7 +55,7 @@
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"
   vars:
-    regexp: 'splunk(?:forwarder)?-((\d+)\.(\d+)\.(\d+))-'
+    regexp: 'splunk(?:forwarder|light|cloud)?-((\d+)\.(\d+)\.(\d+))-'
 
 # We are upgrading if it is not a fresh installation and the current version is different from the target version
 - name: "Setting upgrade fact"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -40,7 +40,7 @@
   set_fact:
     splunk_target_version: "{{ splunk.build_location | regex_search(regexp, '\\1') | default('0') }}"
   vars:
-    regexp: 'splunk(?:forwarder)?-((\d+)\.(\d+)\.(\d+))-'
+    regexp: 'splunk(?:forwarder|light|cloud)?-((\d+)\.(\d+)\.(\d+))-'
   when: "'build_location' in splunk and splunk.build_location is not none"
 
 # We can apply the same logic to the current version by checking which manifest file is in Splunk


### PR DESCRIPTION
When we use splunk products like 'splunklight' and 'splunkcloud', we fail to find the version number with our regex search.
This change allows us to recognize/install these products.

**NOTE:** Our current upgrade logic only checks for the version of our currently-installed product and the one we are targeting. It does NOT take the product into account. I'm not sure what the expected behavior should be in these weird edge cases, but we can probably hold off on this work for now due to the scenario's low occurrence/usage.