### PR TITLE
Bugfix/start splunk on upgrade

### DIFF
--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -4,6 +4,7 @@
   become: yes
   become_user: "{{ splunk.user }}"
   register: splunk_status
+  changed_when: False
   ignore_errors: yes
 
 - name: "Start Splunk via cli"

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -21,7 +21,7 @@
     name: splunk
     state: restarted
   when:
-    - not splunk.enable_service
+    - splunk.enable_service
     - splunk_status.rc != 0
     - ansible_system is match("Linux")
   become: yes
@@ -32,7 +32,7 @@
     name: splunkd
     state: restarted
   when:
-    - not splunk.enable_service
+    - splunk.enable_service
     - splunk_status.rc != 0
     - ansible_os_family == "Windows"
 

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -1,17 +1,29 @@
 ---
+- name: "Get Splunk status"
+  command: "{{ splunk.exec }} status --accept-license --answer-yes --no-prompt"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  register: splunk_status
+  ignore_errors: yes
+
 - name: "Start Splunk via cli"
   command: "{{ splunk.exec }} start --accept-license --answer-yes --no-prompt"
   become: yes
   become_user: "{{ splunk.user }}"
   register: start_splunk
   changed_when: start_splunk.rc == 0 and 'already running' not in start_splunk.stdout
-  when: not splunk.enable_service
+  when:
+    - not splunk.enable_service
+    - splunk_status.rc != 0
 
 - name: "Start Splunk via service"
   service:
     name: splunk
     state: restarted
-  when: splunk.enable_service and ansible_system is match("Linux")
+  when:
+    - not splunk.enable_service
+    - splunk_status.rc != 0
+    - ansible_system is match("Linux")
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -19,7 +31,10 @@
   win_service:
     name: splunkd
     state: restarted
-  when: splunk.enable_service and ansible_os_family == "Windows"
+  when:
+    - not splunk.enable_service
+    - splunk_status.rc != 0
+    - ansible_os_family == "Windows"
 
 - name: "Wait for splunkd management port"
   wait_for:

--- a/roles/splunk_common/tasks/stop_splunk.yml
+++ b/roles/splunk_common/tasks/stop_splunk.yml
@@ -4,6 +4,7 @@
   become: yes
   become_user: "{{ splunk.user }}"
   register: splunk_status
+  changed_when: False
   ignore_errors: yes
 
 - name: "Stop Splunk via cli"
@@ -20,8 +21,8 @@
   service:
     name: splunk
     state: stopped
-  when: 
-    - splunk.enable_service 
+  when:
+    - splunk.enable_service
     - splunk_status.rc == 0
     - ansible_system is match("Linux")
   become: yes
@@ -31,7 +32,7 @@
   win_service:
     name: splunkd
     state: stopped
-  when: 
-    - splunk.enable_service 
+  when:
+    - splunk.enable_service
     - splunk_status.rc == 0
     - ansible_os_family == "Windows"

--- a/roles/splunk_common/tasks/stop_splunk.yml
+++ b/roles/splunk_common/tasks/stop_splunk.yml
@@ -5,7 +5,6 @@
   become_user: "{{ splunk.user }}"
   register: splunk_status
   ignore_errors: yes
-  when: not splunk.enable_service
 
 - name: "Stop Splunk via cli"
   command: "{{ splunk.exec }} stop --accept-license --answer-yes --no-prompt"
@@ -21,7 +20,10 @@
   service:
     name: splunk
     state: stopped
-  when: splunk.enable_service and ansible_system is match("Linux")
+  when: 
+    - splunk.enable_service 
+    - splunk_status.rc == 0
+    - ansible_system is match("Linux")
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -29,4 +31,7 @@
   win_service:
     name: splunkd
     state: stopped
-  when: splunk.enable_service and ansible_os_family == "Windows"
+  when: 
+    - splunk.enable_service 
+    - splunk_status.rc == 0
+    - ansible_os_family == "Windows"


### PR DESCRIPTION
When running Splunk upgrades on a systemd-enabled system, the "systemctl restart splunk" will actually fail on the first time because of Splunk license/FTR/upgrade user-prompts. I'm adding another `./bin/splunk status --accept-license --answer-yes --no-prompt` call here to catch those so we can perform the restart via systemd.