### PR TITLE
Enable Forwarder monitoring

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -61,6 +61,8 @@ Below is the list of all environment variables that the inventory script can wor
 | SPLUNK_DFW_NUM_SLOTS_ENABLED | Enables you to set the value of the field dfw_num_slots. | no | no | no |
 | SPARK_MASTER_HOST | This setting identifies the Spark master. | no | no | no |
 | SPARK_MASTER_WEBUI_PORT | Identifies the port for the Spark master web UI. | no | no | no |
+| DMC_FORWARDER_MONITORING | Enables forwarder monitoring on all standalone and search head instances (default: False) | no | no | no |
+| DMC_ASSET_INTERVAL | Cron schedule that determines how often forwarder assets are re-built (default "3,18,33,48 * * * *" - every 15 minutes) | no | no | no |
 
 * Password must be set either in default.yml or as the environment variable `SPLUNK_PASSWORD`
 

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -110,8 +110,8 @@ def getDefaultVars():
     defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
-    defaultVars["enable_forwarder_monitoring"] = os.environ.get('ENABLE_FORWARDER_MONITORING', False)
-    defaultVars["build_asset_schedule"] = os.environ.get('BUILD_ASSET_SCHEDULE', '18 * * * *')
+    defaultVars["dmc_forwarder_monitoring"] = os.environ.get('DMC_FORWARDER_MONITORING', True)
+    defaultVars["dmc_asset_interval"] = os.environ.get('DMC_ASSET_INTERVAL', '18 * * * *')
     #If the value is set, we would use that, otherwise, return True
     defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True
     defaultVars["splunk"]["hostname"] = os.environ.get('SPLUNK_HOSTNAME', socket.getfqdn())

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -110,6 +110,7 @@ def getDefaultVars():
     defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
+    defaultVars["enable_forwarder_monitoring"] = os.environ.get('ENABLE_FORWARDER_MONITORING', False)
     defaultVars["build_asset_schedule"] = os.environ.get('BUILD_ASSET_SCHEDULE', '18 * * * *')
     #If the value is set, we would use that, otherwise, return True
     defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -110,6 +110,7 @@ def getDefaultVars():
     defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
+    defaultVars["build_asset_schedule"] = os.environ.get('BUILD_ASSET_SCHEDULE', '18 * * * *')
     #If the value is set, we would use that, otherwise, return True
     defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True
     defaultVars["splunk"]["hostname"] = os.environ.get('SPLUNK_HOSTNAME', socket.getfqdn())

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -110,7 +110,7 @@ def getDefaultVars():
     defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
-    defaultVars["dmc_forwarder_monitoring"] = os.environ.get('DMC_FORWARDER_MONITORING', True)
+    defaultVars["dmc_forwarder_monitoring"] = os.environ.get('DMC_FORWARDER_MONITORING', False)
     defaultVars["dmc_asset_interval"] = os.environ.get('DMC_ASSET_INTERVAL', '3,18,33,48 * * * *')
     #If the value is set, we would use that, otherwise, return True
     defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -111,7 +111,7 @@ def getDefaultVars():
     defaultVars["splunk_home_ownership_enforcement"] = False if os.environ.get('SPLUNK_HOME_OWNERSHIP_ENFORCEMENT', "").lower() == "false" else True
     defaultVars["hide_password"] = True if os.environ.get('HIDE_PASSWORD', "").lower() == "true" else False
     defaultVars["dmc_forwarder_monitoring"] = os.environ.get('DMC_FORWARDER_MONITORING', True)
-    defaultVars["dmc_asset_interval"] = os.environ.get('DMC_ASSET_INTERVAL', '18 * * * *')
+    defaultVars["dmc_asset_interval"] = os.environ.get('DMC_ASSET_INTERVAL', '3,18,33,48 * * * *')
     #If the value is set, we would use that, otherwise, return True
     defaultVars["splunk"]["preferred_captaincy"] = False if os.environ.get('SPLUNK_PREFERRED_CAPTAINCY', "").lower() == "false" else True
     defaultVars["splunk"]["hostname"] = os.environ.get('SPLUNK_HOSTNAME', socket.getfqdn())

--- a/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
+++ b/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
@@ -13,11 +13,15 @@
   notify:
     - Restart the splunkd service
 
+- name: Flush restart handlers
+  meta: flush_handlers
+
 - name: Build forwarder assets
   uri:
