### PR TITLE
Ensure that Splunk REST API calls are properly urlencoded

### DIFF
--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -21,10 +21,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: False
-    body: "name=indexer_discovery&pass4SymmKey={{ splunk.shc.secret }}"
-    body_format: json
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "indexer_discovery"
+      pass4SymmKey: "{{ splunk.shc.secret }}"
+    body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
   register: set_indexer_discovery

--- a/roles/splunk_common/tasks/enable_dfs.yml
+++ b/roles/splunk_common/tasks/enable_dfs.yml
@@ -6,9 +6,12 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "disabled=false&port={{ splunk.dfs.port }}&spark_master_host={{ splunk.dfs.spark_master_host }}&spark_master_webui_port={{ splunk.dfs.spark_master_webui_port }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      disabled: "false"
+      port: "{{ splunk.dfs.port }}"
+      spark_master_host: "{{ splunk.dfs.spark_master_host }}"
+      spark_master_webui_port: "{{ splunk.dfs.spark_master_webui_port }}"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   register: dfs_enable_result
@@ -21,9 +24,11 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "dfc_num_slots={{ splunk.dfs.dfc_num_slots }}&dfw_num_slots={{ splunk.dfs.dfw_num_slots }}&dfw_num_slots_enabled={{ splunk.dfs.dfw_num_slots_enabled }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      dfc_num_slots: "{{ splunk.dfs.dfc_num_slots }}"
+      dfw_num_slots: "{{ splunk.dfs.dfw_num_slots }}"
+      dfw_num_slots_enabled: "{{ splunk.dfs.dfw_num_slots_enabled }}"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   register: dfs_limits_result
@@ -36,9 +41,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "phased_execution=true&max_searches_per_process=1"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      phased_execution: "true"
+      max_searches_per_process: "1"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   register: search_limits_result
@@ -62,9 +68,11 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=search_optimization%3a%3adfs_job_extractor&enabled=true&commands=stats,join,sort,head,tail,reverse,dedup,rename,fields,union,from,eval"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "search_optimization::dfs_job_extractor"
+      enabled: "true"
+      commands: "stats,join,sort,head,tail,reverse,dedup,rename,fields,union,from,eval"
+    body_format: "form-urlencoded"
     status_code: 201
     timeout: 10
   register: create_dfs_job_extractor_result
@@ -78,9 +86,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "enabled=true&commands=stats,join,sort,head,tail,reverse,dedup,rename,fields,union,from,eval"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      enabled: "true"
+      commands: "stats,join,sort,head,tail,reverse,dedup,rename,fields,union,from,eval"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   register: update_dfs_job_extractor_result

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -8,9 +8,11 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=indexer_discovery:splunk-indexer&pass4SymmKey={{ splunk.shc.secret }}&master_uri={{ cert_prefix }}://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "indexer_discovery:splunk-indexer"
+      pass4SymmKey: "{{ splunk.shc.secret }}"
+      master_uri: "{{ cert_prefix }}://{{ groups['splunk_cluster_master'][0] }}:{{ splunk.svc_port }}"
+    body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
   when: splunk.indexer_cluster
@@ -27,9 +29,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=tcpout:group1&indexerDiscovery=splunk-indexer"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "tcpout:group1"
+      indexerDiscovery: "splunk-indexer"
+    body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
   when: splunk.indexer_cluster
@@ -44,9 +47,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "indexAndForward=false&defaultGroup=group1"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      indexAndForward: "false"
+      defaultGroup: "group1"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   when: splunk.indexer_cluster
@@ -75,9 +79,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=indexAndForward&index=false"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "indexAndForward"
+      index: "false"
+    body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
   register: disable_indexing_stanza

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -6,9 +6,12 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name={{ app_url | urlencode() }}&update=true&filename=true&auth={{ splunkbase_token }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "{{ app_url }}"
+      update: "true"
+      filename: "true"
+      auth: "{{ splunkbase_token }}"
+    body_format: "form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 300
   when:
@@ -70,9 +73,11 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=/tmp/app.spl&update=true&filename=true"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "/tmp/app.spl"
+      update: "true"
+      filename: "true"
+    body_format: "form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 90
   when:

--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -19,9 +19,10 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name=splunk_hec_token&token={{ splunk.hec_token }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "splunk_hec_token"
+      token: "{{ splunk.hec_token }}"
+    body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
   ignore_errors: true

--- a/roles/splunk_common/tasks/set_root_endpoint.yml
+++ b/roles/splunk_common/tasks/set_root_endpoint.yml
@@ -6,9 +6,9 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "root_endpoint={{ splunk.root_endpoint }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      root_endpoint: "{{ splunk.root_endpoint }}"
+    body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
   when: splunk.root_endpoint

--- a/roles/splunk_deployment_server/tasks/install_deployment_apps.yml
+++ b/roles/splunk_deployment_server/tasks/install_deployment_apps.yml
@@ -7,9 +7,12 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "name={{ app_url | urlencode() }}&update=true&filename=true&auth={{ splunkbase_token }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      name: "{{ app_url }}"
+      update: "true"
+      filename: "true"
+      auth: "{{ splunkbase_token }}"
+    body_format: "form-urlencoded"
     status_code: [ 200, 201 ]
     timeout: 300
   when:

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -36,9 +36,9 @@
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
-    body: "preferred_captain={{ splunk_search_head_captain | bool | lower }}"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
+    body:
+      preferred_captain: "{{ splunk_search_head_captain | bool | lower }}"
+    body_format: "form-urlencoded"
     timeout: 10
   notify:
     - Restart the splunkd service


### PR DESCRIPTION
By default, the ansible "uri" module does not urlencode body content. There were many places in playbooks where it was being used with variables plugged directly into the body content, which led to the possibility of it sending invalid HTTP requests to the Splunk REST APIs.

For example, randomly generated secrets that contained a % character resulted in failures like this one:

Status code was 400 and not [201, 409]: HTTP Error 400: Unparsable URI-encoded request data

This could easily be reproduced by including invalid characters in shc.secret.

To fix this, I updated almost all of the instances of "uri" to use "form-urlencoded" for "body_format" and splitting out each key/value pair inside the body object. This way, ansible is always used to properly urlencoded the requests being sent to the Splunk Rest APIs.