### PR TITLE
Fix for ansible_post_tasks

### DIFF
--- a/execute_adhoc_plays.yml
+++ b/execute_adhoc_plays.yml
@@ -1,16 +1,13 @@
 ---
-- name: Create defaults dir
-  file:
-    path: "{{ config.defaults_dir }}"
-    state: directory
-
 - name: Fetch adhoc playbooks
   get_url:
     url: "{{ playbook }}"
-    dest: "{{ config.defaults_dir + '/' + playbook|basename }}"
+    dest: "{{ '/opt/container_artifact/' + playbook|basename }}"
     force: yes
   ignore_errors: yes
   register: downloaded_plays
+  when:
+    - playbook is match("^(http|https|file)://.*")
 
 - name: Execute playbooks
   include_tasks: "{{ lookup('first_found', play_locations) }}"

--- a/site.yml
+++ b/site.yml
@@ -35,6 +35,5 @@
           when:
             - ansible_post_tasks is defined
             - ansible_post_tasks is not none
-            - ansible_post_tasks is match("^(http|https|file)://.*")
       become: yes
       become_user: "{{ splunk.user }}"


### PR DESCRIPTION
Use /opt/container_artifact/ directory when downloading, since defaults
directory will typically not be writable.

Allow local paths to be used again (without file://), which was broken
by recent changes. It is necessary to allow playbooks paths to be
provided without having to copy/move them, to preserve any relative
paths that they contain.