### PR TITLE
Feature/asan builds

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -355,6 +355,7 @@ def overrideEnvironmentVars(vars_scope):
     vars_scope["splunk"]["enable_service"] = os.environ.get('SPLUNK_ENABLE_SERVICE', vars_scope["splunk"]["enable_service"])
     vars_scope["splunk"]["service_name"] = os.environ.get('SPLUNK_SERVICE_NAME', vars_scope["splunk"]["service_name"])
     vars_scope["splunk"]["allow_upgrade"] = os.environ.get('SPLUNK_ALLOW_UPGRADE', vars_scope["splunk"]["allow_upgrade"])
+    vars_scope["splunk"]["asan"] = bool(os.environ.get("SPLUNK_ENABLE_ASAN", vars_scope["splunk"].get("asan")))
 
 def getDFS(vars_scope):
     """

--- a/multisite.yml
+++ b/multisite.yml
@@ -2,6 +2,8 @@
 - name: Run multisite provisioning
   hosts: localhost
   gather_facts: true
+  environment:
+    ASAN_OPTIONS: detect_leaks=0
   tasks:
       # These should only be run for the three roles that currently
       # have multisite defined; cluster master, search head, and indexer

--- a/roles/splunk_common/tasks/enable_asan.yml
+++ b/roles/splunk_common/tasks/enable_asan.yml
@@ -1,0 +1,23 @@
+---
+- name: Copy ASan libraries
+  copy:
+    src: "{{ splunk.home }}/lib/{{ item }}"
+    dest: "/lib64/{{ item }}"
+    remote_src: yes
+    mode: 0755
+  with_items:
+    - libssp.so.0
+    - libasan.so
+    - libasan.so.2
+    - libasan.so.2.0.0
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Create ASan output directory
+  file:
+    path: "{{ splunk.home }}/_asanoutput"
+    state: directory
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -54,6 +54,10 @@
   when:
     - first_run | bool
 
+- include_tasks: enable_asan.yml
+  when:
+    - "'asan' in splunk and splunk.asan | bool"
+
 - include_tasks: pre_splunk_start_commands.yml
   ignore_errors: true
   when:

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -32,6 +32,10 @@
     - splunk.allow_upgrade is defined
     - splunk.allow_upgrade | bool
 
+- include_tasks: enable_asan.yml
+  when:
+    - "'asan' in splunk and splunk.asan | bool"
+
 - include_tasks: remove_first_login.yml
   when:
     - first_run | bool
@@ -53,10 +57,6 @@
 - include_tasks: set_user_seed.yml
   when:
     - first_run | bool
-
-- include_tasks: enable_asan.yml
-  when:
-    - "'asan' in splunk and splunk.asan | bool"
 
 - include_tasks: pre_splunk_start_commands.yml
   ignore_errors: true

--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,8 @@
 - name: Run default Splunk provisioning
   hosts: localhost
   gather_facts: true
+  environment:
+    ASAN_OPTIONS: detect_leaks=0
   tasks:
 
     - block:


### PR DESCRIPTION
Adding a trigger to do some special provisioning when using ASan Splunk builds. This is mostly for internal usage, which is why I did not include a `splunk.asan` in any of the shipped default.ymls - although if enough people feel strongly about doing so I can make it happen.

I still need to do some testing on this, but theoretically this should allow developer debugging using something like:
```
docker run -e SPLUNK_ENABLE_ASAN=yes -e SPLUNK_BUILD_URL=http://host/splunk-unstripped.tgz -e SPLUNK_LAUNCH_CONF= LSAN_OPTIONS=exitcode=0:report_objects:1, ASAN_OPTIONS=detect_leaks=1:log_path=/opt/splunk/_asanoutput/splunk:halt_on_error=false:atexit=true:print_stats=true:detect_stack_use_after_return=true:debug=true ... splunk/splunk:edge
```
