### PR TITLE
Adding the multisite = True parameter 

### DIFF
--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -22,7 +22,7 @@
   no_log: "{{ hide_password }}"
 
 - name: Setup SHC with Associated Site
-  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.secret }}"
+  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.secret }} -multisite True"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_associated_site


### PR DESCRIPTION
What I'm seeing is that if we had unassociated splunk search heads in one site, then they were not associated with the other site when it came up.  I guess another question - should it try to automatically associate the search heads?