### PR TITLE
Fixing unresolved vars

### DIFF
--- a/roles/splunk_common/handlers/main.yml
+++ b/roles/splunk_common/handlers/main.yml
@@ -27,7 +27,6 @@
     state: restarted
   when: splunk.enable_service and not ansible_system is match("Linux")
 
-- name: "Wait for port {{ splunk.svc_port }} to become open"
-  listen: "Restart the splunkd service"
+- name: "Wait for splunkd management port"
   wait_for:
     port: "{{ splunk.svc_port }}"

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -21,6 +21,6 @@
     state: restarted
   when: splunk.enable_service and ansible_os_family == "Windows"
 
-- name: "Wait for port {{ splunk.svc_port }} to become open"
+- name: "Wait for splunkd management port"
   wait_for:
     port: "{{ splunk.svc_port }}"


### PR DESCRIPTION
I think the last PR's use of the nested vars in the task name broke things. I believe this is due to the fact that the variable is defined at the inventory-scope and not globally to Ansible. For instance, there's some undefined behavior if this were run against 2 different hosts with 2 different settings.