### PR TITLE
autodetect service_name for forwarder and allow override. systemd tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
 .DS_Store
+# Vim temp files, etc
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+#vim pymode
+.ropeproject 
+# Notepad++ backups #
+*.bak
+.ropeproject/
+# exclude python byte code
 *.pyc
 *.idea
 *.pyo

--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -9,9 +9,9 @@
   delay: "{{ delay_num }}"
   when: not splunk.enable_service
 
-- name: "Restart the splunkd service - Via systemd"
+- name: "Restart the splunkd service - Via Linux systemd or init"
   service:
-    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
+    name: "{{ splunk_service_name }}"
     state: restarted
   when: splunk.enable_service and ansible_system is match("Linux")
   become: yes
@@ -19,7 +19,7 @@
 
 - name: "Restart the splunkd service - Via windows system"
   win_service:
-    name: splunkd
+    name: splunk_service_name
     state: restarted
   when: splunk.enable_service and not ansible_system is match("Linux")
 

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -1,8 +1,4 @@
 ---
-- name: "Retrieve PID 1 process information (Linux)"
-  command: "ps 1"
-  register: pid1
-  when:  ansible_system is match("Linux")
 
 - name: "Retrieve Splunk version"
   command: "{{ splunk.exec }} version --accept-license --answer-yes --no-prompt"
@@ -22,7 +18,7 @@
   command: "{{ splunk.exec }} enable boot-start -systemd-managed 1 -user {{ splunk.user }} --accept-license --answer-yes --no-prompt"
   when:
     - ansible_system is match("Linux")
-    - pid1.stdout.find("systemd") != -1
+    - splunk_systemd
     - installed_splunk_version[0] is version("7.2.2", ">=")
 
 # Using service file approach for systemd rather than 'boot-start' with
@@ -31,7 +27,7 @@
 - name: "Copy Splunkd unit file - Linux (systemd)"
   template:
     src: Splunkd.service.j2
-    dest: /etc/systemd/system/Splunkd.service
+    dest: "/etc/systemd/system/{{ splunk_service_name }}"
     owner: "{{ privileged_user }}"
     group: "{{ privileged_user }}"
     mode: 0644
@@ -39,25 +35,31 @@
   become_user: "{{ privileged_user }}"
   when:
     - ansible_system is match("Linux")
-    - pid1.stdout.find("systemd") != -1
+    - splunk_systemd
     - installed_splunk_version[0] is version("7.2.2", "<")
+
+- name: "Disable cgroup systemd settings in Docker"
+  replace:
+    path: "/etc/systemd/system/{{ splunk_service_name }}"
+    regexp: '^ExecStartPost=(.*)$'
+    replace: '#ExecStartPost=\1'
 
 - name: "Reload daemons via systemctl - Linux (systemd)"
   become: yes
   become_user: "{{ privileged_user }}"
   systemd:
       daemon-reload: yes
-      name: Splunkd.service
+      name: "{{ splunk_service_name }}"
       enabled: true
   when:
     - ansible_system is match("Linux")
-    - pid1.stdout.find('systemd') != -1
+    - splunk_systemd
 
 - name: "Enable service via boot-start - Linux (init)"
   become: yes
   become_user: "{{ privileged_user }}"
   command: "{{ splunk.exec }} enable boot-start -user {{ splunk.user }} --accept-license --answer-yes --no-prompt"
-  when: ansible_system is match("Linux") and pid1.stdout.find('systemd') == -1
+  when: ansible_system is match("Linux") and not splunk_systemd
 
 - name: "Enable service via boot-start - Windows"
   command: "{{ splunk.exec }} enable boot-start -user {{ splunk.user }} --accept-license --answer-yes --no-prompt"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -123,3 +123,26 @@
     # standalone instances UNLESS they are specified by forward-servers
     - "'splunk_search_head' not in groups"
 
+- name: "Retrieve PID 1 process information (Linux)"
+  command: "ps 1"
+  register: pid1
+  changed_when: false
+  when:  ansible_system is match("Linux")
+
+- name: "Set systemd boolean"
+  set_fact:
+    splunk_systemd: "{{ pid1.stdout.find('systemd') != -1 }}"
+  when:
+    - ansible_system is match("Linux")
+
+# usually we can auto detect what the service name should be, but sometimes
+# we want to manually specify it. This is where we detect it was manually set.
+- name: "Setting service_name fact from config"
+  set_fact:
+    splunk_service_name: "{{ splunk.service_name }}"
+  when:
+    - "'service_name' in splunk"
+
+- name: "Auto Detect service_name"
+  include_tasks: get_facts_service_name.yml
+  when: splunk_service_name is not defined

