### PR TITLE
Force string var to integer

### DIFF
--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -10,7 +10,7 @@
 - name: Lower SHC replication factor
   set_fact:
     shc_replication_factor: 1
-  when: num_search_head_hosts <= 3
+  when: num_search_head_hosts|int <= 3
 
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:


### PR DESCRIPTION
Found while testing shc on new debian 10 image (python3). Integer comparison does not work on string variable.