### PR TITLE
Ensuring version check is done by splunk.user

### DIFF
--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -2,6 +2,8 @@
 - name: "Retrieve Splunk version"
   command: "{{ splunk.exec }} version --accept-license --answer-yes --no-prompt"
   register: installed_splunk_version
+  become: yes
+  become_user: "{{ splunk.user }}"
   when: ansible_system is match("Linux")
 
 - name: "Set installed version fact"


### PR DESCRIPTION
Looks like we missed a case where the `{{ splunk.exec }}` should be executed as the Splunk user.

https://github.com/splunk/splunk-ansible/issues/359