### PR TITLE
Fixing an issue found after updating the captaincy to False

### DIFF
--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -74,7 +74,7 @@
   command: "{{ splunk.exec }} resync shcluster-replicated-config -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
-  when: not splunk_search_head_captain | bool
+  when: not splunk_search_head_captain | bool and splunk.preferred_captaincy | bool
   register: task_result
   changed_when: task_result.rc == 0
   until: task_result.rc == 0


### PR DESCRIPTION
Basically, the destructive resync shouldn't happen if we're still trying to figure out the captain, because we didn't set the preferred captain.