--- a/roles/splunk_common/tasks/get_facts_service_name.yml
+++ b/roles/splunk_common/tasks/get_facts_service_name.yml
@@ -1,0 +1,32 @@
+---
+- name: "Setting service_name to SplunkForwarder.service"
+  set_fact:
+    splunk_service_name: "SplunkForwarder.service"
+  when:
+    - splunk_service_name is not defined
+    - splunk.enable_service and ansible_system is match("Linux")
+    - splunk_systemd
+    - splunk.build_location is search('forwarder')
+
+- name: "Setting service_name to Splunkd.service"
+  set_fact:
+    splunk_service_name: "Splunkd.service"
+  when:
+    - splunk_service_name is not defined
+    - splunk.enable_service and ansible_system is match("Linux")
+    - splunk_systemd
+
+- name: "Setting service_name to splunkd"
+  set_fact:
+    splunk_service_name: "splunkd"
+  when:
+    - splunk_service_name is not defined
+    - splunk.enable_service and ansible_system is match("Linux")
+    - splunk_systemd is False
+
+- name: "Setting service_name to splunkd"
+  set_fact:
+    splunk_service_name: "splunkd"
+  when:
+    - splunk_service_name is not defined
+    - splunk.enable_service and not ansible_system is match("Linux")

--- a/roles/splunk_common/tasks/install_splunk_tgz.yml
+++ b/roles/splunk_common/tasks/install_splunk_tgz.yml
@@ -5,6 +5,9 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     remote_src: "{{ splunk.build_remote_src }}"
+  environment:
+    http_proxy: "{{ lookup('env','http_proxy') | default('') }}"
+    https_proxy: "{{ lookup('env','https_proxy') | default('') }}"
   when: splunk.build_remote_src
   register: install_result
   until: install_result is succeeded

--- a/roles/splunk_common/tasks/install_splunk_yum.yml
+++ b/roles/splunk_common/tasks/install_splunk_yum.yml
@@ -1,7 +1,12 @@
+# added the environment section due to bug:
+# https://github.com/ansible/ansible/issues/18979
 - name: Install Splunk (yum)
   yum:
     name: "{{ splunk.build_location }}"
     state: "{{ 'latest' if splunk_upgrade else 'present' }}"
+  environment:
+    http_proxy: "{{ lookup('env','http_proxy') | default('') }}"
+    https_proxy: "{{ lookup('env','https_proxy') | default('') }}"
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -32,6 +32,12 @@
     - splunk.allow_upgrade is defined
     - splunk.allow_upgrade | bool
 
+- name: "Set splunk-launch.conf options"
+  include_tasks: set_splunk-launch_options.yml
+  when:
+    - "'launch_options' in splunk"
+    - "splunk['launch_options']|length > 0"
+
 - include_tasks: remove_first_login.yml
   when:
     - first_run | bool

--- a/roles/splunk_common/tasks/set_splunk-launch_options.yml
+++ b/roles/splunk_common/tasks/set_splunk-launch_options.yml
@@ -1,0 +1,7 @@
+---
+- name: "Set splunk-launch.conf options"
+  lineinfile:
+    path: "{{ splunk.home}}/etc/splunk-launch.conf"
+    regexp: "^{{ item.key }}"
+    line: "{{ item.key }}={{ item.value }}"
+  loop: "{{ splunk.launch_options | dict2items }}"

--- a/roles/splunk_common/tasks/start_splunk.yml
+++ b/roles/splunk_common/tasks/start_splunk.yml
@@ -41,7 +41,7 @@
 
 - name: "Start Splunk via service"
   service:
-    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
+    name: "{{ splunk_service_name }}"
     state: restarted
   when:
     - splunk.enable_service

--- a/roles/splunk_common/tasks/stop_splunk.yml
+++ b/roles/splunk_common/tasks/stop_splunk.yml
@@ -20,7 +20,7 @@
 
 - name: "Stop Splunk via systemctl"
   service:
-    name: "{% if pid1.stdout.find('systemd') != -1 %}Splunkd{% else %}{{ splunk.service_name }}{% endif %}"
+    name: "{{ splunk_service_name }}"
     state: stopped
   when:
     - splunk.enable_service

