### PR TITLE
Bugfix/failed to open user seed conf

### DIFF
--- a/roles/splunk_common/tasks/get_facts_target_version.yml
+++ b/roles/splunk_common/tasks/get_facts_target_version.yml
@@ -10,7 +10,7 @@
     splunk_target_version: "{{ splunk.build_location | regex_search(regexp, '\\1') | default('0') }}"
   vars:
     regexp: 'splunk\D*?-((\d+)\.(\d+)\.(\d+))'
-  when: "splunk_build_type is defined and splunk_build_type is match('(tgz|rpm|deb)')"
+  when: "splunk_build_type is defined and splunk_build_type is match('(tgz|msi|rpm|deb)')"
 
 # if using yum to install a package, we can use the list option to see what versions are available
 - name: "Set target version fact (yum)"

--- a/roles/splunk_common/tasks/install_splunk_msi.yml
+++ b/roles/splunk_common/tasks/install_splunk_msi.yml
@@ -1,5 +1,5 @@
 - name: Install Splunk (Windows)
-  command: "msiexec /I {{ splunk.build_location }} AGREETOLICENSE=yes SPLUNKUSERNAME={{ splunk.admin_user }} SPLUNKPASSWORD={{ splunk.password }} LAUNCHSPLUNK=0 INSTALLDIR=C:\\\\opt\\\\{{ splunk.tar_dir }} /passive /qn"
+  command: "msiexec /I {{ splunk.build_location }} AGREETOLICENSE=yes LAUNCHSPLUNK=0 INSTALLDIR=C:\\\\opt\\\\{{ splunk.tar_dir }} /passive /qn"
   when: ansible_system is match("CYGWIN*|Win32NT")
   register: install_result
   until: install_result is succeeded


### PR DESCRIPTION
For MSI installation, the splunk install task passes in the SPLUNKUSERNAME and SPLUNKPASSWORD and which will generate user-seed.conf automatically with plaintext password, later the "set user-seed.conf" task will append HASHED_PASSWORD into user-seed.conf and they are conflict actually. 