### PR TITLE
allow manually specifying forward-servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ large-tests: test-setup
 	@echo 'Running the super awesome large tests'
 	cd roles/splunk_standalone && molecule test
 	cd roles/splunk_universal_forwarder && molecule test
+	cd roles/splunk_heavy_forwarder && molecule test --all
 
 py3k-large-tests: py3k-test-setup
 	@echo 'Running the super awesome large tests'

--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -11,7 +11,7 @@
 
 - name: "Restart the splunkd service - Via systemd"
   service:
-    name: Splunkd
+    name: "{{ splunk.service_name }}"
     state: restarted
   when: splunk.enable_service and ansible_system is match("Linux")
   become: yes

--- a/roles/splunk_common/tasks/add_forward_server.yml
+++ b/roles/splunk_common/tasks/add_forward_server.yml
@@ -1,9 +1,10 @@
 ---
-- name: "Enable forwarding to {{ item }}"
+- name: "Enable forwarding to {{ forward_servers }}"
   command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ forward_servers }}"
+  when: forward_servers | bool
   register: forward_status
   until: forward_status.rc == 0 or 'forwarded-server already present' in forward_status.stderr
   failed_when:

--- a/roles/splunk_common/tasks/add_forward_server.yml
+++ b/roles/splunk_common/tasks/add_forward_server.yml
@@ -1,10 +1,9 @@
 ---
-- name: "Enable forwarding to {{ role }}"
+- name: "Enable forwarding to {{ item }}"
   command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
-  with_items: "{{ groups[role] }}"
-  when: "role in groups"
+  with_items: "{{ forward_servers }}"
   register: forward_status
   until: forward_status.rc == 0 or 'forwarded-server already present' in forward_status.stderr
   failed_when:

--- a/roles/splunk_common/tasks/add_forward_server.yml
+++ b/roles/splunk_common/tasks/add_forward_server.yml
@@ -4,14 +4,13 @@
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ forward_servers }}"
-  when: forward_servers | bool
   register: forward_status
-  until: forward_status.rc == 0 or 'forwarded-server already present' in forward_status.stderr
+  changed_when:
+    - "'Added forwarding to: ' + item + ':' + (splunk.s2s_port|string) in forward_status.stdout"
+    - "'forwarded-server already present' not in forward_status.stderr"
   failed_when:
     - forward_status.rc != 0
     - "'forwarded-server already present' not in forward_status.stderr"
-  retries: "{{ retry_num }}"
-  delay: 3
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -15,7 +15,7 @@
     body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
-  when: splunk.indexer_cluster
+  when: splunk_indexer_cluster
   register: setup_indexer_discovery_stanza
   changed_when: setup_indexer_discovery_stanza.status == 201
   no_log: "{{ hide_password }}"
@@ -35,7 +35,7 @@
     body_format: "form-urlencoded"
     status_code: 201,409
     timeout: 10
-  when: splunk.indexer_cluster
+  when: splunk_indexer_cluster
   register: setup_tcpoutgroup_stanza
   changed_when: setup_tcpoutgroup_stanza.status == 201
   no_log: "{{ hide_password }}"
@@ -53,7 +53,7 @@
     body_format: "form-urlencoded"
     status_code: 200
     timeout: 10
-  when: splunk.indexer_cluster
+  when: splunk_indexer_cluster
   register: setup_tcpout_stanza
   changed_when: setup_tcpout_stanza.status == 200
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -58,18 +58,11 @@
   changed_when: setup_tcpout_stanza.status == 200
   no_log: "{{ hide_password }}"
 
-# Configure forwarding to indexers directly
-# See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
+# set up forward servers set by get_facts
 - include_tasks: ../../../roles/splunk_common/tasks/add_forward_server.yml
   vars:
