### PR TITLE
add user to config

### DIFF
--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -28,7 +28,7 @@
       - "{{ splunk.license_download_dest }}"
       - "{{ splunk.nfr_license }}"
       - "{{ splunk.license_uri }}"
-      skip: true
+      errors: "ignore"
   loop_control:
     loop_var: license_file
   notify:

--- a/win-ansible.cfg
+++ b/win-ansible.cfg
@@ -24,6 +24,7 @@ remote_tmp = /tmp/.ansible/tmp
 [privilege_escalation]
 become = true
 become_method = runas
+become_user = splunk
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
ansible on windows2019 is requiring that we assign a user to become in the global config:

`TASK [Gathering Facts] ******************************************************************************************************************************
task path: /cygdrive/c/opt/ansible/site.yml:2
fatal: [localhost]: FAILED! => {"msg": "No setting was provided for required configuration plugin_type: become plugin: runas setting: become_user "}`

Able to gather facts & execute fine after this change.