### PR TITLE
Added a bearer token authentication for splunk download

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -304,9 +304,13 @@ def getSplunkBuild(vars_scope):
     """
     Determine the location of the Splunk build
     """
+    bearer_token_provided = os.environ.get("SPLUNK_BUILD_URL_BEARER_TOKEN")
+    if bearer_token_provided:
+        vars_scope["splunk"]["build_url_bearer_token"] = bearer_token_provided
     vars_scope["splunk"]["build_location"] = os.environ.get("SPLUNK_BUILD_URL", vars_scope["splunk"].get("build_location"))
     vars_scope["splunk"]["build_remote_src"] = False
-    if vars_scope["splunk"]["build_location"] and vars_scope["splunk"]["build_location"].startswith("http"):
+    # If a bearer token is provided, we will download the package first and install via local source
+    if vars_scope["splunk"]["build_location"] and vars_scope["splunk"]["build_location"].startswith("http") and not bearer_token_provided:
         vars_scope["splunk"]["build_remote_src"] = True
 
 def getSplunkbaseToken(vars_scope):

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -37,3 +37,4 @@
   with_items:
     - "{{ splunk.build_location }}"
     - "/tmp/splunk.msi"
+    - "{{ downloaded_splunk_path }}"

--- a/roles/splunk_common/tasks/install_splunk_tgz.yml
+++ b/roles/splunk_common/tasks/install_splunk_tgz.yml
@@ -1,3 +1,32 @@
+- name: Download Splunk with the bearer token authentication
+  get_url:
+    url: "{{ splunk.build_location }}"
+    dest: "{{ splunk.opt }}"
+    headers:
+      Authorization: "Bearer {{ splunk.build_url_bearer_token }}"
+  when: splunk.build_url_bearer_token is defined
+  register: download_result
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- set_fact:
+    downloaded_splunk_path: "{{ download_result.dest }}"
+  when: download_result is defined and download_result.changed | bool
+
+- name: Install Splunk from downloaded local build
+  unarchive:
+    src: "{{ downloaded_splunk_path }}"
+    dest: "{{ splunk.opt }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when: download_result is defined
+  register: install_result
+  until: install_result is succeeded
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  become: yes
+  become_user: "{{ privileged_user }}"
+
 - name: Install Splunk (Linux) from network
   unarchive:
     src: "{{ splunk.build_location }}"
@@ -8,7 +37,7 @@
   environment:
     http_proxy: "{{ lookup('env','http_proxy') | default('') }}"
     https_proxy: "{{ lookup('env','https_proxy') | default('') }}"
-  when: splunk.build_remote_src
+  when: splunk.build_remote_src and downloaded_splunk_path is not defined
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"
@@ -23,7 +52,7 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     remote_src: "{{ splunk.build_remote_src }}"
-  when: not splunk.build_remote_src
+  when: not splunk.build_remote_src and downloaded_splunk_path is not defined
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"


### PR DESCRIPTION
- SPLUNK_BUILD_URL_BEARER_TOKEN can be used to pull Splunk builds against remote paths that require a bearer token authentication.