-    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/{{ splunk.admin_user }}/splunk_monitoring_console/saved/searches/DMC Forwarder - Build Asset Table/dispatch"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/{{ splunk.admin_user }}/splunk_monitoring_console/saved/searches/DMC+Forwarder+-+Build+Asset+Table/dispatch"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     validate_certs: false
+    status_code: 200,201
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
+++ b/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
@@ -1,0 +1,15 @@
+- name: Enable forwarder monitoring
+  ini_file:
+    path: "{{ splunk.home }}/etc/apps/splunk_monitoring_console/local/savedsearches.conf"
+    section: "DMC Forwarder - Build Asset Table"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_dict: {"cron_schedule": "{{ build_asset_schedule }}", "alert.track": 0, "disabled": 0, "display.virtualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1, "run_on_startup": 0}
+
+- name: Build forwarder assets
+  uri:
+    url: "{{ cert_prefix }}:127.0.0.1:{{ splunk.svc_port }}/servicesNS/{{ splunk.admin_user }}/splunk_monitoring_console/saved/searches/DMC Forwarder - Build Asset Table/dispatch"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+  no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
+++ b/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
@@ -4,12 +4,7 @@
     section: "DMC Forwarder - Build Asset Table"
     option: "{{ item.key }}"
     value: "{{ item.value }}"
-  with_dict: {"cron_schedule": "{{ dmc_asset_interval }}", "alert.track": 0, "disabled": 0,
-              "display.visualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1,
-              "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1,
-              "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1,
-              "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1,
-              "run_on_startup": 0}
+  with_dict: {"cron_schedule": "{{ dmc_asset_interval }}", "alert.track": 0, "disabled": 0}
   notify:
     - Restart the splunkd service
 

--- a/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
+++ b/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
@@ -4,12 +4,20 @@
     section: "DMC Forwarder - Build Asset Table"
     option: "{{ item.key }}"
     value: "{{ item.value }}"
-  with_dict: {"cron_schedule": "{{ build_asset_schedule }}", "alert.track": 0, "disabled": 0, "display.virtualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1, "run_on_startup": 0}
+  with_dict: {"cron_schedule": "{{ dmc_asset_interval }}", "alert.track": 0, "disabled": 0,
+              "display.visualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1,
+              "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1,
+              "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1,
+              "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1,
+              "run_on_startup": 0}
+  notify:
+    - Restart the splunkd service
 
 - name: Build forwarder assets
   uri:
-    url: "{{ cert_prefix }}:127.0.0.1:{{ splunk.svc_port }}/servicesNS/{{ splunk.admin_user }}/splunk_monitoring_console/saved/searches/DMC Forwarder - Build Asset Table/dispatch"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/{{ splunk.admin_user }}/splunk_monitoring_console/saved/searches/DMC Forwarder - Build Asset Table/dispatch"
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    validate_certs: false
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -83,11 +83,3 @@
   register: disable_indexing_stanza
   changed_when: disable_indexing_stanza.status == 201
   no_log: "{{ hide_password }}"
-
-- name: Enable forwarder monitoring
-  ini_file:
-    path: "{{ splunk.home }}/etc/apps/splunk_monitoring_console/local/savedsearches.conf"
-    section: "DMC Forwarder - Build Asset Table"
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-  with_dict: {"cron_schedule": "{{ build_asset_schedule }}", "alert.track": 0, "disabled": 0, "display.virtualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1, "run_on_startup": 0}

--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -83,3 +83,11 @@
   register: disable_indexing_stanza
   changed_when: disable_indexing_stanza.status == 201
   no_log: "{{ hide_password }}"
+
+- name: Enable forwarder monitoring
+  ini_file:
+    path: "{{ splunk.home }}/etc/apps/splunk_monitoring_console/local/savedsearches.conf"
+    section: "DMC Forwarder - Build Asset Table"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_dict: {"cron_schedule": "{{ build_asset_schedule }}", "alert.track": 0, "disabled": 0, "display.virtualizations.custom.splunk_monitoring_console.heatmap.showLegend": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showTooltip": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showXAxis": 1, "display.visualizations.custom.splunk_monitoring_console.heatmap.showYAxis": 1, "run_on_startup": 0}

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
   when:
-    - enable_forwarder_monitoring | bool
+    - dmc_forwarder_monitoring | bool
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_dfs.yml
   when:

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -34,6 +34,10 @@
     - splunk.site is defined
     - splunk.multisite_master is defined
 
+- include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
+  when:
+    - enable_forwarder_monitoring | bool
+
 - include_tasks: ../../../roles/splunk_common/tasks/enable_dfs.yml
   when:
     - "'dfs' in splunk and 'enable' in splunk.dfs and splunk.dfs.enable is not none"

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -36,6 +36,7 @@
 
 - include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
   when:
+    - dmc_forwarder_monitoring is defined
     - dmc_forwarder_monitoring | bool
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_dfs.yml

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
   when:
-    - enable_forwarder_monitoring | bool
+    - dmc_forwarder_monitoring | bool
 
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
   when:

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -15,6 +15,7 @@
 
 - include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
   when:
+    - dmc_forwarder_monitoring is defined
     - dmc_forwarder_monitoring | bool
 
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -13,6 +13,10 @@
     - splunk.deployment_server is defined
     - splunk.deployment_server
 
+- include_tasks: ../../splunk_common/tasks/enable_forwarder_monitoring.yml
+  when:
+    - enable_forwarder_monitoring | bool
+
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
   when:
     - splunk.apps_location


### PR DESCRIPTION
Create a saved search for building forwarder assets (enables monitoring) and execute it. Users can also pass in a cron schedule for the search (defaults to 15 mins).