### PR TITLE
Adding factor of safety to SHC readiness and handling nonetype checks

### DIFF
--- a/ansible_commands/shc_ready.py
+++ b/ansible_commands/shc_ready.py
@@ -28,7 +28,7 @@ class ShcReady(object):
         shc_peers = resp['entry'][0]['content']['peers']
         # Check #1, see if peers are up
         # the comparison will be >= in case play is run after cluster is setup
-        if len(shc_peers.keys()) < len(self.shc_peers): # SH Captain included in list
+        if not shc_peers or len(shc_peers.keys()) < len(self.shc_peers): # SH Captain included in list
             raise Exception("SHC failure, setup not complete. Insufficient number of peers online")
         #correct number of peers online
         # Check #2, see if peers are ready to accept bundle

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -600,6 +600,7 @@ def prep_for_yaml_out(inventory):
                    "build_location",
                    "build_remote_src",
                    "deployer_included",
+                   "hostname",
                    "upgrade",
                    "role",
                    "search_head_cluster",

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-retry_delay: 3
+retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60
 shc_sync_retry_num: 60

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-retry_delay: 3
+retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60
 shc_sync_retry_num: 60


### PR DESCRIPTION
Adding more SHC readiness error handling and increasing timeout slightly to allow for longer setups. When bringing up a C13 deployment I saw:
```
2020-01-31 18:41:04,218 p=75 u=ansible n=ansible | Friday 31 January 2020  18:41:04 +0000 (0:00:00.118)       0:00:34.531 ********
2020-01-31 18:41:04,637 p=75 u=ansible n=ansible | FAILED - RETRYING: Wait for SHC to be ready (60 retries left).
...
2020-01-31 18:44:16,505 p=75 u=ansible n=ansible | FAILED - RETRYING: Wait for SHC to be ready (2 retries left).
2020-01-31 18:44:19,771 p=75 u=ansible n=ansible | TASK [splunk_deployer : Wait for SHC to be ready] ******************************
2020-01-31 18:44:19,771 p=75 u=ansible n=ansible | ok: [localhost]
```

Also threw in a fix for https://github.com/splunk/splunk-ansible/issues/369 