--- a/roles/splunk_standalone/molecule/systemd/Dockerfile.j2
+++ b/roles/splunk_standalone/molecule/systemd/Dockerfile.j2
@@ -1,0 +1,23 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+USER root
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/splunk_standalone/molecule/systemd/INSTALL.rst
+++ b/roles/splunk_standalone/molecule/systemd/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/splunk_standalone/molecule/systemd/molecule.yml
+++ b/roles/splunk_standalone/molecule/systemd/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    c: ../../.yamllint
+platforms:
+  - name: splunk_standalone-systemd-centos8
+    image: geerlingguy/docker-centos8-ansible:latest
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/lib/systemd/systemd"
+    env:
+      http_proxy: "${http_proxy}"
+      https_proxy: "${https_proxy}"
+      no_proxy: "${no_proxy}"
+provisioner:
+  name: ansible
+  log: true
+  lint:
+    name: ansible-lint
+    enabled: true
+    options:
+      x: ["204", "701"]
+      force-color: true
+scenario:
+  name: systemd
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: E501
+  options:
+    junit-xml: ../../../../tests/results/uf-rpm-test-results.xml

--- a/roles/splunk_standalone/molecule/systemd/playbook.yml
+++ b/roles/splunk_standalone/molecule/systemd/playbook.yml
@@ -1,0 +1,87 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    ansible_post_tasks: null
+    ansible_pre_tasks: null
+    config:
+    baked: default.yml
+    defaults_dir: /tmp/defaults
+    env:
+      headers: null
+      var: SPLUNK_DEFAULTS_URL
+      verify: true
+    host:
+      headers: null
+      url: null
+      verify: true
+    max_delay: 60
+    max_retries: 3
+    max_timeout: 1200
+    hide_password: false
+    retry_num: 5
+    delay_num: 3
+    splunk:
+      role: splunk_standalone
+      license_master_included: false
+      license_uri: null
+      preferred_captaincy: true
+      wildcard_license: false
+      build_remote_src: true
+      build_location: https://download.splunk.com/products/splunk/releases/7.3.3/linux/splunk-7.3.3-7af3758d0d5e-linux-2.6-x86_64.rpm
+      ignore_license: true
+      apps_location: null
+      app_paths:
+        default: /opt/splunk/etc/apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+      conf:
+        user-prefs:
+          directory: /opt/splunk/etc/users/admin/user-prefs/local
+          content:
+            general:
+              default_namespace: appboilerplate
+              search_syntax_highlighting: dark
+      enable_service: true
+      exec: /opt/splunk/bin/splunk
+      group: splunk
+      hec_disabled: 0
+      hec_enableSSL: 1
+      hec_port: 8088
+      hec_token: abcd1234
+      home: /opt/splunk
+      http_enableSSL: 0
+      http_enableSSL_cert: null
+      http_enableSSL_privKey: null
+      http_enableSSL_privKey_password: null
+      # http_port changed from 8000 to 8080 to test custom http port functionality
+      http_port: 8080
+      idxc:
+        enable: false
+        label: idxc_label
+        replication_factor: 3
+        replication_port: 9887
+        search_factor: 3
+        secret: ce5hXskIQRFck4WmBOBOZOC7ZqBN1Q8G
+      opt: /opt
+      admin_user: admin
+      password: helloworld
+      root_endpoint: /splunkui
+      pid: /opt/splunk/var/run/splunk/splunkd.pid
+      s2s_enable: true
+      s2s_port: 9997
+      shc:
+        enable: false
+        label: shc_label
+        replication_factor: 3
+        replication_port: 9887
+        secret: ofzi+x7zTOha7eTAO3qYj7wBPGzyrRos
+      smartstore: null
+      svc_port: 8089
+      user: splunk
+      launch_options:
+        OPTIMISTIC_ABOUT_FILE_LOCKING: "1"
+    splunk_home_ownership_enforcement: true
+  roles:
+    - role: splunk_standalone

--- a/roles/splunk_standalone/molecule/systemd/prepare.yml
+++ b/roles/splunk_standalone/molecule/systemd/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: check splunk user
+      user:
+        name: splunk
+        password: "*"
+        state: present
+      become: true
+    - name: setup yum proxy
+      lineinfile:
+        path: /etc/yum.conf
+        regexp: '^proxy='
+        line: "proxy={{ lookup('env','http_proxy') }}"
+      when:
+        - "lookup('env','http_proxy') is defined"
+        - "lookup('env','http_proxy')  | length > 0"

