### PR TITLE
regex fix for debug build

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -40,7 +40,7 @@
   set_fact:
     splunk_target_version: "{{ splunk.build_location | regex_search(regexp, '\\1') | default('0') }}"
   vars:
-    regexp: 'splunk(?:forwarder|light|cloud|-unstripped)?-((\d+)\.(\d+)\.(\d+))'
+    regexp: 'splunk\D*?-((\d+)\.(\d+)\.(\d+))'
   when: "'build_location' in splunk and splunk.build_location is not none"
 
 # We can apply the same logic to the current version by checking which manifest file is in Splunk
@@ -55,7 +55,7 @@
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"
   vars:
-    regexp: 'splunk(?:forwarder|light|cloud|-unstripped)?-((\d+)\.(\d+)\.(\d+))'
+    regexp: 'splunk\D*?-((\d+)\.(\d+)\.(\d+))'
 
 # We are upgrading if it is not a fresh installation and the current version is different from the target version
 - name: "Setting upgrade fact"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -40,7 +40,7 @@
   set_fact:
     splunk_target_version: "{{ splunk.build_location | regex_search(regexp, '\\1') | default('0') }}"
   vars:
-    regexp: 'splunk(?:forwarder|light|cloud)?-((\d+)\.(\d+)\.(\d+))-'
+    regexp: 'splunk(?:forwarder|light|cloud|-unstripped)?-((\d+)\.(\d+)\.(\d+))'
   when: "'build_location' in splunk and splunk.build_location is not none"
 
 # We can apply the same logic to the current version by checking which manifest file is in Splunk
@@ -55,7 +55,7 @@
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"
   vars:
-    regexp: 'splunk(?:forwarder|light|cloud)?-((\d+)\.(\d+)\.(\d+))-'
+    regexp: 'splunk(?:forwarder|light|cloud|-unstripped)?-((\d+)\.(\d+)\.(\d+))'
 
 # We are upgrading if it is not a fresh installation and the current version is different from the target version
 - name: "Setting upgrade fact"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ mock
 docker
 requests
 molecule
+ansible<2.8


### PR DESCRIPTION
Allows debug build names containing "splunk-unstripped-x.x.x" and local builds that may not have the ending hyphen (ex: "splunk-x.x.x.tgz")