### PR TITLE
remove any Python-2.7 files before install

### DIFF
--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -21,6 +21,7 @@
     - "{{ splunk.home }}/bin"
     - "{{ splunk.home }}/lib"
     - "{{ splunk.home }}/share"
+    - "{{ splunk.home }}/Python-2.7"
   when: splunk_upgrade | bool
 
 - name: Install Splunk (Linux)


### PR DESCRIPTION
The issue here is that any python updates may need to remove additional files than the new upgraded one.