### PR TITLE
Bugfix/default service name for linux windows

### DIFF
--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -64,7 +64,7 @@ splunk:
     multisite_search_factor_origin: 3
     multisite_search_factor_total: 3
     enable_service: False
-    service_name: "splunk"
+    service_name: "splunkd"
     smartstore:
     app_paths:
         default: !!python/object/apply:os.path.join [*home, "etc/apps"]

--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -11,7 +11,7 @@
 
 - name: "Restart the splunkd service - Via systemd"
   service:
-    name: "{{ splunk.service_name }}"
+    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
     state: restarted
   when: splunk.enable_service and ansible_system is match("Linux")
   become: yes

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -47,7 +47,7 @@
   become_user: "{{ privileged_user }}"
   systemd:
       daemon-reload: yes
-      name: "{{ splunk.service_name | default('Splunkd.service') }}"
+      name: Splunkd.service
       enabled: true
   when:
     - ansible_system is match("Linux")

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -41,7 +41,7 @@
 
 - name: "Start Splunk via service"
   service:
-    name: "{{ splunk.service_name }}"
+    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
     state: restarted
   when:
     - splunk.enable_service

--- a/roles/splunk_common/tasks/stop_splunk.yml
+++ b/roles/splunk_common/tasks/stop_splunk.yml
@@ -20,7 +20,7 @@
 
 - name: "Stop Splunk via systemctl"
   service:
-    name: Splunkd
+    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
     state: stopped
   when:
     - splunk.enable_service

--- a/roles/splunk_standalone/molecule/default/tests/test_default.py
+++ b/roles/splunk_standalone/molecule/default/tests/test_default.py
@@ -7,6 +7,28 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
+splunk_home = '/opt/splunk'
+splunk = "%s/bin/splunk" % splunk_home
+splunk_user = 'splunk'
+splunk_group = 'splunk'
+
+def test_splunk_user_group(host):
+    user = host.user(splunk_user)
+    assert user.name == splunk_user
+    assert user.group == splunk_group
+
+
+def test_splunk_installation(host):
+    dir = host.file(splunk_home)
+    assert dir.is_directory
+    assert dir.user == splunk_user
+    assert dir.group == splunk_group
+
+    f = host.file(splunk)
+    assert f.is_file
+    assert f.user == splunk_user
+    assert f.group == splunk_group
+
 
 def test_splunk_running(host):
     output = host.run('/opt/splunk/bin/splunk status')
@@ -21,15 +43,15 @@ def test_user_seed(host):
 def test_ui_login(host):
     f = host.file('/opt/splunk/etc/.ui_login')
     assert f.exists
-    assert f.user == 'splunk'
-    assert f.group == 'splunk'
+    assert f.user == splunk_user
+    assert f.group == splunk_group
 
 
 def test_bin_splunk(host):
     f = host.file('/opt/splunk/bin/splunk')
     assert f.exists
-    assert f.user == 'splunk'
-    assert f.group == 'splunk'
+    assert f.user == splunk_user
+    assert f.group == splunk_group
 
 
 def test_splunk_hec(host):
@@ -47,8 +69,8 @@ def test_splunkd(host):
 def test_custom_user_prefs(host):
     f = host.file('/opt/splunk/etc/users/admin/user-prefs/local/user-prefs.conf')
     assert f.exists
-    assert f.user == 'splunk'
-    assert f.group == 'splunk'
+    assert f.user == splunk_user
+    assert f.group == splunk_group
     assert f.contains("[general]")
     assert f.contains("default_namespace = appboilerplate")
     assert f.contains("search_syntax_highlighting = dark")

--- a/roles/splunk_standalone/molecule/default/tests/test_default.py
+++ b/roles/splunk_standalone/molecule/default/tests/test_default.py
@@ -12,6 +12,7 @@ splunk = "%s/bin/splunk" % splunk_home
 splunk_user = 'splunk'
 splunk_group = 'splunk'
 
+
 def test_splunk_user_group(host):
     user = host.user(splunk_user)
     assert user.name == splunk_user


### PR DESCRIPTION
Fix to default values for service_name on Linux systemd based distros and on Windows.
Quick refactoring to molecule splunk_standalone default test scenario.