### PR TITLE
Adjust file removal

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -57,19 +57,6 @@
   become_user: "{{ privileged_user }}"
   register: manifests
 
-- name: "Find python files"
-  find:
-    paths:
-        - "{{ splunk.home }}/share"
-        - "{{ splunk.home }}/bin"
-        - "{{ splunk.home }}/lib"
-    patterns: '.*?\.py$'
-    use_regex: yes
-    recurse: yes
-  become: yes
-  become_user: "{{ privileged_user }}"
-  register: py_files
-
 - name: "Set current version fact"
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -12,7 +12,7 @@
 
 - name: Remove old directories
   file:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     state: "absent"
   ignore_errors: yes
   become: yes

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -10,7 +10,7 @@
   - "{{ manifests.files }}"
   when: splunk_upgrade | bool
 
-- name: Remove old python files
+- name: Remove old directories
   file:
     path: "{{ item.path }}"
     state: "absent"
@@ -18,7 +18,9 @@
   become: yes
   become_user: "{{ privileged_user }}"
   with_items:
-  - "{{ py_files.files }}"
+    - "{{ splunk.home }}/bin"
+    - "{{ splunk.home }}/lib"
+    - "{{ splunk.home }}/share"
   when: splunk_upgrade | bool
 
 - name: Install Splunk (Linux)


### PR DESCRIPTION
This seems like it would be more efficient, because we're not attempting to enumerate all of the python files, also this only happens inside of the install splunk play, so its more efficient if we never call it.  Still need to do the longer term fix of reading the manifest and using that for the upgrade logic instead.