### PR TITLE
Removing non-essential ITSI components on indexer tier

### DIFF
--- a/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
@@ -1,0 +1,10 @@
+---
+- name: Determine ITSI default apps
+  set_fact:
+    itsi_apps: ["DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
+                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", 
+                "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "itsi", "splunk_app_infrastructure"]
+
+- name: Remove ITSI apps from installed apps list
+  set_fact:
+    installed_apps: "{{ installed_apps | difference(itsi_apps) | unique }}"

--- a/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
@@ -2,7 +2,7 @@
 - name: Determine ITSI default apps
   set_fact:
     itsi_apps: ["DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
-                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", 
+                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD",
                 "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "itsi", "splunk_app_infrastructure"]
 
 - name: Remove ITSI apps from installed apps list

--- a/roles/splunk_cluster_master/tasks/push_apps_to_indexers.yml
+++ b/roles/splunk_cluster_master/tasks/push_apps_to_indexers.yml
@@ -5,6 +5,10 @@
   when:
     - '"SplunkEnterpriseSecuritySuite" in installed_apps'
 
+- include_tasks: generate_itsi_bundle.yml
+  when:
+    - '"itsi" in installed_apps'
+
 # TODO: Might be better to use synchronize here, but we'll need rsync installed
 - name: Copy installed apps to master-apps
   command: "cp -R {{ splunk.app_paths.default }}/{{ item }} {{ splunk.app_paths.idxc }}"


### PR DESCRIPTION
Per:
- https://docs.splunk.com/Documentation/ITSI/4.3.0/Install/InstallDD
- https://docs.splunk.com/Documentation/ITSI/4.3.0/Install/UpgradeSHC

This PR should only support the following apps installed on indexers:
- SA-IndexCreation
- Splunk_TA_Infrastructure
- SA-ITSI-Licensechecker
- SA-UserAccess

