### PR TITLE
Replacing six urllib compatibility with requests

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -24,7 +24,6 @@ import random
 import string
 from time import sleep
 import requests
-import six.moves.urllib.parse as urllib2_parse
 import urllib3
 import yaml
 import socket
@@ -163,12 +162,11 @@ def getSplunkApps(vars_scope):
     splunkbase_username = (vars_scope["splunkbase_username"] if "splunkbase_username" in vars_scope else None) or os.environ.get("SPLUNKBASE_USERNAME") or None
     splunkbase_password = (vars_scope["splunkbase_password"] if "splunkbase_password" in vars_scope else None) or os.environ.get("SPLUNKBASE_PASSWORD") or None
     if splunkbase_username and splunkbase_password:
-        splunkbase_username = urllib2_parse.quote(splunkbase_username)
-        splunkbase_password = urllib2_parse.quote(splunkbase_password)
-        response = urllib2_parse.urlopen("https://splunkbase.splunk.com/api/account:login/", "username={}&password={}".format(splunkbase_username, splunkbase_password))
-        if response.getcode() != 200:
+        resp = requests.post("https://splunkbase.splunk.com/api/account:login/", 
+                             data={"username": splunkbase_username, "password": splunkbase_password})
+        if resp.status_code != 200:
             raise Exception("Invalid Splunkbase credentials - will not download apps from Splunkbase")
-        output = response.read()
+        output = resp.content
         splunkbase_token = re.search("<id>(.*)</id>", output, re.IGNORECASE)
         vars_scope["splunkbase_token"] = splunkbase_token.group(1) if splunkbase_token else None
     apps = os.environ.get("SPLUNK_APPS_URL", None)

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -104,3 +104,13 @@ def test_getSplunkApps(vars_scope, trigger_splunkbase, os_env, apps_count):
             assert not vars_scope.get("splunkbase_token")
     # Check that the SPLUNK_APPS_URL gets assigned
     assert len(vars_scope["splunk"].get("apps_location")) == apps_count
+
+def test_getSplunkApps_exception():
+    with patch("environ.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=400, content="error")
+        try:
+            environ.getSplunkApps({"splunkbase_username": "ocho", "splunkbase_password": "cinco"})
+            assert False
+        except Exception as e:
+            assert True
+            assert "Invalid Splunkbase credentials" in str(e)

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import os
 import sys
 import pytest
-import mock
+from mock import MagicMock, patch
 
 FILE_DIR = os.path.dirname(os.path.realpath(__file__))
 #FIXTURES_DIR = os.path.join(FILE_DIR, "fixtures")
@@ -29,12 +29,12 @@ def test_getVars(regex, result):
     This method makes the assumption that there will always be a group(1),
     So if doing an exact string match, for now group the entire string
     '''
-    with mock.patch("os.environ", new={"FOOBAR": "123", "BARFOO": "456"}):
+    with patch("os.environ", new={"FOOBAR": "123", "BARFOO": "456"}):
         r = environ.getVars(regex)
         assert r == result
 
-@mock.patch('environ.loadDefaultSplunkVariables', return_value={"splunk": {"build_location": None}})
-@mock.patch('environ.overrideEnvironmentVars')
+@patch('environ.loadDefaultSplunkVariables', return_value={"splunk": {"build_location": None}})
+@patch('environ.overrideEnvironmentVars')
 def test_getDefaultVars(mock_overrideEnvironmentVars, mock_loadDefaultSplunkVariables):
     '''
     Unit test for getting our default variables
@@ -64,3 +64,43 @@ def test_convert_path_windows_to_nix(filepath, result):
     '''
     outcome = environ.convert_path_windows_to_nix(filepath)
     assert outcome == result
+
+@pytest.mark.parametrize(("vars_scope", "trigger_splunkbase", "os_env", "apps_count"),
+                         [
+                            # Check variety of splunkbase parameters
+                            ({}, False, {}, 0),
+                            ({"splunkbase_username": "ocho"}, False, {}, 0),
+                            ({"splunkbase_password": "cinco"}, False, {}, 0),
+                            ({"splunkbase_username": "ocho", "splunkbase_password": "cinco"}, True, {}, 0),
+                            # Check variety of environment variable parameters
+                            ({}, False, {"SPLUNK_APPS": "hi"}, 0),
+                            ({}, False, {"SPLUNK_APPS_URL": "hi"}, 1),
+                            ({}, False, {"SPLUNK_APPS_URL": "a,b,ccccc,dd"}, 4),
+                            # Sanity check the combination of splunkbase params + env vars work
+                            ({"splunkbase_username": "ocho"}, False, {"SPLUNKBASE_USERNAME": "qwerty"}, 0),
+                            ({"splunkbase_password": "cinco"}, False, {"SPLUNKBASE_PASSWORD": "qwerty"}, 0),
+                            ({"splunkbase_username": "ocho"}, True, {"SPLUNKBASE_PASSWORD": "cinco"}, 0),
+                            ({"splunkbase_password": "cinco"}, True, {"SPLUNKBASE_USERNAME": "ocho"}, 0),
+                            ({}, True, {"SPLUNKBASE_USERNAME": "ocho", "SPLUNKBASE_PASSWORD": "cinco"}, 0),
+                            ({"splunkbase_username": "ocho"}, False, {"SPLUNKBASE_USERNAME": "qwerty", "SPLUNK_APPS_URL": "a,b,dd"}, 3),
+                            ({"splunkbase_password": "cinco"}, False, {"SPLUNKBASE_PASSWORD": "qwerty", "SPLUNK_APPS_URL": "a,b,dd"}, 3),
+                            ({"splunkbase_username": "ocho"}, True, {"SPLUNKBASE_PASSWORD": "cinco", "SPLUNK_APPS_URL": "a,b,dd"}, 3),
+                            ({"splunkbase_password": "cinco"}, True, {"SPLUNKBASE_USERNAME": "ocho", "SPLUNK_APPS_URL": "a,b,dd"}, 3),
+                            ({}, True, {"SPLUNKBASE_USERNAME": "ocho", "SPLUNKBASE_PASSWORD": "cinco", "SPLUNK_APPS_URL": "a,b,dd"}, 3),
+                         ]
+                        )
+def test_getSplunkApps(vars_scope, trigger_splunkbase, os_env, apps_count):
+    vars_scope["splunk"] = {}
+    with patch("environ.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, content="<id>123abc</id>")
+        with patch("os.environ", new=os_env):
+            environ.getSplunkApps(vars_scope)
+        # Make sure Splunkbase token is populated when appropriate
+        if trigger_splunkbase:
+            mock_post.assert_called_with("https://splunkbase.splunk.com/api/account:login/", data={"username": "ocho", "password": "cinco"})
+            assert vars_scope.get("splunkbase_token") == "123abc"
+        else:
+            mock_post.assert_not_called()
+            assert not vars_scope.get("splunkbase_token")
+    # Check that the SPLUNK_APPS_URL gets assigned
+    assert len(vars_scope["splunk"].get("apps_location")) == apps_count


### PR DESCRIPTION
I don't think we need the six urllib backwards compatibility library here, because we're already importing the python requests package.

There's also some unit tests added around this method to catch issues like this from occurring. 