### PR TITLE
Increasing timeouts for apps/java

### DIFF
--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -74,7 +74,7 @@
     headers:
       Content-Type: "application/x-www-form-urlencoded"
     status_code: [ 200, 201 ]
-    timeout: 30
+    timeout: 90
   when:
     - "'splunkbase.splunk.com' not in app_url"
     - "'itsi' not in app_contents.stdout_lines"

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -5,7 +5,7 @@
     headers:
       Cookie: oraclelicense=accept-securebackup-cookie
     dest: /opt/container_artifact
-    timeout: 30
+    timeout: 90
   register: download_result
   until: download_result.status_code == 200
   retries: 5


### PR DESCRIPTION
Particularly for some apps (read: ESS) on Windows, the installation via REST takes ~30s so this times out occasionally. Opening this up to 90s to purposely handle longer installation times.