### PR TITLE
fix setting mgmt for splunk port via default.yml

### DIFF
--- a/roles/splunk_common/handlers/main.yml
+++ b/roles/splunk_common/handlers/main.yml
@@ -27,7 +27,7 @@
     state: restarted
   when: splunk.enable_service and not ansible_system is match("Linux")
 
-- name: "Wait for port 8089 to become open"
+- name: "Wait for port {{ splunk.svc_port }} to become open"
   listen: "Restart the splunkd service"
   wait_for:
-    port: 8089
+    port: "{{ splunk.svc_port }}"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -66,6 +66,11 @@
     - "'http_port' in splunk"
     - splunk.http_port | int != 8000
 
+- include_tasks: set_mgmt_port.yml
+  when:
+    - "'svc_port' in splunk"
+    - splunk.svc_port | int != 8089
+
 - include_tasks: enable_ssl_on_gui.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"

--- a/roles/splunk_common/tasks/set_mgmt_port.yml
+++ b/roles/splunk_common/tasks/set_mgmt_port.yml
@@ -1,8 +1,7 @@
 ---
-- name: Set HTTP Port
+- name: Set mgmt port
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
     section: settings
-    option: "httpport"
-    value: "{{ splunk.http_port }}"
-
+    option: "mgmtHostPort"
+    value: "127.0.0.1:{{ splunk.svc_port }}"

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -21,6 +21,6 @@
     state: restarted
   when: splunk.enable_service and ansible_os_family == "Windows"
 
-- name: "Wait for port 8089 to become open"
+- name: "Wait for port {{ splunk.svc_port }} to become open"
   wait_for:
-    port: 8089
+    port: "{{ splunk.svc_port }}"


### PR DESCRIPTION
It turns out, that setting service port via `default.yml` doesn't work - some playbooks are updated but the one which modifies `web.conf` doesn't exist. So the splunk still listens on port 8089 instead of custom one and bootstraping  fails with errors