### PR TITLE
Adding retries to apply cluster bundle

### DIFF
--- a/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
@@ -30,6 +30,8 @@
       and (splunk_cluster_bundle_result.stdout is not search("[Ee]rror")))
     and ("already" not in splunk_cluster_bundle_result.stderr)
   no_log: "{{ hide_password }}"
+  retries: "{{ retry_num }}" # We will sometimes see this if the number of peers dictacted by the replication factor aren't up
+  delay: 5
 
 - name: Wait for bundle push
   command: "{{ splunk.exec }} show cluster-bundle-status -auth {{ splunk.admin_user }}:{{ splunk.password }}"


### PR DESCRIPTION
```TASK [splunk_cluster_master : Apply cluster bundle] ****************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": ["/opt/splunk/bin/splunk", "apply", "cluster-bundle", "-auth", "admin:Chang3d!", "--skip-validation", "--answer-yes"], "delta": "0:00:00.660851", "end": "2019-05-21 21:08:33.576651", "failed_when_result": true, "rc": 0, "start": "2019-05-21 21:08:32.915800", "stderr": "Cannot apply bundle, because replication factor number of peers are not up", "stderr_lines": ["Cannot apply bundle, because replication factor number of peers are not up"], "stdout": "\nEncountered some errors while applying the bundle.", "stdout_lines": ["", "Encountered some errors while applying the bundle."]}```

Saw this. I'm not sure of the root cause yet, but it would be good to at least put in a little resiliency here.