### PR TITLE
Reverting standalone changes

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -88,8 +88,10 @@ def getSplunkInventory(inventory, reName=r"(.*)_URL"):
                 'hosts': list([host.split(':')[0] for host in hosts])
             }
     inventory["all"]["vars"] = getDefaultVars()
+    inventory["all"]["vars"]["docker"] = False
 
     if os.path.isfile("/.dockerenv"):
+        inventory["all"]["vars"]["docker"] = True
         if "localhost" not in inventory["all"]["children"]:
             inventory["all"]["hosts"].append("localhost")
         inventory["_meta"]["hostvars"]["localhost"] = inventory["all"]["vars"]

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -88,7 +88,7 @@
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
 - name: "Setting forward servers fact from index cluster group"
   set_fact:
-    splunk_forward_servers: "{{ groups['splunk_indexer'] }}"
+    splunk_forward_servers: "{{ groups['splunk_indexer'] | difference([ansible_hostname]) }}"
   when:
     - "splunk_forward_servers is not defined"
     - "'splunk_indexer' in groups"
@@ -98,7 +98,7 @@
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/forwardersdirecttopeers
 - name: "Setting forward servers fact from standalone group"
   set_fact:
-    splunk_forward_servers: "{{ groups['splunk_standalone'] }}"
+    splunk_forward_servers: "{{ groups['splunk_standalone'] | difference([ansible_hostname]) }}"
   when:
     - "splunk_forward_servers is not defined"
     - "'splunk_standalone' in groups"

--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -35,16 +35,6 @@
   set_fact:
     first_run: "{{ not pre_existing_splunk_secret.stat.exists | default(True) }}"
 
-# Checking that the .dockerenv file exists is enough to know if we are inside a docker container.
-- name: "Check if we are in a docker"
-  stat:
-    path: "/.dockerenv"
-  register: docker_env
-
-- name: "Set docker fact"
-  set_fact:
-    is_docker: "{{ docker_env.stat.exists | default(False) }}"
-
 - name: "Set splunk_build_type fact"
   include_tasks: get_facts_build_type.yml
 

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -18,6 +18,27 @@
     - dmc_forwarder_monitoring is defined
     - dmc_forwarder_monitoring | bool
 
+## Indexer Clustering Scenario
+- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
+  when:
+    - splunk_indexer_cluster is defined
+    - splunk.multisite_master is not defined
+    - splunk.set_search_peers is defined
+    - splunk.set_search_peers | bool
+
+## Non Indexer Clustering Scenario
+- include_tasks: ../../splunk_common/tasks/peer_indexers.yml
+  when:
+    - splunk_indexer_cluster is not defined
+    - splunk.multisite_master is not defined
+    - splunk.set_search_peers is defined
+    - splunk.set_search_peers | bool
+    - "'splunk_indexer' in groups"
+
+- include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml
+  when:
+    - "splunk_indexer_cluster is defined or splunk_forward_servers is defined"
+
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
   when:
     - splunk.apps_location

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -18,27 +18,6 @@
     - dmc_forwarder_monitoring is defined
     - dmc_forwarder_monitoring | bool
 
-## Indexer Clustering Scenario
-- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
-  when:
-    - splunk_indexer_cluster is defined
-    - splunk.multisite_master is not defined
-    - splunk.set_search_peers is defined
-    - splunk.set_search_peers | bool
-
-## Non Indexer Clustering Scenario
-- include_tasks: ../../splunk_common/tasks/peer_indexers.yml
-  when:
-    - splunk_indexer_cluster is not defined
-    - splunk.multisite_master is not defined
-    - splunk.set_search_peers is defined
-    - splunk.set_search_peers | bool
-    - "'splunk_indexer' in groups"
-
-- include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml
-  when:
-    - "splunk_indexer_cluster is defined or splunk_forward_servers is defined"
-
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
   when:
     - splunk.apps_location

--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,7 @@
 - name: Run default Splunk provisioning
   hosts: localhost
   gather_facts: true
+  strategy: free
   environment: "{{ ansible_environment | default({}) }}"
   tasks:
 


### PR DESCRIPTION
Removing the `docker_env`/`is_docker` vars from get_facts.yml because they are not used anywhere. I encountered some errors/test failures when the latest edge image was rolled into our internal tools. Reproduced with:
```
docker run -d -P --name so1 -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld -e SPLUNK_STANDALONE_URL=so1 -e DEBUG=true splunk/splunk:edge
```

It seems this change doesn't play very nice with https://github.com/splunk/splunk-ansible/blob/develop/roles/splunk_common/tasks/get_facts.yml#L90, and what ends up happening is you end up with some reflexive forwarding. 

@mikedickey I know you added this section in the standalone role from your last PR, but I think we should probably draw some lines around expectations of each role. I'm not sure if it makes sense for standalones to automatically peer the indexer tier. Arguably, this is no longer a "standalone" now and is probably more apt to be considered just a "search head". Also going back to internal usage of these images, there may be some users who create standalones to setup peering to various other roles themselves for the sake of testing.
