### PR TITLE
Fixing deployment-apps dir path

### DIFF
--- a/roles/splunk_deployment_server/tasks/generate_server_classes.yml
+++ b/roles/splunk_deployment_server/tasks/generate_server_classes.yml
@@ -16,7 +16,7 @@
 
 - name: Gather all deployment server apps
   find:
-    path: "{{ splunk.home }}/etc/deployment_apps"
+    path: "{{ splunk.app_paths.deployment }}"
     recurse: no
     file_type: directory
   register: deployment_apps


### PR DESCRIPTION
This is causing the test failures in docker-splunk re: 1deployment1so + 1deployment1uf
