### PR TITLE
Smart store advanced config

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -379,12 +379,12 @@ def obfuscate_vars(inventory):
     if inventory["all"]["vars"]["splunk"].get("idxc") and inventory["all"]["vars"]["splunk"]["idxc"].get("secret"):
         inventory["all"]["vars"]["splunk"]["idxc"]["secret"] = stars
     if inventory["all"]["vars"]["splunk"].get("smartstore", False):
-        for index in range(0, len(inventory["all"]["vars"]["splunk"]["smartstore"])):
-            if inventory["all"]["vars"]["splunk"]["smartstore"][index].get("s3", False):
-                if inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"].get("access_key", False):
-                    inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"]["access_key"] = stars
-                if inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"].get("secret_key", False):
-                    inventory["all"]["vars"]["splunk"]["smartstore"][index]["s3"]["secret_key"] = stars
+        for idx in range(0, len(inventory["all"]["vars"]["splunk"]["smartstore"]["index"])):
+            if inventory["all"]["vars"]["splunk"]["smartstore"]["index"][idx].get("s3", False):
+                if inventory["all"]["vars"]["splunk"]["smartstore"]["index"][idx]["s3"].get("access_key", False):
+                    inventory["all"]["vars"]["splunk"]["smartstore"]["index"][idx]["s3"]["access_key"] = stars
+                if inventory["all"]["vars"]["splunk"]["smartstore"]["index"][idx]["s3"].get("secret_key", False):
+                    inventory["all"]["vars"]["splunk"]["smartstore"]["index"][idx]["s3"]["secret_key"] = stars
     return inventory
 
 def create_parser():

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -44,3 +44,19 @@
     - { key: "coldPath", value: "{{ index.coldPath }}" }
   when: index.indexName != "default"
 
+- name: Configure retention policy
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "{{ index.indexName }}"
+  with_items:
+    - { key: "maxGlobalDataSizeMB", value: "{{ index.maxGlobalDataSizeMB }}" }
+    - { key: "maxGlobalRawDataSizeMB", value: "{{ index.maxGlobalRawDataSizeMB }}" }
+
+- name: Configure per index cache manager
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
+    section: "{{ index.indexName }}"
+  with_items:
+    - { key: "hotlist_recency_secs", value: "{{ index.hotlist_recency_secs }}" }
+    - { key: "hotlist_bloom_filter_recency_hours", value: "{{ index.hotlist_bloom_filter_recency_hours }}" }
+  when: index.indexName != "default"

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -39,24 +39,33 @@
     option: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
-    - { key: "homePath", value: "{{ index.homePath }}" }
-    - { key: "thawedPath", value: "{{ index.thawedPath }}" }
-    - { key: "coldPath", value: "{{ index.coldPath }}" }
-  when: index.indexName != "default"
+    - { key: "homePath", value: "{{ index.homePath | default('', true) }}" }
+    - { key: "thawedPath", value: "{{ index.thawedPath | default('', true) }}" }
+    - { key: "coldPath", value: "{{ index.coldPath | default('', true) }}" }
+  when:
+    - index.indexName != "default"
+    - item.value != ''
 
 - name: Configure retention policy
   ini_file:
     dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
     section: "{{ index.indexName }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
   with_items:
-    - { key: "maxGlobalDataSizeMB", value: "{{ index.maxGlobalDataSizeMB }}" }
-    - { key: "maxGlobalRawDataSizeMB", value: "{{ index.maxGlobalRawDataSizeMB }}" }
+    - { key: "maxGlobalDataSizeMB", value: "{{ index.maxGlobalDataSizeMB | default('', true) }}" }
+    - { key: "maxGlobalRawDataSizeMB", value: "{{ index.maxGlobalRawDataSizeMB | default('', true) }}" }
+  when: item.value != ''
 
 - name: Configure per index cache manager
   ini_file:
     dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/indexes.conf"
     section: "{{ index.indexName }}"
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
   with_items:
-    - { key: "hotlist_recency_secs", value: "{{ index.hotlist_recency_secs }}" }
-    - { key: "hotlist_bloom_filter_recency_hours", value: "{{ index.hotlist_bloom_filter_recency_hours }}" }
-  when: index.indexName != "default"
+    - { key: "hotlist_recency_secs", value: "{{ index.hotlist_recency_secs | default('', true) }}" }
+    - { key: "hotlist_bloom_filter_recency_hours", value: "{{ index.hotlist_bloom_filter_recency_hours | default('', true) }}" }
+  when:
+    - index.indexName != "default"
+    - item.value != ''

--- a/roles/splunk_cluster_master/tasks/configure_indexes.yml
+++ b/roles/splunk_cluster_master/tasks/configure_indexes.yml
@@ -44,7 +44,7 @@
     - { key: "coldPath", value: "{{ index.coldPath | default('', true) }}" }
   when:
     - index.indexName != "default"
-    - item.value != ''
+    - item.value | length > 0
 
 - name: Configure retention policy
   ini_file:
@@ -55,7 +55,7 @@
   with_items:
     - { key: "maxGlobalDataSizeMB", value: "{{ index.maxGlobalDataSizeMB | default('', true) }}" }
     - { key: "maxGlobalRawDataSizeMB", value: "{{ index.maxGlobalRawDataSizeMB | default('', true) }}" }
-  when: item.value != ''
+  when: item.value | length > 0
 
 - name: Configure per index cache manager
   ini_file:
@@ -68,4 +68,4 @@
     - { key: "hotlist_bloom_filter_recency_hours", value: "{{ index.hotlist_bloom_filter_recency_hours | default('', true) }}" }
   when:
     - index.indexName != "default"
-    - item.value != ''
+    - item.value | length > 0

--- a/roles/splunk_cluster_master/tasks/configure_server.yml
+++ b/roles/splunk_cluster_master/tasks/configure_server.yml
@@ -4,6 +4,6 @@
     section: "cachemanager"
   with_items:
     - { key: "max_cache_size", value: "{{ splunk.smartstore.max_cache_size }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.eviction_padding }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.hotlist_recency_secs }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.hotlist_bloom_filter_recency_hours }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.eviction_padding }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.hotlist_recency_secs }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.hotlist_bloom_filter_recency_hours }}" }

--- a/roles/splunk_cluster_master/tasks/configure_server.yml
+++ b/roles/splunk_cluster_master/tasks/configure_server.yml
@@ -1,0 +1,9 @@
+- name: Configure all indexers cache manager
+  ini_file:
+    dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/server.conf"
+    section: "cachemanager"
+  with_items:
+    - { key: "max_cache_size", value: "{{ splunk.smartstore.max_cache_size }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.eviction_padding }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.hotlist_recency_secs }}" }
+    - { key: "eviction_padding", value: "{{ splunk.smartstore.index.hotlist_bloom_filter_recency_hours }}" }

--- a/roles/splunk_cluster_master/tasks/configure_server.yml
+++ b/roles/splunk_cluster_master/tasks/configure_server.yml
@@ -2,8 +2,7 @@
   ini_file:
     dest: "{{ splunk.home }}/etc/master-apps/_cluster/local/server.conf"
     section: "cachemanager"
-  with_items:
-    - { key: "max_cache_size", value: "{{ splunk.smartstore.max_cache_size }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.eviction_padding }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.hotlist_recency_secs }}" }
-    - { key: "eviction_padding", value: "{{ splunk.smartstore.hotlist_bloom_filter_recency_hours }}" }
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_dict: "{{splunk.smartstore.cachemanager}}"
+  when: splunk.smartstore.cachemanager is defined

--- a/roles/splunk_cluster_master/tasks/configure_server.yml
+++ b/roles/splunk_cluster_master/tasks/configure_server.yml
@@ -4,5 +4,5 @@
     section: "cachemanager"
     option: "{{ item.key }}"
     value: "{{ item.value }}"
-  with_dict: "{{splunk.smartstore.cachemanager}}"
+  with_dict: "{{ splunk.smartstore.cachemanager }}"
   when: splunk.smartstore.cachemanager is defined

--- a/roles/splunk_cluster_master/tasks/enable_smartstore.yml
+++ b/roles/splunk_cluster_master/tasks/enable_smartstore.yml
@@ -3,6 +3,6 @@
   include_tasks: configure_server.yml
 - name: Configure each index
   include_tasks: configure_indexes.yml
-  loop: "{{ splunk.smartstore }}"
+  loop: "{{ splunk.smartstore.index }}"
   loop_control:
     loop_var: index

--- a/roles/splunk_cluster_master/tasks/enable_smartstore.yml
+++ b/roles/splunk_cluster_master/tasks/enable_smartstore.yml
@@ -1,4 +1,6 @@
 ---
+- name: Configure all indexers behavior
+  include_tasks: configure_server.yml
 - name: Configure each index
   include_tasks: configure_indexes.yml
   loop: "{{ splunk.smartstore }}"


### PR DESCRIPTION
All cachemanager options in server.conf are available:
https://docs.splunk.com/Documentation/Splunk/8.0.0/admin/Serverconf

All retention policy and cache related stuff in index.conf are available:
https://docs.splunk.com/Documentation/Splunk/8.0.0/admin/Indexesconf

Alos, redefining the smartstore stanza a bit to allow more options.
Example config:
```
smartstore:
    cachemanager:
      max_cache_size: 500
      max_concurrent_uploads: 7
    index:
      - indexName: default
        remoteName: remote_store
        remoteLocation: s3_bucket
        scheme: s3
        s3:
          access_key: abc
          secret_key: 123
          endpoint: http://my-s3.amazonaws.com
      - indexName: custom_index
        remoteName: my_storage
        scheme: http
        remoteLocation: my_storage.net
        maxGlobalDataSizeMB: 500
        maxGlobalRawDataSizeMB: 200
        hotlist_recency_secs: 30
        hotlist_bloom_filter_recency_hours: 1
```

fix #309