### PR TITLE
Global updates to retries and delay

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ While developing new playbooks that require remote Splunk-to-Splunk connectivity
   register: set_indexer_as_peer
   until: set_indexer_as_peer.rc == 0 or set_indexer_as_peer.rc == 24
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   changed_when: set_indexer_as_peer.rc == 0
   failed_when: set_indexer_as_peer.rc != 0 and 'already exists' not in set_indexer_as_peer.stderr
   notify:
@@ -57,7 +57,7 @@ Another utility you can add when creating new plays is an implicit wait. For mor
     - task_response.status == 200
     - lookup('pipe', 'date +"%s"')|int - task_response.json.entry[0].content.startup_time > 10
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: true
   no_log: "{{ hide_password }}"
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -45,57 +45,59 @@ max_delay: 60
 max_retries: 3
 max_timeout: 1200
 hide_password: false
-retry_num: 50
-shc_bootstrap_delay: 30
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 splunk:
-admin_user: admin
-app_paths:
-    default: /opt/splunk/etc/apps
-    deployment: /opt/splunk/etc/deployment-apps
-    httpinput: /opt/splunk/etc/apps/splunk_httpinput
-    idxc: /opt/splunk/etc/master-apps
-    shc: /opt/splunk/etc/shcluster/apps
-enable_service: false
-exec: /opt/splunk/bin/splunk
-group: splunk
-hec_disabled: 1
-hec_enableSSL: 1
-hec_port: 8088
-hec_token: null
-home: /opt/splunk
-http_enableSSL: 0
-http_enableSSL_cert: null
-http_enableSSL_privKey: null
-http_enableSSL_privKey_password: null
-http_port: 8000
-idxc:
-    enable: false
-    label: idxc_label
-    replication_factor: 3
-    replication_port: 9887
-    search_factor: 3
+    admin_user: admin
+    app_paths:
+        default: /opt/splunk/etc/apps
+        deployment: /opt/splunk/etc/deployment-apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+    enable_service: false
+    exec: /opt/splunk/bin/splunk
+    group: splunk
+    hec_disabled: 1
+    hec_enableSSL: 1
+    hec_port: 8088
+    hec_token: null
+    home: /opt/splunk
+    http_enableSSL: 0
+    http_enableSSL_cert: null
+    http_enableSSL_privKey: null
+    http_enableSSL_privKey_password: null
+    http_port: 8000
+    idxc:
+        enable: false
+        label: idxc_label
+        replication_factor: 3
+        replication_port: 9887
+        search_factor: 3
+        secret: null
+    ignore_license: false
+    license_download_dest: /tmp/splunk.lic
+    nfr_license: /tmp/nfr_enterprise.lic
+    opt: /opt
+    password: helloworld
+    pid: /opt/splunk/var/run/splunk/splunkd.pid
+    s2s_enable: true
+    s2s_port: 9997
+    search_head_cluster_url: null
     secret: null
