### PR TITLE
Fixed spelling bug, fixed bug that appears when you have search heads…

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -106,16 +106,20 @@
   set_fact:
     splunk_forward_servers: "{{ groups['splunk_indexer'] }}"
   when:
-    - "splunk_forward_server is not defined"
+    - "splunk_forward_servers is not defined"
     - "'splunk_indexer' in groups"
 
 # if not specified in config *and*
 # no index clusters, then look for standalone
-# Configure forwarding to standalones directly
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
 - name: "Setting forward servers fact from standalone group"
   set_fact:
     splunk_forward_servers: "{{ groups['splunk_standalone'] }}"
   when:
-    - "splunk_forward_server is not defined"
+    - "splunk_forward_servers is not defined"
     - "'splunk_standalone' in groups"
+    # This part takes a little explaining.  If we have a mixed cluster with no indexers
+    # (Only standalone and search heads) we should not automatically forward the data to
+    # standalone instances UNLESS they are specified by forward-servers
+    - "'splunk_search_head' not in groups"
+

--- a/roles/splunk_search_head/tasks/peer_indexers.yml
+++ b/roles/splunk_search_head/tasks/peer_indexers.yml
@@ -2,6 +2,7 @@
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:
     splunk_instance_address: "{{ groups['splunk_indexer'][0] }}"
+  when: "'splunk_indexer' in groups"
 
 - name: Set all indexers as search peers
   command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"


### PR DESCRIPTION
… and no indexers, and changed how forwarding happens to standalone instances

Basically, if we have search heads present, we should avoid fowarding the data over, which means that the mixed environments now require the "specify forward servers" that was checked in with a previous pr 