### PR TITLE
Copy module -> file module; support splunk group to read/write

### DIFF
--- a/roles/splunk_common/tasks/remove_first_login.yml
+++ b/roles/splunk_common/tasks/remove_first_login.yml
@@ -5,6 +5,6 @@
     state: touch
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-    mode: "u=rw,g=,o="
+    mode: 0660
   become: yes
   become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/set_config_file.yml
+++ b/roles/splunk_common/tasks/set_config_file.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create {{ conf_directory }} directory if not existing
+- name: Create {{ conf_directory }} directory
   file:
     path: "{{ conf_directory }}"
     state: directory
@@ -7,14 +7,15 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
-- name: Create {{ conf_file }} if not existing
-  copy:
-    dest: "{{ conf_directory }}/{{ conf_file }}"
-    mode: u=rw,g=,o=
+- name: Create {{ conf_file }}
+  file:
+    path: "{{ conf_directory }}/{{ conf_file }}"
+    state: touch
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-    content: ""
-    force: no
+    mode: 0660
+  become: yes
+  become_user: "{{ splunk.user }}"
 
 - include_tasks: set_config_stanza.yml
   vars:


### PR DESCRIPTION
Addressing https://github.com/splunk/splunk-ansible/issues/334

Also, the `splunk` group should probably also be able to read/write the files created so adjusting the octal permissions on these created files. 