### PR TITLE
Preventing updating etc when pulling remote URL

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -8,6 +8,9 @@
     - splunk_home_ownership_enforcement | bool
 
 - include_tasks: update_etc.yml
+  when:
+    - ansible_system is match("Linux")
+    - splunk.build_location is not match("^(https?|file):\/\/.*")
 
 - include_tasks: stop_splunk.yml
   when:


### PR DESCRIPTION
Looks like this script will always run and try to update `/opt/splunk/etc` when there's a version mismatch between what is baked into the image and what is actually running. I think this makes sense if you're running a Splunk env (with persistent volumes) using `splunk/splunk:7.2.7` and you update your deployment to suddenly use `splunk/splunk:7.3.0`. 

However, there is some unwarranted behavior when using dynamic builds via `SPLUNK_BUILD_URL`. You can possibly have the case where the newer Splunk version removes some files, but `updateetc.sh` will auto-load the etc directory from the previous Splunk version and leaves you with an environment where Splunk is running with some potentially deprecated apps/configs.

Don't know the best way of handling it, because I see the value of both. But for now, I think it's probably safe to say if your containers are fetching a Splunk build from some URL, you probably want what's in that package and only what's in that package.