-ignore_license: false
-license_download_dest: /tmp/splunk.lic
-nfr_license: /tmp/nfr_enterprise.lic
-opt: /opt
-password: helloworld
-pid: /opt/splunk/var/run/splunk/splunkd.pid
-s2s_enable: true
-s2s_port: 9997
-search_head_cluster_url: null
-secret: null
-shc:
-    enable: false
-    label: shc_label
-    replication_factor: 3
-    replication_port: 9887
-    secret: null
-smartstore: null
-svc_port: 8089
-tar_dir: splunk
-user: splunk
-wildcard_license: false
+    shc:
+        enable: false
+        label: shc_label
+        replication_factor: 3
+        replication_port: 9887
+        secret: null
+    smartstore: null
+    svc_port: 8089
+    tar_dir: splunk
+    user: splunk
+    wildcard_license: false
 splunk_home_ownership_enforcement: true
 ```
 </p></details>
@@ -137,57 +139,59 @@ max_delay: 60
 max_retries: 3
 max_timeout: 1200
 hide_password: false
-retry_num: 50
-shc_bootstrap_delay: 30
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 splunk:
-admin_user: admin
-app_paths:
-    default: /opt/splunk/etc/apps
-    deployment: /opt/splunk/etc/deployment-apps
-    httpinput: /opt/splunk/etc/apps/splunk_httpinput
-    idxc: /opt/splunk/etc/master-apps
-    shc: /opt/splunk/etc/shcluster/apps
-enable_service: false
-exec: /opt/splunk/bin/splunk
-group: splunk
-hec_disabled: 0
-hec_enableSSL: 1
-hec_port: 8088
-hec_token: abcd-1234-efgh-5678
-home: /opt/splunk
-http_enableSSL: 0
-http_enableSSL_cert: null
-http_enableSSL_privKey: null
-http_enableSSL_privKey_password: null
-http_port: 8000
-idxc:
-    enable: false
-    label: idxc_label
-    replication_factor: 3
-    replication_port: 9887
-    search_factor: 3
+    admin_user: admin
+    app_paths:
+        default: /opt/splunk/etc/apps
+        deployment: /opt/splunk/etc/deployment-apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+    enable_service: false
+    exec: /opt/splunk/bin/splunk
+    group: splunk
+    hec_disabled: 0
+    hec_enableSSL: 1
+    hec_port: 8088
+    hec_token: abcd-1234-efgh-5678
+    home: /opt/splunk
+    http_enableSSL: 0
+    http_enableSSL_cert: null
+    http_enableSSL_privKey: null
+    http_enableSSL_privKey_password: null
+    http_port: 8000
+    idxc:
+        enable: false
+        label: idxc_label
+        replication_factor: 3
+        replication_port: 9887
+        search_factor: 3
+        secret: null
+    ignore_license: false
+    license_download_dest: /tmp/splunk.lic
+    nfr_license: /tmp/nfr_enterprise.lic
+    opt: /opt
+    password: helloworld
+    pid: /opt/splunk/var/run/splunk/splunkd.pid
+    s2s_enable: true
+    s2s_port: 9997
+    search_head_cluster_url: null
     secret: null
-ignore_license: false
-license_download_dest: /tmp/splunk.lic
-nfr_license: /tmp/nfr_enterprise.lic
-opt: /opt
-password: helloworld
-pid: /opt/splunk/var/run/splunk/splunkd.pid
-s2s_enable: true
-s2s_port: 9997
-search_head_cluster_url: null
-secret: null
-shc:
-    enable: false
-    label: shc_label
-    replication_factor: 3
-    replication_port: 9887
-    secret: null
-smartstore: null
-svc_port: 8089
-tar_dir: splunk
-user: splunk
-wildcard_license: false
+    shc:
+        enable: false
+        label: shc_label
+        replication_factor: 3
+        replication_port: 9887
+        secret: null
+    smartstore: null
+    svc_port: 8089
+    tar_dir: splunk
+    user: splunk
+    wildcard_license: false
 splunk_home_ownership_enforcement: true
 ```
 </p></details>
@@ -225,8 +229,10 @@ max_delay: 60
 max_retries: 3
 max_timeout: 1200
 hide_password: false
-retry_num: 50
-shc_bootstrap_delay: 30
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 splunk:
     root_endpoint: /splunkweb
     admin_user: admin

--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -24,11 +24,15 @@ hide_password: <bool>
 
 retry_num: <int>
 * Number of retries to make for potentially flakey/error-prone tasks
-* Default: 50
+* Default: 60
 
-shc_bootstrap_delay: <int>
-* Number of seconds of delay when verifying SHC success on the deployer
-* Default: 30
+wait_for_splunk_retry_num: <int>
+* Number of retries to make when waiting for a Splunk instance to be available
+* Default: 60
+
+shc_sync_retry_num: <int>
+* Number of retries to make when waiting for sync up with a search head cluster
+* Default: 60
 
 splunk_home_ownership_enforcement: true
 * Boolean that to control and enable UAC on $SPLUNK_HOME (recommended to be enabled)
@@ -416,8 +420,10 @@ The following is used in the quickstart section to start Splunk in a standalone 
 ansible_post_tasks: null
 ansible_pre_tasks: null
 hide_password: false
