### PR TITLE
Address synchronization issues

### DIFF
--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -69,3 +69,19 @@
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
+
+- include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
+  vars:
+    splunk_instance_address: "{{ groups['splunk_deployer'][0] }}"
+
+- name: Destructive sync search head
+  command: "{{ splunk.exec }} resync shcluster-replicated-config -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  when: not splunk_search_head_captain | bool
+  register: task_result
+  changed_when: task_result.rc == 0
+  until: task_result.rc == 0
+  retries: "{{ retry_num }}"
+  delay: 10
+  no_log: "{{ hide_password }}"

--- a/site.yml
+++ b/site.yml
@@ -36,5 +36,12 @@
             - ansible_post_tasks is defined
             - ansible_post_tasks is not none
             - ansible_post_tasks is match("^(http|https|file)://.*")
+
+        - name: Check all instances for required restarts
+          include_tasks: ./roles/splunk_common/tasks/check_for_required_restarts.yml
+
+        - name: Flush restart handlers
+          meta: flush_handlers
+
       become: yes
       become_user: "{{ splunk.user }}"


### PR DESCRIPTION
So, a little background.  During some internal testing we saw issues where a search head cluster would appear to desync with some of its members (this happened during the S3 (search head cluster, no index cluster) SVA setup.  I happened to see it too, although rarely, and this is the fix for it.  However, it does come with some negatives.  First of all, it increases the overall deployment time of the S3 scenario by over 100 seconds (taking it from ~114 seconds to ~218 for me), so I am worried about how this performs at a massive scale.  I may try to loop additional people in before submitting this as a fix, because of the performance implications . This is what the code is based on https://docs.splunk.com/Documentation/Splunk/7.3.0/DistSearch/HowconfrepoworksinSHC - under the "Perform a manual resync" section.

Its a good question if this belongs here or if this is something that needs to get pushed onto the consumers (here's how to resync if you see this error, etc etc.) I'm sort of in favor of the latter, but willing to entertain different options.