--- a/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+splunk_home = '/opt/splunk'
+splunk = "%s/bin/splunk" % splunk_home
+splunk_user = 'splunk'
+splunk_group = 'splunk'
+
+
+def test_splunk_user_group(host):
+    user = host.user(splunk_user)
+    assert user.name == splunk_user
+    assert user.group == splunk_group
+
+
+def test_splunk_installation(host):
+    dir = host.file(splunk_home)
+    assert dir.is_directory
+    assert dir.user == splunk_user
+    assert dir.group == splunk_group
+
+    f = host.file(splunk)
+    assert f.is_file
+    assert f.user == splunk_user
+    assert f.group == splunk_group
+
+
+def test_splunk_running(host):
+    output = host.run('/opt/splunk/bin/splunk status')
+    assert "running" in output.stdout
+
+
+def test_user_seed(host):
+    f = host.file('/opt/splunk/etc/system/local/user-seed.conf')
+    assert not f.exists
+
+
+def test_ui_login(host):
+    f = host.file('/opt/splunk/etc/.ui_login')
+    assert f.exists
+    assert f.user == splunk_user
+    assert f.group == splunk_group
+
+
+def test_bin_splunk(host):
+    f = host.file('/opt/splunk/bin/splunk')
+    assert f.exists
+    assert f.user == splunk_user
+    assert f.group == splunk_group
+
+
+def test_splunk_hec(host):
+    output = host.run('curl -k https://localhost:8088/services/collector/event \
+        -H "Authorization: Splunk abcd1234" -d \'{"event": "helloworld"}\'')
+    assert "Success" in output.stdout
+
+
+def test_splunkd(host):
+    output = host.run('curl -k https://localhost:8089/services/server/info \
+        -u admin:helloworld')
+    assert "Splunk" in output.stdout
+
+
+def test_custom_user_prefs(host):
+    f = host.file('/opt/splunk/etc/users/admin/user-prefs/local/user-prefs.conf')
+    assert f.exists
+    assert f.user == splunk_user
+    assert f.group == splunk_group
+    assert f.contains("[general]")
+    assert f.contains("default_namespace = appboilerplate")
+    assert f.contains("search_syntax_highlighting = dark")
+
+
+def test_splunkweb_root_endpoint(host):
+    output = host.run('curl http://localhost:8080/splunkui/en-US/')
+    assert "This resource can be found at" in output.stdout
+    assert "/account/login?return_to" in output.stdout
+
+
+def test_service(host):
+    s = host.service('Splunkd')
+    assert s.is_running
+    assert s.is_enabled

--- a/roles/splunk_universal_forwarder/molecule/systemd/Dockerfile.j2
+++ b/roles/splunk_universal_forwarder/molecule/systemd/Dockerfile.j2
@@ -1,0 +1,23 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+USER root
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/splunk_universal_forwarder/molecule/systemd/INSTALL.rst
+++ b/roles/splunk_universal_forwarder/molecule/systemd/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/splunk_universal_forwarder/molecule/systemd/molecule.yml
+++ b/roles/splunk_universal_forwarder/molecule/systemd/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    c: ../../.yamllint
+platforms:
+  - name: splunk_universal_forwarder-systemd-centos8
+    image: geerlingguy/docker-centos8-ansible:latest
+    pre_build_image: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/lib/systemd/systemd"
+    env:
+      http_proxy: "${http_proxy}"
+      https_proxy: "${https_proxy}"
+      no_proxy: "${no_proxy}"
+provisioner:
+  name: ansible
+  log: true
+  lint:
+    name: ansible-lint
+    enabled: true
+    options:
+      x: ["204", "701"]
+      force-color: true
+scenario:
+  name: systemd
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    options:
+      ignore: E501
+  options:
+    junit-xml: ../../../../tests/results/uf-rpm-test-results.xml