-retry_num: 50
-shc_bootstrap_delay: 30
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 splunk_home_ownership_enforcement: true
 
 config:

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -1,9 +1,10 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-delay_num: 3
-shc_bootstrap_delay: 30
-retry_num: 50
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 
 config:
     max_retries: 3

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -1,9 +1,10 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-delay_num: 3
-shc_bootstrap_delay: 30
-retry_num: 50
+retry_delay: 10
+retry_num: 60
+wait_for_splunk_retry_num: 150
+shc_sync_retry_num: 300
 
 config:
     max_retries: 3

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -1,9 +1,10 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-delay_num: 3
-shc_bootstrap_delay: 30
-retry_num: 50
+retry_delay: 3
+retry_num: 60
+wait_for_splunk_retry_num: 60
+shc_sync_retry_num: 60
 
 config:
     max_retries: 3

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -1,9 +1,10 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-delay_num: 3
-shc_bootstrap_delay: 30
-retry_num: 50
+retry_delay: 10
+retry_num: 60
+wait_for_splunk_retry_num: 150
+shc_sync_retry_num: 300
 
 config:
     max_retries: 3

--- a/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
@@ -31,7 +31,7 @@
     and ("already" not in splunk_cluster_bundle_result.stderr)
   no_log: "{{ hide_password }}"
   retries: "{{ retry_num }}" # We will sometimes see this if the number of peers dictacted by the replication factor aren't up
-  delay: 5
+  delay: "{{ retry_delay }}"
 
 - name: Wait for bundle push
   command: "{{ splunk.exec }} show cluster-bundle-status -auth {{ splunk.admin_user }}:{{ splunk.password }}"
@@ -39,7 +39,7 @@
   until: cluster_bundle_status.stdout.find("cluster_status=None") != -1
   retries: "{{ retry_num }}"
   changed_when: cluster_bundle_status.rc == 0
-  delay: 5
+  delay: "{{ retry_delay }}"
   ignore_errors: true
   become: yes
   become_user: "{{ splunk.user }}"

--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -33,7 +33,7 @@
   until: task_result.rc == 0
   changed_when: task_result.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
     - Restart the splunkd service
   become: yes

--- a/roles/splunk_cluster_master/tasks/setup_multisite.yml
+++ b/roles/splunk_cluster_master/tasks/setup_multisite.yml
@@ -15,7 +15,7 @@
   until: set_multisite_master.rc == 0
   changed_when: set_multisite_master.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service

--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -5,8 +5,8 @@
   become_user: "{{ splunk.user }}"
   register: task_result
   until: task_result.rc == 0
-  retries: 3
-  delay: "{{ delay_num }}"
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
   when: not splunk.enable_service
 
 - name: "Restart the splunkd service - Via systemd"

--- a/roles/splunk_common/tasks/add_splunk_object.yml
+++ b/roles/splunk_common/tasks/add_splunk_object.yml
@@ -15,7 +15,7 @@
     - task_result.rc != 0
     - "'already exists' not in task_result.stderr"
   retries: "{{ retry_num }}"
-  delay: "{{ delay_num }}"
+  delay: "{{ retry_delay }}"
   ignore_errors: true
   no_log: "{{ hide_password }}"
   notify:

--- a/roles/splunk_common/tasks/install_splunk_apt.yml
+++ b/roles/splunk_common/tasks/install_splunk_apt.yml
@@ -5,6 +5,6 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"

--- a/roles/splunk_common/tasks/install_splunk_deb.yml
+++ b/roles/splunk_common/tasks/install_splunk_deb.yml
@@ -6,6 +6,6 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"

--- a/roles/splunk_common/tasks/install_splunk_msi.yml
+++ b/roles/splunk_common/tasks/install_splunk_msi.yml
@@ -4,4 +4,4 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"

--- a/roles/splunk_common/tasks/install_splunk_tgz.yml
+++ b/roles/splunk_common/tasks/install_splunk_tgz.yml
@@ -9,7 +9,7 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"
 
@@ -24,6 +24,6 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"

--- a/roles/splunk_common/tasks/install_splunk_yum.yml
+++ b/roles/splunk_common/tasks/install_splunk_yum.yml
@@ -5,6 +5,6 @@
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk11_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk11_jdk.yml
@@ -13,8 +13,8 @@
     src: "{{ java_download_url }}"
     dest: /opt/container_artifact
     remote_src: yes
