### PR TITLE
Add prefix check to pre_tasks

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,6 +22,7 @@
           when:
             - ansible_pre_tasks is defined
             - ansible_pre_tasks is not none
+            - ansible_pre_tasks is match("^(http|https|file)://.*")
 
         - name: Provision role
           include_role:


### PR DESCRIPTION
Since `ansible_post_tasks` checks for prefix matches,`ansible_pre_tasks` should match. I'd argue that this was unnecessary breaking behavior in the first place, but consistency is king and I didn't want to bike shed on it. =P