### PR TITLE
Moving rectify search/replication factors into python

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -148,8 +148,16 @@ def getIndexerClustering(vars_scope):
     idxc_vars["secret"] = os.environ.get("SPLUNK_IDXC_SECRET", idxc_vars.get("secret"))
     # Rectify cluster replication + search factors
     indexer_count = len(inventory.get("splunk_indexer", {}).get("hosts", []))
-    idxc_vars["replication_factor"] = min(indexer_count, int(idxc_vars.get("replication_factor", 0)))
-    idxc_vars["search_factor"] = min(idxc_vars["replication_factor"], int(idxc_vars.get("search_factor", 0)))
+    # Replication factor should be <= number of indexers
+    replf = int(idxc_vars.get("replication_factor", 0))
+    if replf > indexer_count:
+        raise Exception("Cannot meet replication factor of {}, not enough peers available".format(replf))
+    idxc_vars["replication_factor"] = replf
+    # Search factor should be <= replication factor
+    searchf = int(idxc_vars.get("search_factor", 0))
+    if searchf > replf:
+        raise Exception("Cannot meet search factor of {}, must be at most {} (replication factor)".format(searchf, replf))
+    idxc_vars["search_factor"] = searchf
 
 def getSearchHeadClustering(vars_scope):
     """
@@ -162,7 +170,11 @@ def getSearchHeadClustering(vars_scope):
     shc_vars["secret"] = os.environ.get("SPLUNK_SHC_SECRET", shc_vars.get("secret"))
     # Rectify SHC replication factor
     sh_count = len(inventory.get("splunk_search_head", {}).get("hosts", []))
-    shc_vars["replication_factor"] = min(sh_count, int(shc_vars.get("replication_factor", 0)))
+    # Replication factor should be <= number of search heads
+    replf = int(shc_vars.get("replication_factor", 0))
+    if replf > sh_count:
+        raise Exception("Cannot meet replication factor of {}, not enough search heads available".format(replf))
+    shc_vars["replication_factor"] = replf
 
 def getMultisite(vars_scope):
     """

--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -1,12 +1,4 @@
 ---
-- name: Rectify cluster replication factor
-  set_fact:
-    idxc_replication_factor: "{% if splunk.idxc.replication_factor|int > groups['splunk_indexer']|length %} {{ groups['splunk_indexer'] | length }} {% else %} {{ splunk.idxc.replication_factor | int }} {% endif %}"
-
-- name: Rectify cluster search factor
-  set_fact:
-    idxc_search_factor: "{% if splunk.idxc.search_factor|int > idxc_replication_factor|int %} {{ idxc_replication_factor | int }} {% else %} {{ splunk.idxc.search_factor | int }} {% endif %}"
-
 - name: Set indexer discovery
   uri:
     url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-server"
@@ -28,7 +20,7 @@
   when: splunk.smartstore
 
 - name: Set the current node as a Splunk indexer cluster master
-  command: "{{ splunk.exec }} edit cluster-config -mode master -replication_factor {{ idxc_replication_factor }} -search_factor {{ idxc_search_factor }} -secret '{{ splunk.idxc.secret }}' -cluster_label '{{ splunk.idxc.label }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  command: "{{ splunk.exec }} edit cluster-config -mode master -replication_factor {{ splunk.idxc.replication_factor }} -search_factor {{ splunk.idxc.search_factor }} -secret '{{ splunk.idxc.secret }}' -cluster_label '{{ splunk.idxc.label }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
   register: task_result
   until: task_result.rc == 0
   changed_when: task_result.rc == 0

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -1,14 +1,10 @@
 ---
-- name: Rectify SHC replication factor
-  set_fact:
-    shc_replication_factor: "{% if splunk.shc.replication_factor|int > groups['splunk_search_head']|length %} {{ groups['splunk_search_head'] | length }} {% else %} {{ splunk.shc.replication_factor | int }} {% endif %}"
-
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:
     splunk_instance_address: "{{ groups['splunk_deployer'][0] }}"
 
 - name: Initialize SHC cluster config
