### PR TITLE
Add support for overriding splunk.user via SPLUNK_USER environment variable

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -174,6 +174,7 @@ def getSplunkApps(vars_scope):
         vars_scope["splunk"]["apps_location"] = []
 
 def overrideEnvironmentVars(vars_scope):
+    vars_scope["splunk"]["user"] = os.environ.get("SPLUNK_USER", vars_scope["splunk"]["user"])
     vars_scope["splunk"]["group"] = os.environ.get("SPLUNK_GROUP", vars_scope["splunk"]["group"])
     vars_scope["ansible_pre_tasks"] = os.environ.get("SPLUNK_ANSIBLE_PRE_TASKS", vars_scope["ansible_pre_tasks"])
     vars_scope["ansible_post_tasks"] = os.environ.get("SPLUNK_ANSIBLE_POST_TASKS", vars_scope["ansible_post_tasks"])


### PR DESCRIPTION
Currenty, you can only override the user splunk runs as by using a default.yml file that overrides splunk.user.

For Universal Forwarders especially, it is sometimes desired to run splunkd as root or some other user so that it is able to read log files generated and owned by other processes.

This just makes it possible to change the user splunk runs as using the SPLUNK_USER environment variable, the same was as the SPLUNK_GROUP environment variable can be used to override splunk.group