### PR TITLE
Removing unused variable

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -80,7 +80,6 @@ splunk:
         pass4SymmKey: null
     ignore_license: false
     license_download_dest: /tmp/splunk.lic
-    nfr_license: /tmp/nfr_enterprise.lic
     opt: /opt
     password: helloworld
     pid: /opt/splunk/var/run/splunk/splunkd.pid
@@ -176,7 +175,6 @@ splunk:
         secret: null
     ignore_license: false
     license_download_dest: /tmp/splunk.lic
-    nfr_license: /tmp/nfr_enterprise.lic
     opt: /opt
     password: helloworld
     pid: /opt/splunk/var/run/splunk/splunkd.pid
@@ -267,7 +265,6 @@ splunk:
         secret: null
     ignore_license: false
     license_download_dest: /tmp/splunk.lic
-    nfr_license: /tmp/nfr_enterprise.lic
     opt: /opt
     password: helloworld
     pid: /opt/splunk/var/run/splunk/splunkd.pid

--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -135,10 +135,6 @@ splunk:
   * Path in filesystem where licenses will be downloaded as
   * Default: /tmp/splunk.lic
 
-  nfr_license: <str - filepath>
-  * Path in filesystem where of special NFR licenses
-  * Default: /tmp/nfr_enterprise.lic
-
   wildcard_license: <bool>
   * Enable licenses to be interpreted as fileglobs, to support provisioning with multiple Splunk licenses
   * Default: false
@@ -478,7 +474,6 @@ splunk:
     secret: dmwHG97SpM+GzeGPUELwr7xXowSAVmLW
   ignore_license: false
   license_download_dest: /tmp/splunk.lic
-  nfr_license: /tmp/nfr_enterprise.lic
   opt: /opt
   password: helloworld
   pid: /opt/splunk/var/run/splunk/splunkd.pid

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -252,7 +252,6 @@ def getLicenses(vars_scope):
     vars_scope["splunk"]["wildcard_license"] = False
     if vars_scope["splunk"]["license_uri"] and '*' in vars_scope["splunk"]["license_uri"]:
         vars_scope["splunk"]["wildcard_license"] = True
-    vars_scope["splunk"]["nfr_license"] = os.environ.get("SPLUNK_NFR_LICENSE", "/tmp/nfr_enterprise.lic")
     vars_scope["splunk"]["ignore_license"] = False
     if os.environ.get("SPLUNK_IGNORE_LICENSE", "").lower() == "true":
         vars_scope["splunk"]["ignore_license"] = True

--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -9,12 +9,6 @@
   with_items: "{{ splunk.license_uri.split(',') }}"
   when: splunk.license_uri is defined and splunk.license_uri
 
-# TODO: We should remove this and include it as part of splunk.license_uri now that it supports an array
-- name: Include NFR license
-  set_fact:
-    licenses: "{{ licenses }} + [ '{{ splunk.nfr_license }}' ]"
-  when: splunk.nfr_license is defined and splunk.nfr_license
-
 - name: Apply licenses
   include_tasks: apply_licenses.yml
   with_items:

--- a/roles/splunk_universal_forwarder/molecule/deb/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/deb/playbook.yml
@@ -59,7 +59,6 @@
       http_port: 8000
       ignore_license: false
       license_download_dest: /tmp/splunk.lic
-      nfr_license: /tmp/nfr_enterprise.lic
       opt: /opt
       password: helloworld
       pid: /opt/splunkforwarder/var/run/splunk/splunkd.pid

--- a/roles/splunk_universal_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/default/playbook.yml
@@ -59,7 +59,6 @@
       http_port: 8000
       ignore_license: false
       license_download_dest: /tmp/splunk.lic
-      nfr_license: /tmp/nfr_enterprise.lic
       opt: /opt
       password: helloworld
       pid: /opt/splunkforwarder/var/run/splunk/splunkd.pid

--- a/roles/splunk_universal_forwarder/molecule/rpm/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/rpm/playbook.yml
@@ -59,7 +59,6 @@
       http_port: 8000
       ignore_license: false
       license_download_dest: /tmp/splunk.lic