-  command: "{{ splunk.exec }} init shcluster-config -auth '{{ splunk.admin_user }}:{{ splunk.password }}' -mgmt_uri '{{ cert_prefix }}://{{ splunk.hostname }}:{{ splunk.svc_port }}' -replication_port {{ splunk.shc.replication_port }} -replication_factor {{ shc_replication_factor }} -conf_deploy_fetch_url '{{ cert_prefix }}://{{ groups['splunk_deployer'][0] }}:{{ splunk.svc_port }}' -secret '{{ splunk.shc.secret }}' -shcluster_label '{{ splunk.shc.label }}'"
+  command: "{{ splunk.exec }} init shcluster-config -auth '{{ splunk.admin_user }}:{{ splunk.password }}' -mgmt_uri '{{ cert_prefix }}://{{ splunk.hostname }}:{{ splunk.svc_port }}' -replication_port {{ splunk.shc.replication_port }} -replication_factor {{ splunk.shc.replication_factor }} -conf_deploy_fetch_url '{{ cert_prefix }}://{{ groups['splunk_deployer'][0] }}:{{ splunk.svc_port }}' -secret '{{ splunk.shc.secret }}' -shcluster_label '{{ splunk.shc.label }}'"
   become: yes
   become_user: "{{ splunk.user }}"
   register: task_result

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -58,12 +58,12 @@ def test_getDefaultVars(mock_overrideEnvironmentVars, mock_loadDefaultSplunkVari
                 ({"idxc": {"secret": "1234"}}, {}, {"label": None, "secret": "1234", "replication_factor": 0, "search_factor": 0}),
                 ({"idxc": {"secret": None}}, {}, {"label": None, "secret": None, "replication_factor": 0, "search_factor": 0}),
                 ({"idxc": {"secret": "1234"}}, {}, {"label": None, "secret": "1234", "replication_factor": 0, "search_factor": 0}),
-                # Search factor should never exceed replication factor
-                ({"idxc": {"replication_factor": 0, "search_factor": 2}}, {}, {"label": None, "secret": None, "replication_factor": 0, "search_factor": 0}),
-                ({"idxc": {"replication_factor": 1, "search_factor": 3}}, {}, {"label": None, "secret": None, "replication_factor": 1, "search_factor": 1}),
-                ({"idxc": {"replication_factor": "2", "search_factor": 3}}, {}, {"label": None, "secret": None, "replication_factor": 2, "search_factor": 2}),
-                # This should return replication_factor=2 because there are only 2 hosts in the "splunk_indexer" group
-                ({"idxc": {"replication_factor": 3, "search_factor": 1}}, {}, {"label": None, "secret": None, "replication_factor": 2, "search_factor": 1}),
+                # Replication factor must always be <= number of indexers (2)
+                # Search factor must always be <= replication factor
+                ({"idxc": {"replication_factor": 0, "search_factor": 0}}, {}, {"label": None, "secret": None, "replication_factor": 0, "search_factor": 0}),
+                ({"idxc": {"replication_factor": 1, "search_factor": 1}}, {}, {"label": None, "secret": None, "replication_factor": 1, "search_factor": 1}),
+                ({"idxc": {"replication_factor": "2", "search_factor": 2}}, {}, {"label": None, "secret": None, "replication_factor": 2, "search_factor": 2}),
+                ({"idxc": {"replication_factor": 2, "search_factor": "1"}}, {}, {"label": None, "secret": None, "replication_factor": 2, "search_factor": 1}),
                 # Check environment variable parameters
                 ({}, {"SPLUNK_IDXC_LABEL": ""}, {"label": "", "secret": None, "replication_factor": 0, "search_factor": 0}),
                 ({}, {"SPLUNK_IDXC_LABEL": "abcd"}, {"label": "abcd", "secret": None, "replication_factor": 0, "search_factor": 0}),
@@ -82,6 +82,24 @@ def test_getIndexerClustering(default_yml, os_env, output):
     assert type(vars_scope["splunk"]["idxc"]) == dict
     assert vars_scope["splunk"]["idxc"] == output
 
+
+@pytest.mark.parametrize(("default_yml", "error"),
+            [
+                ({"idxc": {"replication_factor": 3, "search_factor": 3}}, "Cannot meet replication factor of 3, not enough peers available"),
+                ({"idxc": {"replication_factor": "4", "search_factor": 3}}, "Cannot meet replication factor of 4, not enough peers available"),
+                ({"idxc": {"replication_factor": 2, "search_factor": "3"}}, "Cannot meet search factor of 3, must be at most 2 (replication factor)"),
+                ({"idxc": {"replication_factor": 1, "search_factor": 2}}, "Cannot meet search factor of 2, must be at most 1 (replication factor)"),
+            ]
+        )
+def test_getIndexerClustering_exception(default_yml, error):
+    vars_scope = {"splunk": default_yml}
+    with patch("environ.inventory", {"splunk_indexer": {"hosts": ["a", "b"]}}) as mock_inven:
+        with patch("os.environ", new={}):
+            try:
+                environ.getIndexerClustering(vars_scope)
+            except Exception as e:
+                assert str(e) == error
+
 @pytest.mark.parametrize(("default_yml", "os_env", "output"),
             [
                 # Check null parameters
@@ -95,8 +113,6 @@ def test_getIndexerClustering(default_yml, os_env, output):
                 ({"shc": {"replication_factor": 0}}, {}, {"label": None, "secret": None, "replication_factor": 0}),
                 ({"shc": {"replication_factor": 1}}, {}, {"label": None, "secret": None, "replication_factor": 1}),
                 ({"shc": {"replication_factor": "2"}}, {}, {"label": None, "secret": None, "replication_factor": 2}),
-                # This should return replication_factor=2 because there are only 2 hosts in the "splunk_search_head" group
-                ({"shc": {"replication_factor": 3}}, {}, {"label": None, "secret": None, "replication_factor": 2}),
                 # Check environment variable parameters
                 ({}, {"SPLUNK_SHC_LABEL": ""}, {"label": "", "secret": None, "replication_factor": 0}),
                 ({}, {"SPLUNK_SHC_LABEL": "abcd"}, {"label": "abcd", "secret": None, "replication_factor": 0}),
@@ -114,6 +130,21 @@ def test_getSearchHeadClustering(default_yml, os_env, output):
             environ.getSearchHeadClustering(vars_scope)
     assert type(vars_scope["splunk"]["shc"]) == dict
     assert vars_scope["splunk"]["shc"] == output
+
+@pytest.mark.parametrize(("default_yml", "error"),
+            [
+                ({"shc": {"replication_factor": 3}}, "Cannot meet replication factor of 3, not enough search heads available"),
+                ({"shc": {"replication_factor": "4"}}, "Cannot meet replication factor of 4, not enough search heads available"),
+            ]
+        )
+def test_getSearchHeadClustering_exception(default_yml, error):
+    vars_scope = {"splunk": default_yml}
+    with patch("environ.inventory", {"splunk_indexer": {"hosts": ["a", "b"]}}) as mock_inven:
+        with patch("os.environ", new={}):
+            try:
+                environ.getSearchHeadClustering(vars_scope)
+            except Exception as e:
+                assert str(e) == error
 
 @pytest.mark.skip(reason="TODO")
 def test_getMultisite():


### PR DESCRIPTION
Moving all rectification of search/replication factors into environ.py.

This should solve immediate issues with M2 deployment type, although I think there may be inherent flaws with defining search/replication factors here. I'm still working my way through the docs, but in the case of replication factor, it seems like there are dependencies on what the replication factor is defined to be for each individual site:
> If there are some non-explicit sites, then the total value must be at least the sum of all explicit site and origin values.

This makes it very easy to incorrectly set the `site_search_factor_total` because the `default.yml` supplied is not aware of any cluster's site topology other than it's own. Currently we can get by with just min/max, but this is not a very robust solution and it makes not only error correction difficult but it also makes any fail-fast/error-raising conditions harder to infer.

I may take another stab at this later, but putting a PR out for some feedback.

Docs:
https://docs.splunk.com/Documentation/Splunk/8.0.1/Indexer/Sitesearchfactor
https://docs.splunk.com/Documentation/Splunk/8.0.1/Indexer/Sitereplicationfactor