-  retries: 5
-  delay: 10
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
   when:
     - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk9_jdk_windows.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk9_jdk_windows.yml
@@ -6,8 +6,8 @@
     timeout: 30
   register: download_result
   until: download_result.status_code == 200
-  retries: 5
-  delay: 10
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
 
 - name: Unzip the Java distribution
   unarchive:

--- a/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_oracle8_jdk.yml
@@ -8,8 +8,8 @@
     timeout: 90
   register: download_result
   until: download_result.status_code == 200
-  retries: 5
-  delay: 10
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
   when:
     - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat'
   become: yes

--- a/roles/splunk_common/tasks/licenses/add_license.yml
+++ b/roles/splunk_common/tasks/licenses/add_license.yml
@@ -17,8 +17,8 @@
   register: downloaded_license_path
   ignore_errors: yes
   until: downloaded_license_path is success
-  retries: 5
-  delay: 3
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
 
 - name: Ensure license exists
   stat:

--- a/roles/splunk_common/tasks/pre_splunk_start_commands.yml
+++ b/roles/splunk_common/tasks/pre_splunk_start_commands.yml
@@ -13,7 +13,7 @@
     - task_result.rc != 0
     - "'already exists' not in task_result.stderr"
   retries: "{{ retry_num }}"
-  delay: "{{ delay_num }}"
+  delay: "{{ retry_delay }}"
   ignore_errors: true
   no_log: "{{ hide_password }}"
   notify:

--- a/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
@@ -12,8 +12,8 @@
     status_code: [201, 409]
     timeout: 10
   register: setup_itsi_role
-  retries: 3
-  delay: 5
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
   until: setup_itsi_role.status in [201, 409]
   changed_when: setup_itsi_role.status == 201
   no_log: "{{ hide_password }}"
@@ -33,8 +33,8 @@
     status_code: [200, 409]
     timeout: 10
   register: setup_itsi_user
-  retries: 3
-  delay: 5
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
   until: setup_itsi_user.status in [200, 409]
   changed_when: setup_itsi_user.status == 200
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/set_as_deployment_client.yml
+++ b/roles/splunk_common/tasks/set_as_deployment_client.yml
@@ -14,7 +14,7 @@
   until: set_deployment_client.rc == 0
   changed_when: set_deployment_client.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
     - Restart the splunkd service
   ignore_errors: yes

--- a/roles/splunk_common/tasks/set_as_license_slave.yml
+++ b/roles/splunk_common/tasks/set_as_license_slave.yml
@@ -12,7 +12,7 @@
   until: linux_set_lic_slave.rc == 0
   changed_when: linux_set_lic_slave.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
     - Restart the splunkd service
   ignore_errors: yes

--- a/roles/splunk_common/tasks/set_certificate_prefix.yml
+++ b/roles/splunk_common/tasks/set_certificate_prefix.yml
@@ -10,8 +10,8 @@
     timeout: 10
   register: ssl_enabled
   ignore_errors: true
-  delay: 1
-  retries: 5
+  delay: "{{ retry_delay }}"
+  retries: "{{ retry_num }}"
   until: ssl_enabled.status == 200 or ssl_enabled.status == 404
 
 # If the https call failed, we will revert to http and continue REST with normal error handling

--- a/roles/splunk_common/tasks/wait_for_splunk_instance.yml
+++ b/roles/splunk_common/tasks/wait_for_splunk_instance.yml
@@ -10,7 +10,7 @@
   until:
     - task_response.status == 200
     - lookup('pipe', 'date +"%s"')|int - task_response.json.entry[0].content.startup_time > 10
-  retries: "{{ retry_num }}"
-  delay: 30
+  retries: "{{ wait_for_splunk_retry_num }}"
+  delay: "{{ retry_delay }}"
   ignore_errors: true
   no_log: "{{ hide_password }}"

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -30,8 +30,8 @@
   no_log: "{{ hide_password }}"
   register: task_result
   until: task_result.rc == 0
-  retries: "{{ retry_num }}"
-  delay: "{{ shc_bootstrap_delay }}"
+  retries: "{{ shc_sync_retry_num }}"
+  delay: "{{ retry_delay }}"
   when:
     - splunk.search_head_cluster
     - splunk.apps_location