-    role: splunk_indexer
-  when: not splunk.indexer_cluster
-
-# Configure forwarding to standalones directly
-# See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
-- include_tasks: ../../../roles/splunk_common/tasks/add_forward_server.yml
-  vars:
-    role: splunk_standalone
+    forward_servers: "{{ splunk_forward_servers }}"
+  when: splunk_forward_servers is defined
 
 # NOTE: If this task is called or used, it will disable all local indexing!
 - name: Disable indexing on the current node

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -13,7 +13,7 @@
   set_fact:
     installed_splunk_version: "{{ installed_splunk_version.stdout | regex_search(regexp, '\\1') }}"
   vars:
-    regexp: 'Splunk\s((\d+)\.(\d+)\.(\d+)).*'
+    regexp: 'Splunk(?:\sUniversal\sForwarder)?\s((\d+)\.(\d+)\.(\d+)).*'
   when: ansible_system is match("Linux")
 
 - name: "Enable service via boot-start - Linux (systemd)"
@@ -47,7 +47,7 @@
   become_user: "{{ privileged_user }}"
   systemd:
       daemon-reload: yes
-      name: Splunkd.service
+      name: "{{ splunk.service_name | default('Splunkd.service') }}"
       enabled: true
   when:
     - ansible_system is match("Linux")

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -85,7 +85,7 @@
     - "splunk_forward_server is not defined"
     - "'splunk_indexer' in groups"
 
-# if not specified in config *and* 
+# if not specified in config *and*
 # no index clusters, then look for standalone
 # Configure forwarding to standalones directly
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -66,3 +66,32 @@
 - name: "Setting upgrade fact"
   set_fact:
     splunk_upgrade: "{{ 'build_location' in splunk and splunk.build_location and not splunk_install and splunk_target_version and splunk_target_version != splunk_current_version | default(False) }}"
+
+# determine if we need to set up forward servers
+# First, if they are manually specified in the config, use them
+- name: "Setting forward servers fact from config"
+  set_fact:
+    splunk_forward_servers: "{{ splunk.forward_servers }}"
+  when:
+    - "'forward_servers' in splunk"
+
+# If not in the config, is there an index cluster to use?
+# Configure forwarding to indexers directly
+# See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
+- name: "Setting forward servers fact from index cluster group"
+  set_fact:
+    splunk_forward_servers: "{{ groups['splunk_indexer'] }}"
+  when:
+    - "splunk_forward_server is not defined"
+    - "'splunk_indexer' in groups"
+
+# if not specified in config *and* 
+# no index clusters, then look for standalone
+# Configure forwarding to standalones directly
+# See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
+- name: "Setting forward servers fact from standalone group"
+  set_fact:
+    splunk_forward_servers: "{{ groups['splunk_standalone'] }}"
+  when:
+    - "splunk_forward_server is not defined"
+    - "'splunk_standalone' in groups"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -67,6 +67,30 @@
   set_fact:
     splunk_upgrade: "{{ 'build_location' in splunk and splunk.build_location and not splunk_install and splunk_target_version and splunk_target_version != splunk_current_version | default(False) }}"
 
+# determine if we need to set up indexer clusters
+# First, if it is manually specified in the config, use that
+- name: "Setting indexer cluster fact from config"
+  set_fact:
+    splunk_indexer_cluster: "{{ splunk.indexer_cluster }}"
+  when:
+    - "'indexer_cluster' in splunk"
+
+# Second, if there is a cluster master, set to true
+- name: "Setting indexer cluster fact because master found"
+  set_fact:
+    splunk_indexer_cluster: true
+  when:
+    - "splunk_indexer_cluster is not defined"
+    - "'splunk_cluster_master' in groups"
+    - "groups['splunk_cluster_master']|length > 0"
+
+# Last, if it wasn't set yet, set it to false
+- name: "Setting indexer cluster fact to false"
+  set_fact:
+    splunk_indexer_cluster: false
+  when:
+    - "splunk_indexer_cluster is not defined"
+
 # determine if we need to set up forward servers
 # First, if they are manually specified in the config, use them
 - name: "Setting forward servers fact from config"

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -20,7 +20,7 @@
 
 - name: "Start Splunk via service"
   service:
-    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}splunk{% endif %}"
+    name: "{{ splunk.service_name }}"
     state: restarted
   when:
     - splunk.enable_service

