### PR TITLE
App download should fail if the request fails

### DIFF
--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -40,7 +40,6 @@
   when:
     - "'splunkbase.splunk.com' not in app_url"
     - app_url is match("^(https?|file)://.*")
-  ignore_errors: true
 
 # Some premium apps require installation via untar command, while others can be installed normally.
 # We'll need to verify the contents of the package to see if it's a premium app


### PR DESCRIPTION
I think I added `ignore_errors: true` and I'm not certain why. But I ran into a case where I got a 404 on an app URL I passed in and it didn't fail on this step when it probably should.