### PR TITLE
Fixes for SHC expansion & resiliency

### DIFF
--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -1,9 +1,20 @@
 ---
+- name: Set default captaincy
+  set_fact:
+    splunk_search_head_captain: false
+
+- name: Determine captaincy
+  set_fact:
+    splunk_search_head_captain: true
+  when: ansible_hostname == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
+        ansible_fqdn == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
+        splunk.hostname == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
+        splunk.role == "splunk_search_head_captain"
+
 - include_tasks: search_head_clustering.yml
   when:
     - splunk.search_head_cluster
     - splunk.deployer_included
-    - splunk_search_head_captain is defined
 
 ## Indexer Clustering Scenario
 - include_tasks: peer_cluster_master.yml

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -84,5 +84,5 @@
   failed_when: task_result.rc !=0 and "this instance is the captain" not in task_result.stderr
   until: task_result.rc == 0 or "this instance is the captain" in task_result.stderr
   retries: "{{ retry_num }}"
-  delay: 10
+  delay: 60
   no_log: "{{ hide_password }}"

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -70,14 +70,28 @@
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
 
+- name: Add new member to SHC
+  command: "{{ splunk.exec }} add shcluster-member -current_member_uri {{ cert_prefix }}://{{ groups['splunk_search_head_captain'][0] }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  when: not splunk_search_head_captain | bool
+  register: task_result
+  changed_when: task_result.rc == 0
+  failed_when: task_result.rc !=0 and "is already part of cluster" not in task_result.stderr
+  until: task_result.rc == 0 or "is already part of cluster" in task_result.stderr
+  retries: "{{ retry_num }}"
+  delay: 10
+  no_log: "{{ hide_password }}"
+
 - name: Destructive sync search head
   command: "{{ splunk.exec }} resync shcluster-replicated-config -auth {{ splunk.admin_user }}:{{ splunk.password }}"
   become: yes
   become_user: "{{ splunk.user }}"
-  when: not splunk_search_head_captain | bool and splunk.preferred_captaincy | bool
+  when: not splunk_search_head_captain | bool
   register: task_result
   changed_when: task_result.rc == 0
-  until: task_result.rc == 0
+  failed_when: task_result.rc !=0 and "this instance is the captain" not in task_result.stderr
+  until: task_result.rc == 0 or "this instance is the captain" in task_result.stderr
   retries: "{{ retry_num }}"
-  delay: 60
+  delay: 10
   no_log: "{{ hide_password }}"

--- a/site.yml
+++ b/site.yml
@@ -2,19 +2,9 @@
 - name: Run default Splunk provisioning
   hosts: localhost
   gather_facts: true
-  vars:
-    splunk_search_head_captain: false
   tasks:
 
     - block:
-        - name: Determine captaincy
-          set_fact:
-            splunk_search_head_captain: true
-          when: ansible_hostname == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
-                ansible_fqdn == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
-                splunk.hostname == lookup('env', 'SPLUNK_SEARCH_HEAD_CAPTAIN_URL') or
-                splunk.role == "splunk_search_head_captain"
-
         - name: Execute pre-setup playbooks
           include_tasks: execute_adhoc_plays.yml
           vars:


### PR DESCRIPTION
Moved splunk_search_head_captain fact from the top-level site.yml to the main.yml of the splunk_search_head role. It was out of place in site.yml and is only used by plays within that role.

Added "Add new member to SHC" which can be used to append new search heads to an existing cluster. Previously, it was not possible to add new members.

Sanity check to allow destructive sync to fail if member is the captain. This was previously causing the playbooks to repeatedly retry the command until failing, whenever the captaincy was transferred to a member other than the original one, and then re-run on that member (i.e. due to restart).

Reduced destructive sync retry delay from 60 seconds (which seemed quite excessive) to 10 seconds.