### PR TITLE
Deployment server wildcard

### DIFF
--- a/roles/splunk_deployment_server/tasks/generate_server_classes.yml
+++ b/roles/splunk_deployment_server/tasks/generate_server_classes.yml
@@ -14,13 +14,21 @@
     group: "{{ splunk.group }}"
   when: not serverclass_conf.stat.exists
 
+- name: Gather all deployment server apps
+  find:
+    path: "{{ splunk.home }}/etc/deployment_apps"
+    recurse: no
+    file_type: directory
+  register: deployment_apps
+
 - name: Define all:app serverClass
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/serverclass.conf"
-    section: "serverClass:all:app:*"
+    section: "serverClass:all:app:{{ item.path | basename }}"
     option: restartSplunkd
     value: "true"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     allow_no_value: true
   when: not serverclass_conf.stat.exists
+  with_items: "{{ deployment_apps.files }}"

--- a/roles/splunk_deployment_server/tasks/generate_server_classes.yml
+++ b/roles/splunk_deployment_server/tasks/generate_server_classes.yml
@@ -20,6 +20,7 @@
     recurse: no
     file_type: directory
   register: deployment_apps
+  when: not serverclass_conf.stat.exists
 
 - name: Define all:app serverClass
   ini_file:
@@ -32,3 +33,4 @@
     allow_no_value: true
   when: not serverclass_conf.stat.exists
   with_items: "{{ deployment_apps.files }}"
+


### PR DESCRIPTION
Grabs app names and creates a stanza with each name instead of one stanza with the wildcard. For compatibility with removing apps through the Splunk UI ( #279 ).