### PR TITLE
Bugfix/duplicate forwarding

### DIFF
--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -62,7 +62,9 @@
 - include_tasks: ../../../roles/splunk_common/tasks/add_forward_server.yml
   vars:
     forward_servers: "{{ splunk_forward_servers }}"
-  when: splunk_forward_servers is defined
+  when:
+    - not splunk.indexer_cluster
+    - splunk_forward_servers is defined
 
 # NOTE: If this task is called or used, it will disable all local indexing!
 - name: Disable indexing on the current node

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -63,7 +63,7 @@
   vars:
     forward_servers: "{{ splunk_forward_servers }}"
   when:
-    - not splunk.indexer_cluster
+    - not splunk_indexer_cluster
     - splunk_forward_servers is defined
 
 # NOTE: If this task is called or used, it will disable all local indexing!


### PR DESCRIPTION
If we're in an indexer cluster, the above tasks in `enable_forwarding.yml` establish forwarding via indexer-discovery, so manually adding forward-servers shouldn't be called because it's redundant and can be more brittle. This does mean that if you specify `splunk.forward_servers` when a cluster master is detected, it will not be used (cc @tod-uma for feedback on this since you most recently touched these bits with https://github.com/splunk/splunk-ansible/pull/274/)

If we're not in an indexer cluster but we're still using distributed search, the `splunk_forward_servers` should be active and we'll be forwarding directly to them first (priority goes in order of user-defined forward servers > indexers > standalones).
