### PR TITLE
Removing unnecessary apps from ITSI indexer bundle

### DIFF
--- a/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
@@ -2,8 +2,8 @@
 - name: Determine ITSI default apps
   set_fact:
     itsi_apps: ["DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
-                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD",
-                "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "itsi", "splunk_app_infrastructure"]
+                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", "SA-UserAccess",
+                "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "SA-ITSI-Licensechecker", "itsi", "splunk_app_infrastructure"]
 
 - name: Remove ITSI apps from installed apps list
   set_fact:


### PR DESCRIPTION
Per documentation here: https://docs.splunk.com/Documentation/ITSI/4.4.0/Install/InstallSHC