### PR TITLE
Adding logic to prevent double first-time-run installation

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -27,6 +27,7 @@
   include_tasks: install_splunk.yml
   when:
     - not splunk_install
+    - not first_run
     - splunk_upgrade | bool
     - splunk.allow_upgrade is defined
     - splunk.allow_upgrade | bool


### PR DESCRIPTION
I've been seeing this issue come up recently where when a `SPLUNK_BUILD_URL` is supplied, the install occurs twice - I'm not sure exactly what broke this existing logic, but we probably should have a test for this. If anyone knows how this happened and there's a better fix, please let me know :P But I'd like to get this in because this can potentially cause double the network traffic especially when fetching remote builds.

This happens and can be reproduced with `splunk/splunk:latest`:
```
docker run -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld -e SPLUNK_BUILD_URL=http://localhost:8001/splunk-8.0.0-c7dde01dccdf-Linux-x86_64.tgz --network host -d splunk/splunk:latest
```
```
included: /opt/ansible/roles/splunk_common/tasks/install_splunk.yml for localhost
Wednesday 18 September 2019  05:01:03 +0000 (0:00:00.094)       0:00:07.337 ***

TASK [splunk_common : Remove old manifest files] *******************************
changed: [localhost] => (item={u'rusr': True, u'uid': 41812, u'rgrp': True, u'xoth': False, u'islnk': False, u'woth': False, u'nlink': 1, u'issock': False, u'mtime': 1559284631.0, u'gr_name': u'splunk', u'path': u'/opt/splunk/splunk-7.3.0-657388c7a488-linux-2.6-x86_64-manifest', u'xusr': False, u'atime': 1559284631.0, u'inode': 3834645, u'isgid': False, u'size': 2254627, u'isdir': False, u'ctime': 1568693152.081721, u'isblk': False, u'wgrp': False, u'xgrp': False, u'isuid': False, u'dev': 113, u'roth': True, u'isreg': True, u'isfifo': False, u'mode': u'0444', u'pw_name': u'splunk', u'gid': 41812, u'ischr': False, u'wusr': False})
Wednesday 18 September 2019  05:01:03 +0000 (0:00:00.129)       0:00:07.467 ***

TASK [splunk_common : Remove old directories] **********************************
changed: [localhost] => (item=/opt/splunk/bin)
changed: [localhost] => (item=/opt/splunk/lib)
changed: [localhost] => (item=/opt/splunk/share)
ok: [localhost] => (item=/opt/splunk/Python-2.7)
Wednesday 18 September 2019  05:01:04 +0000 (0:00:00.831)       0:00:08.298 ***
included: /opt/ansible/roles/splunk_common/tasks/install_splunk_tgz.yml for localhost
Wednesday 18 September 2019  05:01:04 +0000 (0:00:00.082)       0:00:08.381 ***

TASK [splunk_common : Install Splunk (Linux)] **********************************
changed: [localhost]
Wednesday 18 September 2019  05:01:32 +0000 (0:00:27.522)       0:00:35.904 ***

TASK [splunk_common : Remove installers] ***************************************
ok: [localhost] => (item=http://localhost:8001/splunk-8.0.0-c7dde01dccdf-Linux-x86_64.tgz)
ok: [localhost] => (item=/tmp/splunk.msi)
Wednesday 18 September 2019  05:01:32 +0000 (0:00:00.279)       0:00:36.183 ***
included: /opt/ansible/roles/splunk_common/tasks/install_splunk.yml for localhost
Wednesday 18 September 2019  05:01:32 +0000 (0:00:00.107)       0:00:36.291 ***

TASK [splunk_common : Remove old manifest files] *******************************
ok: [localhost] => (item={u'rusr': True, u'uid': 41812, u'rgrp': True, u'xoth': False, u'islnk': False, u'woth': False, u'nlink': 1, u'issock': False, u'mtime': 1559284631.0, u'gr_name': u'splunk', u'path': u'/opt/splunk/splunk-7.3.0-657388c7a488-linux-2.6-x86_64-manifest', u'xusr': False, u'atime': 1559284631.0, u'inode': 3834645, u'isgid': False, u'size': 2254627, u'isdir': False, u'ctime': 1568693152.081721, u'isblk': False, u'wgrp': False, u'xgrp': False, u'isuid': False, u'dev': 113, u'roth': True, u'isreg': True, u'isfifo': False, u'mode': u'0444', u'pw_name': u'splunk', u'gid': 41812, u'ischr': False, u'wusr': False})
Wednesday 18 September 2019  05:01:32 +0000 (0:00:00.149)       0:00:36.440 ***

TASK [splunk_common : Remove old directories] **********************************
changed: [localhost] => (item=/opt/splunk/bin)
changed: [localhost] => (item=/opt/splunk/lib)
changed: [localhost] => (item=/opt/splunk/share)
ok: [localhost] => (item=/opt/splunk/Python-2.7)
Wednesday 18 September 2019  05:01:33 +0000 (0:00:00.915)       0:00:37.356 ***
included: /opt/ansible/roles/splunk_common/tasks/install_splunk_tgz.yml for localhost
Wednesday 18 September 2019  05:01:33 +0000 (0:00:00.088)       0:00:37.445 ***

TASK [splunk_common : Install Splunk (Linux)] **********************************
changed: [localhost]
Wednesday 18 September 2019  05:02:01 +0000 (0:00:27.672)       0:01:05.118 ***

TASK [splunk_common : Remove installers] ***************************************
ok: [localhost] => (item=http://localhost:8001/splunk-8.0.0-c7dde01dccdf-Linux-x86_64.tgz)
ok: [localhost] => (item=/tmp/splunk.msi)
Wednesday 18 September 2019  05:02:01 +0000 (0:00:00.295)       0:01:05.413 ***
```