### PR TITLE
Remove hard-coded environment

### DIFF
--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -1,6 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
+ansible_env: {}
 retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -1,6 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
+ansible_env: {}
 retry_delay: 10
 retry_num: 60
 wait_for_splunk_retry_num: 150

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -1,6 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
+ansible_env: {}
 retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -1,6 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
+ansible_env: {}
 retry_delay: 10
 retry_num: 60
 wait_for_splunk_retry_num: 150

--- a/multisite.yml
+++ b/multisite.yml
@@ -2,8 +2,7 @@
 - name: Run multisite provisioning
   hosts: localhost
   gather_facts: true
-  environment:
-    ASAN_OPTIONS: detect_leaks=0
+  environment: "{{ ansible_env }}"
   tasks:
       # These should only be run for the three roles that currently
       # have multisite defined; cluster master, search head, and indexer

--- a/site.yml
+++ b/site.yml
@@ -2,8 +2,7 @@
 - name: Run default Splunk provisioning
   hosts: localhost
   gather_facts: true
-  environment:
-    ASAN_OPTIONS: detect_leaks=0
+  environment: "{{ ansible_env }}"
   tasks:
 
     - block:


### PR DESCRIPTION
Removing this hard-coded bit to support more flexible, user-defined env vars used during Ansible execution-time. Also handling ASAN parameter to add the necessary env var to get it working.