-      nfr_license: /tmp/nfr_enterprise.lic
       opt: /opt
       password: helloworld
       pid: /opt/splunkforwarder/var/run/splunk/splunkd.pid

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -216,28 +216,27 @@ def test_getDistributedTopology(os_env, license_master_included, deployer_includ
     assert vars_scope["splunk"]["search_head_cluster"] == search_head_cluster
     assert vars_scope["splunk"]["search_head_cluster_url"] == search_head_cluster_url
 
-@pytest.mark.parametrize(("os_env", "license_uri", "wildcard_license", "nfr_license", "ignore_license", "license_download_dest"),
+@pytest.mark.parametrize(("os_env", "license_uri", "wildcard_license", "ignore_license", "license_download_dest"),
                          [
-                            ({}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", False, "/tmp/splunk.lic"),
+                            ({}, "splunk.lic", False, False, "/tmp/splunk.lic"),
                             # Check individual environment variables
-                            ({"SPLUNK_LICENSE_URI": "http://web/license.lic"}, "http://web/license.lic", False, "/tmp/nfr_enterprise.lic", False, "/tmp/splunk.lic"),
-                            ({"SPLUNK_LICENSE_URI": "/mnt/*.lic"}, "/mnt/*.lic", True, "/tmp/nfr_enterprise.lic", False, "/tmp/splunk.lic"),
-                            ({"SPLUNK_NFR_LICENSE": "/mnt/nfr.lic"}, "splunk.lic", False, "/mnt/nfr.lic", False, "/tmp/splunk.lic"),
-                            ({"SPLUNK_IGNORE_LICENSE": ""}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", False, "/tmp/splunk.lic"),
-                            ({"SPLUNK_IGNORE_LICENSE": "true"}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", True, "/tmp/splunk.lic"),
-                            ({"SPLUNK_IGNORE_LICENSE": "TRUE"}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", True, "/tmp/splunk.lic"),
-                            ({"SPLUNK_IGNORE_LICENSE": "false"}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", False, "/tmp/splunk.lic"),
-                            ({"SPLUNK_LICENSE_INSTALL_PATH": "/Downloads/"}, "splunk.lic", False, "/tmp/nfr_enterprise.lic", False, "/Downloads/"),
+                            ({"SPLUNK_LICENSE_URI": "http://web/license.lic"}, "http://web/license.lic", False, False, "/tmp/splunk.lic"),
+                            ({"SPLUNK_LICENSE_URI": "/mnt/*.lic"}, "/mnt/*.lic", True, False, "/tmp/splunk.lic"),
+                            ({"SPLUNK_NFR_LICENSE": "/mnt/nfr.lic"}, "splunk.lic", False, False, "/tmp/splunk.lic"),
+                            ({"SPLUNK_IGNORE_LICENSE": ""}, "splunk.lic", False, False, "/tmp/splunk.lic"),
+                            ({"SPLUNK_IGNORE_LICENSE": "true"}, "splunk.lic", False, True, "/tmp/splunk.lic"),
+                            ({"SPLUNK_IGNORE_LICENSE": "TRUE"}, "splunk.lic", False, True, "/tmp/splunk.lic"),
+                            ({"SPLUNK_IGNORE_LICENSE": "false"}, "splunk.lic", False, False, "/tmp/splunk.lic"),
+                            ({"SPLUNK_LICENSE_INSTALL_PATH": "/Downloads/"}, "splunk.lic", False, False, "/Downloads/"),
                          ]
                         )
-def test_getLicenses(os_env, license_uri, wildcard_license, nfr_license, ignore_license, license_download_dest):
+def test_getLicenses(os_env, license_uri, wildcard_license, ignore_license, license_download_dest):
     vars_scope = {"splunk": {}}
     with patch("os.environ", new=os_env):
         environ.getLicenses(vars_scope)
     assert vars_scope["splunk"]["license_uri"] == license_uri
     assert type(vars_scope["splunk"]["wildcard_license"]) == bool
     assert vars_scope["splunk"]["wildcard_license"] == wildcard_license
-    assert vars_scope["splunk"]["nfr_license"] == nfr_license
     assert type(vars_scope["splunk"]["ignore_license"]) == bool
     assert vars_scope["splunk"]["ignore_license"] == ignore_license
     assert vars_scope["splunk"]["license_download_dest"] == license_download_dest


### PR DESCRIPTION
Removing `SPLUNK_NFR_LICENSE` variable - this was used internally, and it's captured with changes made to `SPLUNK_LICENSE_URI` such that we can add licenses through that variable:
https://github.com/splunk/splunk-ansible/pull/281