### PR TITLE
Java rh

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -119,7 +119,7 @@ def getDefaultVars():
     if java_version in ['oracle:8', 'openjdk:8', 'openjdk:9','openjdk:11']:
         defaultVars["java_version"] = os.environ.get("JAVA_VERSION", "")
         if java_version == "oracle:8":
-            defaultVars["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz")
+            defaultVars["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz")
             try:
                 defaultVars["java_update_version"] = re.search("jdk-8u(\d+)-linux-x64.tar.gz", defaultVars["java_download_url"]).group(1)
             except:

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -119,7 +119,7 @@ def getDefaultVars():
     if java_version in ['oracle:8', 'openjdk:8', 'openjdk:9','openjdk:11']:
         defaultVars["java_version"] = os.environ.get("JAVA_VERSION", "")
         if java_version == "oracle:8":
-            defaultVars["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz")
+            defaultVars["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "https://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz")
             try:
                 defaultVars["java_update_version"] = re.search("jdk-8u(\d+)-linux-x64.tar.gz", defaultVars["java_download_url"]).group(1)
             except:

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk11_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk11_jdk.yml
@@ -4,7 +4,7 @@
     path: /usr/share/man/man1
     state: directory
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -16,7 +16,7 @@
   retries: 5
   delay: 10
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -26,7 +26,7 @@
   command: cp {{ splunk.home }}/etc/splunk-launch.conf.default {{ splunk.home }}/etc/splunk-launch.conf
   ignore_errors: true
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
 
 - name: Create symlinks for java/javac
   file:
@@ -40,7 +40,7 @@
   become_user: "{{ privileged_user }}"
   ignore_errors: true
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
 
 - name: Set JAVA_HOME in splunk-launch.conf
   become: yes
@@ -50,4 +50,4 @@
     regexp: '^JAVA_HOME'
     line: "JAVA_HOME=/opt/container_artifact/jdk-{{ java_update_version }}"
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
@@ -59,6 +59,13 @@
     - "'10' in ansible_distribution_version"
   become: yes
   become_user: "{{ privileged_user }}"
+  
+- name: Install openjdk for Redhat
+  command: "microdnf install java-1.8.0-openjdk"
+  when:
+    - ansible_distribution == 'RedHat'
+  become: yes
+  become_user: "{{ privileged_user }}"
 
 - name: Create splunk-launch.conf
   become: yes

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
@@ -59,7 +59,7 @@
     - "'10' in ansible_distribution_version"
   become: yes
   become_user: "{{ privileged_user }}"
-  
+
 - name: Install openjdk for Redhat
   command: "microdnf install java-1.8.0-openjdk"
   when:

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -11,7 +11,7 @@
   retries: 5
   delay: 10
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -20,35 +20,35 @@
     src: "/opt/container_artifact/jdk-8u{{ java_update_version }}-linux-x64.tar.gz"
     dest: /opt/container_artifact
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
 - name: Create alternatives for installed JDK Java binary
   command: "update-alternatives --install /usr/bin/java java /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/java 100"
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
 - name: Create alternatives for installed JDK Javac binary
   command: "update-alternatives --install /usr/bin/javac javac /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/javac 100"
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
 - name: Set Java
   command: "update-alternatives --set java /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/java"
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
 - name: Set Javac
   command: "update-alternatives --set javac /opt/container_artifact/jdk1.8.0_{{ java_update_version }}/bin/javac"
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -58,7 +58,7 @@
   command: cp {{ splunk.home }}/etc/splunk-launch.conf.default {{ splunk.home }}/etc/splunk-launch.conf
   ignore_errors: true
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
 
 - name: Get JAVA_HOME
   shell: 'readlink -f /usr/bin/java | sed "s:bin/java::"'
@@ -67,7 +67,7 @@
   become_user: "{{ privileged_user }}"
   ignore_errors: true
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
 
 - name: Set JAVA_HOME in splunk-launch.conf
   become: yes
@@ -78,4 +78,4 @@
     line: "JAVA_HOME={{ java_home.stdout }}"
   ignore_errors: true
   when:
-    - ansible_distribution == 'Debian'
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'


### PR DESCRIPTION
Now that the other pr for orca images is merged, opening this pr.
Once this is merged, I will open another PR in docker-splunk that updates the test cases for Java

Openjdk 8 and 11 work for docker-splunk as well as for orca.
Changed Oracle 8 release version to an older one where they allow auto-download. Seems like the minor version doesn't matter since we never update it anyway.