### PR TITLE
On an upgrade, make sure to remove any residual python files

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -57,6 +57,19 @@
   become_user: "{{ privileged_user }}"
   register: manifests
 
+- name: "Find python files"
+  find:
+    paths: 
+        - "{{ splunk.home }}/share"
+        - "{{ splunk.home }}/bin"
+        - "{{ splunk.home }}/lib"
+    patterns: '.*?\.py$'
+    use_regex: yes
+    recurse: yes
+  become: yes
+  become_user: "{{ privileged_user }}"
+  register: py_files
+
 - name: "Set current version fact"
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -59,7 +59,7 @@
 
 - name: "Find python files"
   find:
-    paths: 
+    paths:
         - "{{ splunk.home }}/share"
         - "{{ splunk.home }}/bin"
         - "{{ splunk.home }}/lib"

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -10,6 +10,17 @@
   - "{{ manifests.files }}"
   when: splunk_upgrade | bool
 
+- name: Remove old python files
+  file:
+    path: "{{ item.path }}"
+    state: "absent"
+  ignore_errors: yes
+  become: yes
+  become_user: "{{ privileged_user }}"
+  with_items:
+  - "{{ py_files.files }}"
+  when: splunk_upgrade | bool
+
 - name: Install Splunk (Linux)
   unarchive:
     src: "{{ splunk.build_location }}"


### PR DESCRIPTION
On an upgrade, some versions of splunk left behind python files we do not want to be there.  Removing these prior to an upgrade.