### PR TITLE
Multiple SPLUNK_STANDALONE_URL hosts provided

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -98,6 +98,8 @@
   when:
     - "splunk_forward_servers is not defined"
     - "'splunk_indexer' in groups"
+    # Prevent self-forwarding
+    - splunk.role != "splunk_indexer"
 
 # if not specified in config *and*
 # no index clusters, then look for standalone
@@ -108,6 +110,8 @@
   when:
     - "splunk_forward_servers is not defined"
     - "'splunk_standalone' in groups"
+    # Prevent self-forwarding
+    - splunk.role != "splunk_standalone"
     # This part takes a little explaining.  If we have a mixed cluster with no indexers
     # (Only standalone and search heads) we should not automatically forward the data to
     # standalone instances UNLESS they are specified by forward-servers


### PR DESCRIPTION
Fixing some behavior caused by https://github.com/splunk/splunk-ansible/pull/396.

When creating the standalone and potentially adding redundant information, this sets up some reflexive forwarding. For instance:
```
docker run -P -d -e SPLUNK_START_ARGS=--accept-license -e SPLUNK_PASSWORD=helloworld -e SPLUNK_STANDALONE_URL=so1 --name so1 --hostname so1 splunk-redhat-8:latest
```
will cause the following:
```
splunk@so1:/opt/splunk/etc/system/local$ cat outputs.conf
[indexAndForward]
index = false
```
which is bad. This can also happen if you specify multiple standalone URLs. Disabling this behavior to forward when the instance is intended to be a sink. 