--- a/roles/splunk_universal_forwarder/molecule/systemd/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/systemd/playbook.yml
@@ -1,0 +1,75 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    ansible_post_tasks: null
+    ansible_pre_tasks: null
+    config:
+      baked: default.yml
+      defaults_dir: /tmp/defaults
+      env:
+        headers: null
+        var: SPLUNK_DEFAULTS_URL
+        verify: true
+      host:
+        headers: null
+        url: null
+        verify: true
+      max_delay: 60
+      max_retries: 3
+      max_timeout: 1200
+    hide_password: false
+    retry_num: 50
+    splunk:
+      role: splunk_universal_forwarder
+      indexer_cluster: false
+      license_master_included: false
+      license_uri: null
+      preferred_captaincy: true
+      build_remote_src: true
+      build_location: https://download.splunk.com/products/universalforwarder/releases/7.3.2/linux/splunkforwarder-7.3.2-c60db69f8e32-linux-2.6-x86_64.rpm
+      apps_location: null
+      admin_user: admin
+      app_paths:
+        default: /opt/splunkforwarder/etc/apps
+        deployment: /opt/splunkforwarder/etc/deployment-apps
+        httpinput: /opt/splunkforwarder/etc/apps/splunk_httpinput
+        idxc: /opt/splunkforwarder/etc/master-apps
+        shc: /opt/splunkforwarder/etc/shcluster/apps
+      conf:
+        user-prefs:
+          directory: /opt/splunkforwarder/etc/users/admin/user-prefs/local
+          content:
+            general:
+              default_namespace: appboilerplate
+              search_syntax_highlighting: dark
+      enable_service: true
+      exec: /opt/splunkforwarder/bin/splunk
+      group: splunk
+      hec_disabled: 0
+      hec_enableSSL: 1
+      hec_port: 8088
+      hec_token: abcd1234
+      home: /opt/splunkforwarder
+      http_enableSSL: 0
+      http_enableSSL_cert: null
+      http_enableSSL_privKey: null
+      http_enableSSL_privKey_password: null
+      http_port: 8000
+      ignore_license: false
+      license_download_dest: /tmp/splunk.lic
+      nfr_license: /tmp/nfr_enterprise.lic
+      opt: /opt
+      password: helloworld
+      pid: /opt/splunkforwarder/var/run/splunk/splunkd.pid
+      s2s_enable: true
+      s2s_port: 9997
+      secret: null
+      smartstore: null
+      svc_port: 8089
+      tar_dir: splunkforwarder
+      user: splunk
+      wildcard_license: false
+    splunk_home_ownership_enforcement: true
+  roles:
+    - role: splunk_universal_forwarder

--- a/roles/splunk_universal_forwarder/molecule/systemd/prepare.yml
+++ b/roles/splunk_universal_forwarder/molecule/systemd/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: check splunk user
+      user:
+        name: splunk
+        password: "*"
+        state: present
+      become: true
+    - name: setup yum proxy
+      lineinfile:
+        path: /etc/yum.conf
+        regexp: '^proxy='
+        line: "proxy={{ lookup('env','http_proxy') }}"
+      when:
+        - "lookup('env','http_proxy') is defined"
+        - "lookup('env','http_proxy')  | length > 0"

--- a/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_splunk_running(host):
+    output = host.run('/opt/splunkforwarder/bin/splunk status')
+    assert "running" in output.stdout
+
+
+def test_user_seed(host):
+    f = host.file('/opt/splunkforwarder/etc/system/local/user-seed.conf')
+    assert not f.exists
+
+
+def test_ui_login(host):
+    f = host.file('/opt/splunkforwarder/etc/.ui_login')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_bin_splunk(host):
+    f = host.file('/opt/splunkforwarder/bin/splunk')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+
+
+def test_splunk_hec(host):
+    output = host.run('curl -k https://localhost:8088/services/collector/event \
+        -H "Authorization: Splunk abcd1234" -d \'{"event": "helloworld"}\'')
+    assert "Success" in output.stdout
+
+
+def test_splunkd(host):
+    output = host.run('curl -k https://localhost:8089/services/server/info \
+        -u admin:helloworld')
+    assert "Splunk" in output.stdout
+
+
+def test_custom_user_prefs(host):
+    f = host.file('/opt/splunkforwarder/etc/users/admin/user-prefs/local/user-prefs.conf')
+    assert f.exists
+    assert f.user == 'splunk'
+    assert f.group == 'splunk'
+    assert f.contains("[general]")
+    assert f.contains("default_namespace = appboilerplate")
+    assert f.contains("search_syntax_highlighting = dark")
+
+
+def test_service(host):
+    s = host.service('SplunkForwarder')
+    assert s.is_running
+    assert s.is_enabled


### PR DESCRIPTION
I started the branch because I waned the splunkforwarder to be able to use the cli boot-start command on systemd systems. However I ran into the fact that by default the forwarder uses SplunkForwarder.service and enterprise uses Splunkd. Along the way I tried to make it so someone can manually specify the service name and tried to centralize the detection of systemd, etc. I also added molecule tests for systemd. 