### PR TITLE
Bugfix/rectify user defined cluster factors

### DIFF
--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -28,7 +28,7 @@
   when: splunk.smartstore
 
 - name: Set the current node as a Splunk indexer cluster master
-  command: "{{ splunk.exec }} edit cluster-config -mode master -replication_factor {{ splunk.idxc.replication_factor }} -search_factor {{ splunk.idxc.search_factor }} -secret '{{ splunk.idxc.secret }}' -cluster_label '{{ splunk.idxc.label }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} edit cluster-config -mode master -replication_factor {{ idxc_replication_factor }} -search_factor {{ idxc_search_factor }} -secret '{{ splunk.idxc.secret }}' -cluster_label '{{ splunk.idxc.label }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   register: task_result
   until: task_result.rc == 0
   changed_when: task_result.rc == 0

--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -1,18 +1,11 @@
 ---
-- name: Get indexer count
+- name: Rectify cluster replication factor
   set_fact:
-    num_indexer_hosts: "{{ groups['splunk_indexer'] | length }}"
+    idxc_replication_factor: "{% if splunk.idxc.replication_factor|int > groups['splunk_indexer']|length %} {{ groups['splunk_indexer'] | length }} {% else %} {{ splunk.idxc.replication_factor | int }} {% endif %}"
 
-- name: Get default replication factor
+- name: Rectify cluster search factor
   set_fact:
-    idxc_search_factor: "{{ splunk.idxc.search_factor }}"
-    idxc_replication_factor: "{{ splunk.idxc.replication_factor }}"
-
-- name: Lower indexer search/replication factor
-  set_fact:
-    idxc_search_factor: 1
-    idxc_replication_factor: 1
-  when: num_indexer_hosts|int < 3
+    idxc_search_factor: "{% if splunk.idxc.search_factor|int > idxc_replication_factor|int %} {{ idxc_replication_factor | int }} {% else %} {{ splunk.idxc.search_factor | int }} {% endif %}"
 
 - name: Set indexer discovery
   uri:

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -1,16 +1,7 @@
 ---
-- name: Get search head count
+- name: Rectify SHC replication factor
   set_fact:
-    num_search_head_hosts: "{{ groups['splunk_search_head'] | length }}"
-
-- name: Get default replication factor
-  set_fact:
-    shc_replication_factor: "{{ splunk.shc.replication_factor }}"
-
-- name: Lower SHC replication factor
-  set_fact:
-    shc_replication_factor: 1
-  when: num_search_head_hosts|int <= 3
+    shc_replication_factor: "{% if splunk.shc.replication_factor|int > groups['splunk_search_head']|length %} {{ groups['splunk_search_head'] | length }} {% else %} {{ splunk.shc.replication_factor | int }} {% endif %}"
 
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:


### PR DESCRIPTION
Addressing https://github.com/splunk/splunk-ansible/issues/248 and (partially) https://github.com/splunk/splunk-ansible/issues/196.

1. Looks like we were never using the post-rectified repl/search factors when bringing up indexer clustering
2. Not explicitly mentioned, but it looks like IDXC replication factor should never be more than the number of indexers available
3. IDXC search factor should never be more than the replication factor
4. SHC replication factor should never be more than the number of search heads available

The changes here should only impact the cases where you bring up a CM with 2 indexers or fewer, or a SHC with 3 members or fewer. 

Reference:
https://docs.splunk.com/Documentation/Splunk/latest/Indexer/Thesearchfactor
https://docs.splunk.com/Documentation/Splunk/latest/Indexer/Thereplicationfactor
https://docs.splunk.com/Documentation/Splunk/latest/DistSearch/ChooseSHCreplicationfactor