### PR TITLE
Adding a different build java8

### DIFF
--- a/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
@@ -19,37 +19,6 @@
   become: yes
   become_user: "{{ privileged_user }}"
 
-- name: Create splunk-launch.conf
-  become: yes
-  become_user: "{{ privileged_user }}"
-  command: cp {{ splunk.home }}/etc/splunk-launch.conf.default {{ splunk.home }}/etc/splunk-launch.conf
-  ignore_errors: true
-  when:
-    - ansible_distribution == 'Debian'
-    - "'10' not in ansible_distribution_version"
-
-- name: Get JAVA_HOME
-  shell: 'readlink -f /usr/bin/java | sed "s:bin/java::"'
-  register: java_home
-  become: yes
-  become_user: "{{ privileged_user }}"
-  ignore_errors: true
-  when:
-    - ansible_distribution == 'Debian'
-    - "'10' not in ansible_distribution_version"
-
-- name: Set JAVA_HOME in splunk-launch.conf
-  become: yes
-  become_user: "{{ privileged_user }}"
-  lineinfile:
-    path: "{{ splunk.home }}/etc/splunk-launch.conf"
-    regexp: '^JAVA_HOME'
-    line: "JAVA_HOME={{ java_home.stdout }}"
-  ignore_errors: true
-  when:
-    - ansible_distribution == 'Debian'
-    - "'10' not in ansible_distribution_version"
-
 - name: Install JDK dependencies
   apt:
     name: ['apt-transport-https', 'ca-certificates', 'wget', 'dirmngr', 'gnupg', 'software-properties-common']
@@ -61,7 +30,12 @@
   become_user: "{{ privileged_user }}"
 
 - name: Get the openjdk apt key
-  shell: wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+  shell: |
+    set -o pipefail
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+  args:
+    executable: /bin/bash
+    warn: false
   when:
     - ansible_distribution == 'Debian'
     - "'10' in ansible_distribution_version"
@@ -77,7 +51,7 @@
   become_user: "{{ privileged_user }}"
 
 - name: Install openjdk
-  apt: 
+  apt:
     name: "adoptopenjdk-8-hotspot"
     update_cache: yes
   when:
@@ -85,3 +59,31 @@
     - "'10' in ansible_distribution_version"
   become: yes
   become_user: "{{ privileged_user }}"
+
+- name: Create splunk-launch.conf
+  become: yes
+  become_user: "{{ privileged_user }}"
+  command: cp {{ splunk.home }}/etc/splunk-launch.conf.default {{ splunk.home }}/etc/splunk-launch.conf
+  ignore_errors: true
+  when:
+    - ansible_distribution == 'Debian'
+
+- name: Get JAVA_HOME
+  shell: 'readlink -f /usr/bin/java | sed "s:bin/java::"'
+  register: java_home
+  become: yes
+  become_user: "{{ privileged_user }}"
+  ignore_errors: true
+  when:
+    - ansible_distribution == 'Debian'
+
+- name: Set JAVA_HOME in splunk-launch.conf
+  become: yes
+  become_user: "{{ privileged_user }}"
+  lineinfile:
+    path: "{{ splunk.home }}/etc/splunk-launch.conf"
+    regexp: '^JAVA_HOME'
+    line: "JAVA_HOME={{ java_home.stdout }}"
+  ignore_errors: true
+  when:
+    - ansible_distribution == 'Debian'

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
@@ -15,6 +15,7 @@
     update_cache: yes
   when:
     - ansible_distribution == 'Debian'
+    - "'10' not in ansible_distribution_version"
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -25,6 +26,7 @@
   ignore_errors: true
   when:
     - ansible_distribution == 'Debian'
+    - "'10' not in ansible_distribution_version"
 
 - name: Get JAVA_HOME
   shell: 'readlink -f /usr/bin/java | sed "s:bin/java::"'
@@ -34,6 +36,7 @@
   ignore_errors: true
   when:
     - ansible_distribution == 'Debian'
+    - "'10' not in ansible_distribution_version"
 
 - name: Set JAVA_HOME in splunk-launch.conf
   become: yes
@@ -45,3 +48,40 @@
   ignore_errors: true
   when:
     - ansible_distribution == 'Debian'
+    - "'10' not in ansible_distribution_version"
+
+- name: Install JDK dependencies
+  apt:
+    name: ['apt-transport-https', 'ca-certificates', 'wget', 'dirmngr', 'gnupg', 'software-properties-common']
+    update_cache: yes
+  when:
+    - ansible_distribution == 'Debian'
+    - "'10' in ansible_distribution_version"
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Get the openjdk apt key
+  shell: wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+  when:
+    - ansible_distribution == 'Debian'
+    - "'10' in ansible_distribution_version"
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Get the key
+  command: "add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/"
+  when:
+    - ansible_distribution == 'Debian'
+    - "'10' in ansible_distribution_version"
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Install openjdk
+  apt: 
+    name: "adoptopenjdk-8-hotspot"
+    update_cache: yes
+  when:
+    - ansible_distribution == 'Debian'
+    - "'10' in ansible_distribution_version"
+  become: yes
+  become_user: "{{ privileged_user }}"


### PR DESCRIPTION
Java8 is back for Debian 10.

`ansible@so1:/opt/splunk$ java -version
openjdk version "1.8.0_222"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_222-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)`