### PR TITLE
Fixing parameter used by molecule playbooks

### DIFF
--- a/roles/splunk_common/tasks/update_etc.yml
+++ b/roles/splunk_common/tasks/update_etc.yml
@@ -6,8 +6,10 @@
 
 - name: Update /opt/splunk/etc
   command: /sbin/updateetc.sh
+  register: updateetc
   when:
-  - updateetc_stat_result.stat.exists
+    - updateetc_stat_result.stat.exists
+  changed_when: updateetc.rc == 0 and 'Updating' in updateetc.stdout
   become: yes
   become_user: "{{ splunk.user }}"
   environment:

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -79,6 +79,6 @@
       smartstore: null
       svc_port: 8089
       user: splunk
-      splunk_home_ownership_enforcement: true
+    splunk_home_ownership_enforcement: true
   roles:
     - role: splunk_standalone


### PR DESCRIPTION
Fix for https://github.com/splunk/splunk-ansible/pull/191#issuecomment-500632289

Looks like there's some bad copy-pasta when these vars were written into the molecule playbook. Previously, this was being treated as `splunk.splunk_home_ownership_enforcement` and instead it should've been simply `splunk_home_ownership_enforcement`.