--- a/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
+++ b/roles/splunk_deployer/tasks/push_apps_to_search_heads.yml
@@ -21,7 +21,7 @@
   changed_when: shcluster_bundle.rc == 0
   failed_when: shcluster_bundle.rc != 0 and "Found zero deployable apps" not in shcluster_bundle.stderr
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: true
 
 - debug:

--- a/roles/splunk_deployment_server/tasks/main.yml
+++ b/roles/splunk_deployment_server/tasks/main.yml
@@ -19,7 +19,7 @@
   until: reload_depserver.rc == 0
   changed_when: reload_depserver.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   no_log: "{{ hide_password }}"
 

--- a/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/playbook.yml
@@ -20,7 +20,7 @@
     max_timeout: 1200
     hide_password: false
     retry_num: 5
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_heavy_forwarder
       license_master_included: false

--- a/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
+++ b/roles/splunk_heavy_forwarder/molecule/manual-forwards/playbook.yml
@@ -20,7 +20,7 @@
     max_timeout: 1200
     hide_password: false
     retry_num: 5
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_heavy_forwarder
       forward_servers:

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -30,7 +30,7 @@
   register: task_result
   until: task_result.rc == 0 or "already exists" in task_result.stderr
   retries: "{{ retry_num }}"
-  delay: "{{ delay_num }}"
+  delay: "{{ retry_delay }}"
   when: splunk.cmd is defined
   no_log: "{{ hide_password }}"
   ignore_errors: true

--- a/roles/splunk_indexer/tasks/indexer_clustering.yml
+++ b/roles/splunk_indexer/tasks/indexer_clustering.yml
@@ -11,7 +11,7 @@
   changed_when: task_result.rc == 0
   until: task_result.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service

--- a/roles/splunk_indexer/tasks/setup_multisite.yml
+++ b/roles/splunk_indexer/tasks/setup_multisite.yml
@@ -15,7 +15,7 @@
   changed_when: task_result.rc == 0
   until: task_result.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
       - Restart the splunkd service
   no_log: "{{ hide_password }}"

--- a/roles/splunk_search_head/tasks/peer_cluster_master.yml
+++ b/roles/splunk_search_head/tasks/peer_cluster_master.yml
@@ -12,7 +12,7 @@
   until: set_cluster_master_as_peer.rc == 0
   changed_when: set_cluster_master_as_peer.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service

--- a/roles/splunk_search_head/tasks/peer_indexers.yml
+++ b/roles/splunk_search_head/tasks/peer_indexers.yml
@@ -12,7 +12,7 @@
   register: set_indexer_as_peer
   until: set_indexer_as_peer.rc == 0 or set_indexer_as_peer.rc == 24
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   changed_when: set_indexer_as_peer.rc == 0
   failed_when: set_indexer_as_peer.rc != 0 and 'already exists' not in set_indexer_as_peer.stderr
   notify:

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -15,7 +15,7 @@
   changed_when: task_result.rc == 0
   until: task_result.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
@@ -56,7 +56,7 @@
   changed_when: task_result.rc == 0
   failed_when: task_result.rc !=0 and "node seems to have already joined another cluster" not in task_result.stderr
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
@@ -70,8 +70,8 @@
   changed_when: task_result.rc == 0
   failed_when: task_result.rc !=0 and "is already part of cluster" not in task_result.stderr
   until: task_result.rc == 0 or "is already part of cluster" in task_result.stderr
-  retries: "{{ retry_num }}"
-  delay: 10
+  retries: "{{ shc_sync_retry_num }}"
+  delay: "{{ retry_delay }}"
   no_log: "{{ hide_password }}"
 
 - name: Destructive sync search head
@@ -83,6 +83,6 @@
   changed_when: task_result.rc == 0
   failed_when: task_result.rc !=0 and "this instance is the captain" not in task_result.stderr
   until: task_result.rc == 0 or "this instance is the captain" in task_result.stderr
-  retries: "{{ retry_num }}"
-  delay: 60
+  retries: "{{ shc_sync_retry_num }}"
+  delay: "{{ retry_delay }}"
   no_log: "{{ hide_password }}"

