### PR TITLE
Fixed a bug causing splunk.apps_location to be ignored

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -169,11 +169,14 @@ def getSplunkApps(vars_scope):
         output = resp.content
         splunkbase_token = re.search("<id>(.*)</id>", output, re.IGNORECASE)
         vars_scope["splunkbase_token"] = splunkbase_token.group(1) if splunkbase_token else None
+    # calculate apps to install as union of defaults and environment variable
+    if not "apps_location" in vars_scope["splunk"]:
+        vars_scope["splunk"]["apps_location"] = []
+    elif type(vars_scope["splunk"]["apps_location"]) == str:
+        vars_scope["splunk"]["apps_location"] = vars_scope["splunk"]["apps_location"].split(",")
     apps = os.environ.get("SPLUNK_APPS_URL", None)
     if apps:
-        vars_scope["splunk"]["apps_location"] = apps.split(",")
-    else:
-        vars_scope["splunk"]["apps_location"] = []
+        vars_scope["splunk"]["apps_location"].extend(apps.split(","))
 
 def overrideEnvironmentVars(vars_scope):
     vars_scope["splunk"]["user"] = os.environ.get("SPLUNK_USER", vars_scope["splunk"]["user"])

--- a/roles/splunk_common/tasks/restrict_permissions.yml
+++ b/roles/splunk_common/tasks/restrict_permissions.yml
@@ -1,0 +1,17 @@
+---
+- name: "Check if {{ file_path }} exists"
+  stat:
+    path: "{{ file_path }}"
+  register: file_stat
+  become: yes
+  become_user: "{{ splunk.user }}"
+  changed_when: False
+  failed_when: False
+
+- name: "Restrict permissions on {{ file_path }}"
+  file:
+    mode: "go-rwx"
+    path: "{{ file_path }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  when: file_stat.stat.exists

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -20,6 +20,15 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
+- include_tasks:
+    file: restrict_permissions.yml
+  vars:
+    file_path: "{{ item }}"
+  with_items:
+    - "{{ splunk.home }}/var/lib/splunk/kvstore/mongo/splunk.key"
+  when:
+    - splunk_status.rc != 0
+
 - name: "Start Splunk via cli"
   command: "{{ splunk.exec }} start --accept-license --answer-yes --no-prompt"
   become: yes


### PR DESCRIPTION
Fixed a bug where the value of splunk.apps_location provided via
defaults.yml was always being ignored by ansible playbooks

Fixed a bug when running docker container on Kubernetes, where
volume mount permissions were causing mongod to fail to startup
when persistent volume claims were reused with the following error:

permissions on /opt/splunk/var/lib/splunk/kvstore/mongo/splunk.key are too open