### PR TITLE
Pinning molecule version due to CI failures

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,8 @@ pylint
 mock
 docker
 requests
-molecule
+molecule==2.22
 coverage
 caniusepython3
 ansible>=2.8.2
+ansible-lint>=4.2.0


### PR DESCRIPTION
Will look into why molecule>=3.0.0 broke our stuff, but patching this for now. 