### PR TITLE
Fix java install issues

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,7 +19,6 @@ callback_whitelist = profile_tasks
 timeout = 30
 action_warnings = False
 allow_world_readable_tmpfiles = True
-remote_tmp = /tmp/.ansible/tmp
 
 [privilege_escalation]
 become = true


### PR DESCRIPTION
Revert a previous change that caused issues with the java install (directory permissions)