### PR TITLE
Allow the user to set the preferred captaincy

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -110,6 +110,10 @@ splunk:
   license_master_included: <bool>
   * Boolean to determine whether there exists a separate license master 
   * Default: false
+  
+  preferred_captaincy: <bool>
+  * Boolean to determine whether splunk should set a preferred captain.  This can have an effect on day 2 operations if the search heads need to be restarted 
+  * Default: true
 
   apps_location: <list>
   * List of apps to install - elements can be in the form of a URL or a location in the filessytem

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -110,6 +110,8 @@ def getDefaultVars():
     defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
+    #If the value is set, we would use that, otherwise, return True
+    defaultVars["splunk"]["preferred_captaincy"] = True if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', True) else False
 
     # Check required Java installation
     java_version = os.environ.get("JAVA_VERSION", "").lower()
@@ -401,6 +403,7 @@ def prep_for_yaml_out(inventory):
                    "search_head_cluster",
                    "indexer_cluster",
                    "license_master_included",
+                   "preferred_captaincy",
                    "license_uri"]
     for key in keys_to_del:
         if key in inventory_to_dump:

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -111,7 +111,7 @@ def getDefaultVars():
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
     #If the value is set, we would use that, otherwise, return True
-    defaultVars["splunk"]["preferred_captaincy"] = True if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', True) else False
+    defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True
 
     # Check required Java installation
     java_version = os.environ.get("JAVA_VERSION", "").lower()

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -44,7 +44,7 @@
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
   when:
-    - splunk_search_head_captain is defined
+    - splunk_search_head_captain is defined and splunk.preferred_captaincy | bool
 
 - name: Flush restart handlers
   meta: flush_handlers

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -25,6 +25,7 @@
       role: splunk_standalone
       license_master_included: false
       license_uri: null
+      preferred_captaincy: true
       wildcard_license: false
       build_remote_src: true
       build_location: https://download.splunk.com/products/splunk/releases/7.3.0/linux/splunk-7.3.0-657388c7a488-Linux-x86_64.tgz

--- a/roles/splunk_universal_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/default/playbook.yml
@@ -25,6 +25,7 @@
       indexer_cluster: false
       license_master_included: false
       license_uri: null
+      preferred_captaincy: true
       build_remote_src: true
       build_location: https://download.splunk.com/products/universalforwarder/releases/7.3.0/linux/splunkforwarder-7.3.0-657388c7a488-Linux-x86_64.tgz
       apps_location: null


### PR DESCRIPTION
Defaults to "true" (old behavior) when not set.  For docker, its encouraged to set the preferred captaincy for day 2 operations.