### PR TITLE
Don't require admin authentication when waiting for remote instance

### DIFF
--- a/roles/splunk_common/tasks/wait_for_splunk_instance.yml
+++ b/roles/splunk_common/tasks/wait_for_splunk_instance.yml
@@ -1,15 +1,12 @@
 ---
 - name: Check Splunk instance is running
   uri:
-    url: "{{ cert_prefix }}://{{ splunk_instance_address }}:{{ splunk.svc_port }}/services/server/info?output_mode=json"
+    url: "{{ cert_prefix }}://{{ splunk_instance_address }}:{{ splunk.svc_port }}"
     method: GET
-    user: "{{ splunk.admin_user }}"
-    password: "{{ splunk.password }}"
     validate_certs: false
   register: task_response
   until:
     - task_response.status == 200
-    - lookup('pipe', 'date +"%s"')|int - task_response.json.entry[0].content.startup_time > 10
   retries: "{{ wait_for_splunk_retry_num }}"
   delay: "{{ retry_delay }}"
   ignore_errors: true


### PR DESCRIPTION
Updated wait_for_splunk_instance.yml so that the HTTP request it makes does not require authentication. When waiting for a remote instance, this created a dependency that the remote instance must have the same admin password as the local instance, which likely doesn't hold true outside of crafted test environments. Splunk itself has no such requirement, which is why it has and uses pass4SymmKey secrets.

Only the root endpoint appears to be unauthenticated in the REST API, so this prevents us from being able to query uptime of the remote instance and ensure it is > 10 seconds. I don't know why this check was put in place, but generally artificial wait times like this can be better handled via more specific checks and retry loops.