### PR TITLE
Use splunk user to get splunk facts

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -9,7 +9,7 @@
   stat:
     path: "{{ splunk.exec }}"
   become: yes
-  become_user: "{{ privileged_user }}"
+  become_user: "{{ splunk.user }}"
   register: pre_existing_splunk_exec
 
 - name: "Set splunk install fact"
@@ -22,7 +22,7 @@
   stat:
     path: "{{ splunk.home }}/etc/auth/splunk.secret"
   become: yes
-  become_user: "{{ privileged_user }}"
+  become_user: "{{ splunk.user }}"
   register: pre_existing_splunk_secret
 
 - name: "Set first run fact"
@@ -54,7 +54,7 @@
     patterns: ".*-manifest$"
     use_regex: yes
   become: yes
-  become_user: "{{ privileged_user }}"
+  become_user: "{{ splunk.user }}"
   register: manifests
 
 - name: "Set current version fact"


### PR DESCRIPTION
There were certain facts accessible to (and owned by) the splunk user that we previously were upgraded to priviliged user to get. This PR updates behaviour so that the splunk user is used to get these facts.