### PR TITLE
Overhauling license management and supporting free license

### DIFF
--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -1,54 +1,29 @@
 ---
-- name: Download Splunk license
-  get_url:
-    url: "{{ splunk.license_uri }}"
-    dest: "{{ splunk.license_download_dest }}"
-    timeout: 20
-  when:
-    - splunk.role == "splunk_license_master" or not splunk.license_master_included
-    - splunk.license_uri and splunk.license_uri is match("^(https?|file)://.*")
-  register: downloaded_license_path
-  ignore_errors: yes
-  until: downloaded_license_path is success
-  retries: 5
-  delay: 3
+- name: Initialize licenses array
+  set_fact:
+    licenses: []
 
-- name: Apply Splunk license
-  command: "{{ splunk.exec }} add licenses {{ license_file }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
-  become: yes
-  become_user: "{{ splunk.user }}"
-  when:
-    - not (splunk.ignore_license | bool)
-    - splunk.role != "splunk_universal_forwarder"
-    - splunk.role == "splunk_license_master" or not splunk.license_master_included
-    - not (splunk.wildcard_license | bool)
-  ignore_errors: true
-  with_first_found:
-    - files:
-      - "{{ splunk.license_download_dest }}"
-      - "{{ splunk.nfr_license }}"
-      - "{{ splunk.license_uri }}"
-      errors: "ignore"
+- name: Determine available licenses
+  set_fact:
+    licenses: "{{ licenses }} + [ '{{ item }}' ]"
+  with_items: "{{ splunk.license_uri.split(',') }}"
+  when: splunk.license_uri is defined and splunk.license_uri
+
+# TODO: We should remove this and include it as part of splunk.license_uri now that it supports an array
+- name: Include NFR license
+  set_fact:
+    licenses: "{{ licenses }} + [ '{{ splunk.nfr_license }}' ]"
+  when: splunk.nfr_license is defined and splunk.nfr_license
+
+- name: Apply licenses
+  include_tasks: apply_licenses.yml
+  with_items:
+    - "{{ licenses }}"
   loop_control:
-    loop_var: license_file
-  notify:
-    - Restart the splunkd service
-  no_log: "{{ hide_password }}"
-
-- name: Apply wildcard licenses
-  command: "{{ splunk.exec }} add licenses {{ item }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
-  with_fileglob:
-    - "{{ splunk.license_uri }}"
-  ignore_errors: true
-  become: yes
-  become_user: "{{ splunk.user }}"
-  when:
-    - not (splunk.ignore_license | bool)
-    - splunk.role == "splunk_license_master" or not splunk.license_master_included
-    - splunk.wildcard_license | bool
-  notify:
-    - Restart the splunkd service
-  no_log: "{{ hide_password }}"
+    loop_var: license
+  when: 
+    - licenses and licenses | length > 0
+    - not splunk.license_master_included | bool or splunk.role == "splunk_license_master"
 
 - name: Set as license slave
   include_tasks: set_as_license_slave.yml

--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -21,7 +21,7 @@
     - "{{ licenses }}"
   loop_control:
     loop_var: license
-  when: 
+  when:
     - licenses and licenses | length > 0
     - not splunk.license_master_included | bool or splunk.role == "splunk_license_master"
 

--- a/roles/splunk_common/tasks/apply_licenses.yml
+++ b/roles/splunk_common/tasks/apply_licenses.yml
@@ -11,5 +11,5 @@
   vars:
     lic: "{{ license }}"
   when:
-    - license | lower != "free" 
+    - license | lower != "free"
     - '"*" not in license'

--- a/roles/splunk_common/tasks/apply_licenses.yml
+++ b/roles/splunk_common/tasks/apply_licenses.yml
@@ -1,0 +1,15 @@
+---
+- include_tasks: licenses/enable_free_license.yml
+  when: license | lower == "free"
+
+- include_tasks: licenses/add_wildcard_license.yml
+  vars:
+    licenses: "{{ license }}"
+  when: '"*" in license'
+
+- include_tasks: licenses/add_license.yml
+  vars:
+    lic: "{{ license }}"
+  when:
+    - license | lower != "free" 
+    - '"*" not in license'

--- a/roles/splunk_common/tasks/licenses/add_license.yml
+++ b/roles/splunk_common/tasks/licenses/add_license.yml
@@ -1,0 +1,45 @@
+---
+- name: Check license source
+  stat:
+    path: "{{ lic }}"
+  register: lic_source
+
+- name: Copy license
+  command: "cp {{ lic }} {{ splunk.license_download_dest }}"
+  when: lic_source.stat.exists
+
+- name: Download license
+  get_url:
+    url: "{{ lic }}"
+    dest: "{{ splunk.license_download_dest }}"
+    timeout: 20
+  when: lic is match("^(https?|file)://.*")
+  register: downloaded_license_path
+  ignore_errors: yes
+  until: downloaded_license_path is success
+  retries: 5
+  delay: 3
+
+- name: Ensure license exists
+  stat:
+    path: "{{ splunk.license_download_dest }}"
+  register: lic_dest
+
+- name: Apply license
+  command: "{{ splunk.exec }} add licenses {{ splunk.license_download_dest }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: "{{ hide_password }}"
+  ignore_errors: yes
+  when:
+    - lic_dest.stat.exists
+    - not (splunk.ignore_license | bool)
+    - splunk.role != "splunk_universal_forwarder"
+  notify:
+    - Restart the splunkd service
+
+- name: Remove artifacts
+  file:
+    dest: "{{ splunk.license_download_dest }}"
+    state: absent
+  ignore_errors: true

--- a/roles/splunk_common/tasks/licenses/add_wildcard_license.yml
+++ b/roles/splunk_common/tasks/licenses/add_wildcard_license.yml
@@ -1,0 +1,6 @@
+---
+- include_tasks: add_license.yml
+  with_fileglob:
+    - "{{ licenses }}"
+  loop_control:
+    loop_var: lic

--- a/roles/splunk_common/tasks/licenses/enable_free_license.yml
+++ b/roles/splunk_common/tasks/licenses/enable_free_license.yml
@@ -1,0 +1,27 @@
+---
+- name: Check current license group
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/licenser/groups/Free?output_mode=json"
+    method: GET
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    status_code: 200,404
+    timeout: 10
+  register: check_free_lic
+  changed_when: false
+  no_log: "{{ hide_password }}"
+
+- name: Activate free license
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/licenser/groups/Free?output_mode=json"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    body:
+      is_active: 1
+    body_format: "form-urlencoded"
+    status_code: 200
+    timeout: 10
+  when: not check_free_lic.json.entry[0].content.is_active


### PR DESCRIPTION
I added support for `SPLUNK_LICENSE_URI=Free` to automatically turn on the free license. During this, I also sort of overhauled the use of `SPLUNK_LICENSE_URI`/`splunk.license_uri` to support a comma-separated string so we can handle multiple licenses so that we could theoretically do:
```
SPLUNK_LICENSE_URI=a.lic,b.lic,c.lic
SPLUNK_LICENSE_URI=a.lic,http://web/b.lic,c.lic
SPLUNK_LICENSE_URI=a.lic,*.license
```

I'm also hoping we can remove `SPLUNK_NFR_LICENSE` and things like `splunk.wildcard_license` with this. 