### PR TITLE
Execute java installation on all container starts

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -38,8 +38,7 @@
 
 - include_tasks: install_java.yml
   when:
-    - java_version is defined
-    - first_run | bool
+    - java_version is defined and java_version
 
 # This needs to be done before any encrypted passkeys are generated
 - include_tasks: set_splunk_secret.yml


### PR DESCRIPTION
Per https://github.com/splunk/splunk-ansible/issues/298, this should be done to handle the case of container/pod restarts.