### PR TITLE
Bugfix/upgrade permissions

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -9,7 +9,7 @@
   stat:
     path: "{{ splunk.exec }}"
   become: yes
-  become_user: "{{ splunk.user }}"
+  become_user: "{{ privileged_user }}"
   register: pre_existing_splunk_exec
 
 - name: "Set splunk install fact"
@@ -22,7 +22,7 @@
   stat:
     path: "{{ splunk.home }}/etc/auth/splunk.secret"
   become: yes
-  become_user: "{{ splunk.user }}"
+  become_user: "{{ privileged_user }}"
   register: pre_existing_splunk_secret
 
 - name: "Set first run fact"
@@ -54,7 +54,7 @@
     patterns: ".*-manifest$"
     use_regex: yes
   become: yes
-  become_user: "{{ splunk.user }}"
+  become_user: "{{ privileged_user }}"
   register: manifests
 
 - name: "Set current version fact"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -8,6 +8,8 @@
 - name: "Check for existing installation"
   stat:
     path: "{{ splunk.exec }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
   register: pre_existing_splunk_exec
 
 - name: "Set splunk install fact"
@@ -19,6 +21,8 @@
 - name: "Check for existing splunk secret"
   stat:
     path: "{{ splunk.home }}/etc/auth/splunk.secret"
+  become: yes
+  become_user: "{{ splunk.user }}"
   register: pre_existing_splunk_secret
 
 - name: "Set first run fact"
@@ -49,6 +53,8 @@
     paths: "{{ splunk.home }}"
     patterns: ".*-manifest$"
     use_regex: yes
+  become: yes
+  become_user: "{{ splunk.user }}"
   register: manifests
 
 - name: "Set current version fact"


### PR DESCRIPTION
This should be a fix for https://github.com/splunk/docker-splunk/issues/209

In particular, the error that preventing the upgrade was:
```
TASK [splunk_common : Check for existing splunk secret] ************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Permission denied"}
```

I think this is due to the gui/uid changes made to the `splunk:splunk` user/group when we overhauled the image with the move to debian-10.