--- a/roles/splunk_heavy_forwarder/molecule/default/Dockerfile.j2
+++ b/roles/splunk_heavy_forwarder/molecule/default/Dockerfile.j2
@@ -1,0 +1,23 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+USER root
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/splunk_heavy_forwarder/molecule/default/INSTALL.rst
+++ b/roles/splunk_heavy_forwarder/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/splunk_heavy_forwarder/molecule/default/molecule.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    c: ../../.yamllint
+platforms:
+  - name: instance
+    image: splunk/splunk
+    command: no-provision
+    env:
+      http_proxy: "${http_proxy}"
+      https_proxy: "${https_proxy}"
+      no_proxy: "${no_proxy}"
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    enabled: true
+    options:
+      x: ["204", "701"]
+      force-color: true
+  log: true
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: E501
+  options:
+    junit-xml: ../../../../tests/results/heavy-default-results.xml

--- a/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
@@ -22,7 +22,7 @@
     retry_num: 5
     delay_num: 3
     splunk:
-      role: splunk_standalone
+      role: splunk_heavy_forwarder
       license_master_included: false
       license_uri: null
       preferred_captaincy: true
@@ -82,4 +82,4 @@
       user: splunk
     splunk_home_ownership_enforcement: true
   roles:
-    - role: splunk_standalone
+    - role: splunk_heavy_forwarder

--- a/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
@@ -28,7 +28,7 @@
       preferred_captaincy: true
       wildcard_license: false
       build_remote_src: true
-      build_location: https://download.splunk.com/products/universalforwarder/releases/7.3.1.1/linux/splunkforwarder-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
+      build_location: https://download.splunk.com/products/splunk/releases/7.3.1.1/linux/splunk-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
       ignore_license: true
       apps_location: null
       app_paths:

--- a/roles/splunk_heavy_forwarder/molecule/default/tests/test_default.py
+++ b/roles/splunk_heavy_forwarder/molecule/default/tests/test_default.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_splunk_running(host):
+    output = host.run('/opt/splunk/bin/splunk status')
+    assert "running" in output.stdout
+
+
+def test_user_seed(host):
+    f = host.file('/opt/splunk/etc/system/local/user-seed.conf')
+    assert not f.exists
+
+
+def test_ui_login(host):
+    f = host.file('/opt/splunk/etc/.ui_login')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_bin_splunk(host):
+    f = host.file('/opt/splunk/bin/splunk')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_splunk_hec(host):
+    output = host.run('curl -k https://localhost:8088/services/collector/event \
+        -H "Authorization: Splunk abcd1234" -d \'{"event": "helloworld"}\'')
+    assert "Success" in output.stdout
+
+
+def test_splunkd(host):
+    output = host.run('curl -k https://localhost:8089/services/server/info \
+        -u admin:helloworld')
+    assert "Splunk" in output.stdout
+
+
+def test_custom_user_prefs(host):
+    f = host.file('/opt/splunk/etc/users/admin/user-prefs/local/user-prefs.conf')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+    assert f.contains("[general]")
+    assert f.contains("default_namespace = appboilerplate")
+    assert f.contains("search_syntax_highlighting = dark")
+
+
+def test_splunkweb_root_endpoint(host):
+    output = host.run('curl http://localhost:8080/splunkui/en-US/')
+    assert "This resource can be found at" in output.stdout
+    assert "/account/login?return_to" in output.stdout

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/Dockerfile.j2
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/Dockerfile.j2
@@ -1,0 +1,23 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+USER root
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/INSTALL.rst
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/molecule.yml
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    c: ../../.yamllint
+platforms:
+  - name: instance
+    image: splunk/splunk
+    command: no-provision
+    env:
+      http_proxy: "${http_proxy}"
+      https_proxy: "${https_proxy}"
+      no_proxy: "${no_proxy}"
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    enabled: true
+    options:
+      x: ["204", "701"]
+      force-color: true
+  log: true
+scenario:
+  name: manual-forwards
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: E501
+  options:
+    junit-xml: ../../../../tests/results/heavy-manual-forwards-results.xml

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
@@ -32,7 +32,7 @@
       preferred_captaincy: true
       wildcard_license: false
       build_remote_src: true