--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -15,7 +15,7 @@
   until: set_new_master.rc == 0
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service
@@ -34,7 +34,7 @@
   until: set_associated_site.rc == 0 or (set_associated_site.rc == 22 and 'No change in master or secret or site' in set_associated_site.stderr)
   changed_when: set_associated_site.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service

--- a/roles/splunk_search_head_captain/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head_captain/tasks/setup_multisite.yml
@@ -15,7 +15,7 @@
   until: set_new_master.rc == 0 or (set_new_master.rc == 22 and  "Use 'splunk edit cluster-master' to edit information for this" in set_new_master.stderr)
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service
@@ -35,7 +35,7 @@
   until: set_associated_site.rc == 0 or (set_associated_site.rc == 22 and 'No change in master or secret or site' in set_associated_site.stderr)
   changed_when: set_associated_site.rc == 0
   retries: "{{ retry_num }}"
-  delay: 3
+  delay: "{{ retry_delay }}"
   ignore_errors: yes
   notify:
     - Restart the splunkd service

--- a/roles/splunk_standalone/molecule/default/playbook.yml
+++ b/roles/splunk_standalone/molecule/default/playbook.yml
@@ -20,7 +20,7 @@
     max_timeout: 1200
     hide_password: false
     retry_num: 5
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_standalone
       license_master_included: false

--- a/roles/splunk_universal_forwarder/molecule/deb/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/deb/playbook.yml
@@ -20,7 +20,7 @@
       max_timeout: 1200
     hide_password: false
     retry_num: 50
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_universal_forwarder
       indexer_cluster: false

--- a/roles/splunk_universal_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/default/playbook.yml
@@ -20,7 +20,7 @@
       max_timeout: 1200
     hide_password: false
     retry_num: 50
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_universal_forwarder
       indexer_cluster: false

--- a/roles/splunk_universal_forwarder/molecule/rpm/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/rpm/playbook.yml
@@ -20,7 +20,7 @@
       max_timeout: 1200
     hide_password: false
     retry_num: 50
-    delay_num: 3
+    retry_delay: 3
     splunk:
       role: splunk_universal_forwarder
       indexer_cluster: false

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -31,7 +31,7 @@
   register: task_result
   until: task_result.rc == 0 or "already exists" in task_result.stderr
   retries: "{{ retry_num }}"
-  delay: "{{ delay_num }}"
+  delay: "{{ retry_delay }}"
   when: splunk.cmd is defined
   no_log: "{{ hide_password }}"
   ignore_errors: true


### PR DESCRIPTION
This PR attempts to make task retry behaviour more consistent. Many tasks had specific hard-coded values for "retries" and "delay" which contradicted the global configuration parameters for these settings. I suspect that these were written before configurable parameters were introduced, and over time copied to new tasks which grew inconsistency.

This PR removes any specific values for these parameters, ensuring that the configuration parameters are universally respected.

This also renamed the global parameters "delay_num" to "retry_delay" which is more consistent with "retry_num" and not misleading. This parameter is used to specify the delay in seconds between retries, so "_num" seemed inappropriate as a name.

A previous PR (https://github.com/splunk/splunk-ansible/pull/267/files) introduced alternative delay values for the tasks that perform destructive sync and wait for the instance to be available. This was reported as an issue specific for large Windows deployments, but the values were enlarged
for all platforms.

To better address this exception more explicitly, I added to new configuration parameters: wait_for_splunk_retry_num and shc_sync_retry_num. I believe it is far better to have larger retry numbers versus larger delays, since the latter has a broadly negative impact across the board, even when things are efficient. Enlarging the retry number yields a similar result, without the negative side effects.

Continuing on preference for retries versus delay, I replaced the shc_bootstrap_delay configuration parameter with shc_sync_retry_num.

Also to address general apparent issues with slowness on Windows, I made the default retry_delay larger (10 seconds) versus Linux (3 seconds). This probably isn't necessary, and I do fear we are just masking out other underlying problems by having these larger delays, and perhaps that is something that should be investigated more as part of a separate effort. In any case, the new values for destructive sync and wait for instance tasks should provide a consistent buffer as with previous behavior.