### PR TITLE
Checking if deployed in Kubernetes

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -90,7 +90,7 @@ def getSplunkInventory(inventory, reName=r"(.*)_URL"):
     inventory["all"]["vars"] = getDefaultVars()
     inventory["all"]["vars"]["docker"] = False
 
-    if os.path.isfile("/.dockerenv"):
+    if os.path.isfile("/.dockerenv") or os.path.isdir("/var/run/secrets/kubernetes.io") or os.environ.get("KUBERNETES_SERVICE_HOST"):
         inventory["all"]["vars"]["docker"] = True
         if "localhost" not in inventory["all"]["children"]:
             inventory["all"]["hosts"].append("localhost")


### PR DESCRIPTION
So reviewing our [docs in docker-splunk](https://splunk.github.io/docker-splunk/), we don't officially support other container runtimes nor do we officially support Kubernetes :P 

Because people are using Kubernetes, we should probably expect that different CRIs may be installed. If Kube works with that CRI, I don't see why these images wouldn't - although at the same time, we're currently only testing with the Docker container engine so I can't anticipate what issues may arise between other runtimes. 