-      build_location: https://download.splunk.com/products/universalforwarder/releases/7.3.1.1/linux/splunkforwarder-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
+      build_location: https://download.splunk.com/products/splunk/releases/7.3.1.1/linux/splunk-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
       ignore_license: true
       apps_location: null
       app_paths:

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
@@ -22,7 +22,11 @@
     retry_num: 5
     delay_num: 3
     splunk:
-      role: splunk_standalone
+      role: splunk_heavy_forwarder
+      forward_servers:
+        - forwarder1.test.com
+        - forwarder2.test.com
+      indexer_cluster: false
       license_master_included: false
       license_uri: null
       preferred_captaincy: true
@@ -82,4 +86,4 @@
       user: splunk
     splunk_home_ownership_enforcement: true
   roles:
-    - role: splunk_standalone
+    - role: splunk_heavy_forwarder

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/tests/test_default.py
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/tests/test_default.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_splunk_running(host):
+    output = host.run('/opt/splunk/bin/splunk status')
+    assert "running" in output.stdout
+
+
+def test_user_seed(host):
+    f = host.file('/opt/splunk/etc/system/local/user-seed.conf')
+    assert not f.exists
+
+
+def test_ui_login(host):
+    f = host.file('/opt/splunk/etc/.ui_login')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_bin_splunk(host):
+    f = host.file('/opt/splunk/bin/splunk')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_splunk_hec(host):
+    output = host.run('curl -k https://localhost:8088/services/collector/event \
+        -H "Authorization: Splunk abcd1234" -d \'{"event": "helloworld"}\'')
+    assert "Success" in output.stdout
+
+
+def test_splunkd(host):
+    output = host.run('curl -k https://localhost:8089/services/server/info \
+        -u admin:helloworld')
+    assert "Splunk" in output.stdout
+
+
+def test_custom_user_prefs(host):
+    f = host.file('/opt/splunk/etc/users/admin/user-prefs/local/user-prefs.conf')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+    assert f.contains("[general]")
+    assert f.contains("default_namespace = appboilerplate")
+    assert f.contains("search_syntax_highlighting = dark")
+
+
+def test_splunkweb_root_endpoint(host):
+    output = host.run('curl http://localhost:8080/splunkui/en-US/')
+    assert "This resource can be found at" in output.stdout
+    assert "/account/login?return_to" in output.stdout

--- a/roles/splunk_standalone/molecule/default/Dockerfile.j2
+++ b/roles/splunk_standalone/molecule/default/Dockerfile.j2
@@ -7,6 +7,13 @@ FROM {{ item.image }}
 {% endif %}
 
 USER root
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \

--- a/roles/splunk_standalone/molecule/default/molecule.yml
+++ b/roles/splunk_standalone/molecule/default/molecule.yml
@@ -11,6 +11,10 @@ platforms:
   - name: instance
     image: splunk/splunk
     command: no-provision
+    env:
+      http_proxy: "${http_proxy}"
+      https_proxy: "${https_proxy}"
+      no_proxy: "${no_proxy}"
 provisioner:
   name: ansible
   lint:
@@ -19,6 +23,7 @@ provisioner:
     options:
       x: ["204", "701"]
       force-color: true
+  log: true
 scenario:
   name: default
 verifier:

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -28,7 +28,7 @@
       preferred_captaincy: true
       wildcard_license: false
       build_remote_src: true
-      build_location: https://download.splunk.com/products/universalforwarder/releases/7.3.1.1/linux/splunkforwarder-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
+      build_location: https://download.splunk.com/products/splunk/releases/7.3.1.1/linux/splunk-7.3.1.1-7651b7244cf2-Linux-x86_64.tgz
       ignore_license: true
       apps_location: null
       app_paths:


### PR DESCRIPTION
In our environment, we have a set of heavy forwarders that are between our indexers and our universal forwarders. This pull request allows us to manually specify our forward servers since there isn't a good way to automatically determine which servers are the ones we want everything to go through.