### PR TITLE
Avoid using ansible_env as var name

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -368,10 +368,10 @@ def getAnsibleContext(vars_scope):
     """
     vars_scope["ansible_pre_tasks"] = os.environ.get("SPLUNK_ANSIBLE_PRE_TASKS", vars_scope.get("ansible_pre_tasks"))
     vars_scope["ansible_post_tasks"] = os.environ.get("SPLUNK_ANSIBLE_POST_TASKS", vars_scope.get("ansible_post_tasks"))
-    vars_scope["ansible_env"] = vars_scope.get("ansible_env") or {}
+    vars_scope["ansible_environment"] = vars_scope.get("ansible_environment") or {}
     env = os.environ.get("SPLUNK_ANSIBLE_ENV")
     if env:
-        vars_scope["ansible_env"].update({k:v for k,v in [x.split("=", 1) for x in env.split(",")]})
+        vars_scope["ansible_environment"].update({k:v for k,v in [x.split("=", 1) for x in env.split(",")]})
 
 def getASan(vars_scope):
     """
@@ -379,7 +379,7 @@ def getASan(vars_scope):
     """
     vars_scope["splunk"]["asan"] = bool(os.environ.get("SPLUNK_ENABLE_ASAN", vars_scope["splunk"].get("asan")))
     if vars_scope["splunk"]["asan"]:
-        vars_scope["ansible_env"].update({"ASAN_OPTIONS": "detect_leaks=0"})
+        vars_scope["ansible_environment"].update({"ASAN_OPTIONS": "detect_leaks=0"})
 
 def overrideEnvironmentVars(vars_scope):
     vars_scope["splunk"]["user"] = os.environ.get("SPLUNK_USER", vars_scope["splunk"]["user"])

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-ansible_env: {}
+ansible_environment: {}
 retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-ansible_env: {}
+ansible_environment: {}
 retry_delay: 10
 retry_num: 60
 wait_for_splunk_retry_num: 150

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-ansible_env: {}
+ansible_environment: {}
 retry_delay: 6
 retry_num: 60
 wait_for_splunk_retry_num: 60

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -1,7 +1,7 @@
 ansible_ssh_user: "splunk"
 ansible_pre_tasks:
 ansible_post_tasks:
-ansible_env: {}
+ansible_environment: {}
 retry_delay: 10
 retry_num: 60
 wait_for_splunk_retry_num: 150

--- a/multisite.yml
+++ b/multisite.yml
@@ -2,7 +2,7 @@
 - name: Run multisite provisioning
   hosts: localhost
   gather_facts: true
-  environment: "{{ ansible_env }}"
+  environment: "{{ ansible_environment }}"
   tasks:
       # These should only be run for the three roles that currently
       # have multisite defined; cluster master, search head, and indexer

--- a/site.yml
+++ b/site.yml
@@ -2,7 +2,7 @@
 - name: Run default Splunk provisioning
   hosts: localhost
   gather_facts: true
-  environment: "{{ ansible_env }}"
+  environment: "{{ ansible_environment }}"
   tasks:
 
     - block:

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -221,28 +221,28 @@ def test_getLaunchConf(default_yml, os_env, output):
 @pytest.mark.parametrize(("default_yml", "os_env", "output"),
             [
                 # Check null parameters
-                ({}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {}}),
+                ({}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {}}),
                 # Check ansible_pre_tasks using defaults or env vars
-                ({"ansible_pre_tasks": ""}, {}, {"ansible_pre_tasks": "", "ansible_post_tasks": None, "ansible_env": {}}),
-                ({"ansible_pre_tasks": "a"}, {}, {"ansible_pre_tasks": "a", "ansible_post_tasks": None, "ansible_env": {}}),
-                ({"ansible_pre_tasks": "a,b,c"}, {}, {"ansible_pre_tasks": "a,b,c", "ansible_post_tasks": None, "ansible_env": {}}),
-                ({}, {"SPLUNK_ANSIBLE_PRE_TASKS": "d"}, {"ansible_pre_tasks": "d", "ansible_post_tasks": None, "ansible_env": {}}),
-                ({}, {"SPLUNK_ANSIBLE_PRE_TASKS": "e,f,g"}, {"ansible_pre_tasks": "e,f,g", "ansible_post_tasks": None, "ansible_env": {}}),
-                ({"ansible_pre_tasks": "a,b,c"}, {"SPLUNK_ANSIBLE_PRE_TASKS": "e,f,g"}, {"ansible_pre_tasks": "e,f,g", "ansible_post_tasks": None, "ansible_env": {}}),
+                ({"ansible_pre_tasks": ""}, {}, {"ansible_pre_tasks": "", "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({"ansible_pre_tasks": "a"}, {}, {"ansible_pre_tasks": "a", "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({"ansible_pre_tasks": "a,b,c"}, {}, {"ansible_pre_tasks": "a,b,c", "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({}, {"SPLUNK_ANSIBLE_PRE_TASKS": "d"}, {"ansible_pre_tasks": "d", "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({}, {"SPLUNK_ANSIBLE_PRE_TASKS": "e,f,g"}, {"ansible_pre_tasks": "e,f,g", "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({"ansible_pre_tasks": "a,b,c"}, {"SPLUNK_ANSIBLE_PRE_TASKS": "e,f,g"}, {"ansible_pre_tasks": "e,f,g", "ansible_post_tasks": None, "ansible_environment": {}}),
                 # Check ansible_post_tasks using defaults or env vars
-                ({"ansible_post_tasks": ""}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "", "ansible_env": {}}),
-                ({"ansible_post_tasks": "a"}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "a", "ansible_env": {}}),
-                ({"ansible_post_tasks": "a,b,c"}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "a,b,c", "ansible_env": {}}),
-                ({}, {"SPLUNK_ANSIBLE_POST_TASKS": "d"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "d", "ansible_env": {}}),
-                ({}, {"SPLUNK_ANSIBLE_POST_TASKS": "e,f,g"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "e,f,g", "ansible_env": {}}),
-                ({"ansible_post_tasks": "a,b,c"}, {"SPLUNK_ANSIBLE_POST_TASKS": "e,f,g"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "e,f,g", "ansible_env": {}}),
-                # Check ansible_env using defaults or env vars
-                ({"ansible_env": None}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {}}),
-                ({"ansible_env": {"a": "b"}}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {"a": "b"}}),
-                ({"ansible_env": {"a": "b", "d": "e"}}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {"a": "b", "d": "e"}}),
-                ({}, {"SPLUNK_ANSIBLE_ENV": "a=b"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {"a": "b"}}),
-                ({}, {"SPLUNK_ANSIBLE_ENV": "a=b,x=y"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {"a": "b", "x": "y"}}),
-                ({"ansible_env": {"a": "c", "d": "e"}}, {"SPLUNK_ANSIBLE_ENV": "a=b,x=y"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_env": {"a": "b", "d": "e", "x": "y"}}),
+                ({"ansible_post_tasks": ""}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "", "ansible_environment": {}}),
+                ({"ansible_post_tasks": "a"}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "a", "ansible_environment": {}}),
+                ({"ansible_post_tasks": "a,b,c"}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": "a,b,c", "ansible_environment": {}}),
+                ({}, {"SPLUNK_ANSIBLE_POST_TASKS": "d"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "d", "ansible_environment": {}}),
+                ({}, {"SPLUNK_ANSIBLE_POST_TASKS": "e,f,g"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "e,f,g", "ansible_environment": {}}),
+                ({"ansible_post_tasks": "a,b,c"}, {"SPLUNK_ANSIBLE_POST_TASKS": "e,f,g"}, {"ansible_pre_tasks": None, "ansible_post_tasks": "e,f,g", "ansible_environment": {}}),
+                # Check ansible_environment using defaults or env vars
+                ({"ansible_environment": None}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {}}),
+                ({"ansible_environment": {"a": "b"}}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {"a": "b"}}),
+                ({"ansible_environment": {"a": "b", "d": "e"}}, {}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {"a": "b", "d": "e"}}),
+                ({}, {"SPLUNK_ANSIBLE_ENV": "a=b"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {"a": "b"}}),
+                ({}, {"SPLUNK_ANSIBLE_ENV": "a=b,x=y"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {"a": "b", "x": "y"}}),
+                ({"ansible_environment": {"a": "c", "d": "e"}}, {"SPLUNK_ANSIBLE_ENV": "a=b,x=y"}, {"ansible_pre_tasks": None, "ansible_post_tasks": None, "ansible_environment": {"a": "b", "d": "e", "x": "y"}}),
             ]
         )
 def test_getAnsibleContext(default_yml, os_env, output):
@@ -270,16 +270,16 @@ def test_getAnsibleContext(default_yml, os_env, output):
             ]
         )
 def test_getASan(default_yml, os_env, splunk_asan):
-    vars_scope = {"ansible_env": {}, "splunk": {}}
+    vars_scope = {"ansible_environment": {}, "splunk": {}}
     vars_scope["splunk"] = default_yml
     with patch("environ.inventory") as mock_inven:
         with patch("os.environ", new=os_env):
             environ.getASan(vars_scope)
     assert vars_scope["splunk"]["asan"] == splunk_asan
     if vars_scope["splunk"]["asan"]:
-        assert vars_scope["ansible_env"].get("ASAN_OPTIONS") == "detect_leaks=0"
+        assert vars_scope["ansible_environment"].get("ASAN_OPTIONS") == "detect_leaks=0"
     else:
-        assert vars_scope["ansible_env"].get("ASAN_OPTIONS") == None
+        assert vars_scope["ansible_environment"].get("ASAN_OPTIONS") == None
 
 @pytest.mark.parametrize(("os_env", "license_master_included", "deployer_included", "indexer_cluster", "search_head_cluster", "search_head_cluster_url"),
                          [


### PR DESCRIPTION
Oops, looks like `ansible_env` is actually some protected var that comes from Ansible itself. Changing this to `ansible_environment`.