### PR TITLE
Allow for disabling s2s in subsequent runs.

### DIFF
--- a/roles/splunk_common/tasks/enable_s2s.yml
+++ b/roles/splunk_common/tasks/enable_s2s.yml
@@ -5,4 +5,4 @@
 
 - include_tasks: s2s/configure_splunktcp.yml
   when:
-    - "'s2s' not in splunk or (not splunk.s2s.ssl | bool)"
+    - "'s2s' not in splunk or ('ssl' not in splunk.s2s or not splunk.s2s.ssl | bool)"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -65,7 +65,7 @@
 
 - include_tasks: enable_s2s.yml
   when:
-    - "('s2s_enable' in splunk and splunk.s2s_enable | bool) or ('s2s' in splunk and 'enable' in splunk.s2s and splunk.s2s.enable | bool)"
+    - "('s2s_enable' in splunk) or ('s2s' in splunk and 'enable' in splunk.s2s)"
     - "('s2s_port' in splunk and splunk.s2s_port) or ('s2s' in splunk and 'port' in splunk.s2s and splunk.s2s.port)"
 
 - include_tasks: set_launch_conf.yml

--- a/roles/splunk_common/tasks/s2s/configure_splunktcp.yml
+++ b/roles/splunk_common/tasks/s2s/configure_splunktcp.yml
@@ -4,7 +4,7 @@
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: "splunktcp://{{ splunk.s2s_port if splunk.s2s_port is defined else splunk.s2s.port }}"
     option: "disabled"
-    value: "0"
+    value: "{{ 0 if 's2s' in splunk and 'enable' in splunk.s2s and splunk.s2s.enable else 1 }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   notify:

--- a/roles/splunk_universal_forwarder/molecule/default/playbook.yml
+++ b/roles/splunk_universal_forwarder/molecule/default/playbook.yml
@@ -62,8 +62,9 @@
       opt: /opt
       password: helloworld
       pid: /opt/splunkforwarder/var/run/splunk/splunkd.pid
-      s2s_enable: true
-      s2s_port: 9997
+      s2s:
+        enable: true
+        port: 9997
       secret: null
       smartstore: null
       svc_port: 8089


### PR DESCRIPTION
I found that the way the s2s logic was written, if you enabled s2s in one run, then disabled it later, it would skip the entire s2s configuration thus leaving the inputs.conf with s2s enabled. This patch alllow you to set splunk.s2s.enabled to false and have it actually disable s2s.