### PR TITLE
Add condition to license copy

### DIFF
--- a/roles/splunk_common/tasks/licenses/add_license.yml
+++ b/roles/splunk_common/tasks/licenses/add_license.yml
@@ -6,7 +6,9 @@
 
 - name: Copy license
   command: "cp {{ lic }} {{ splunk.license_download_dest }}"
-  when: lic_source.stat.exists
+  when:
+    - lic_source.stat.exists
+    - lic != splunk.license_download_dest
 
 - name: Download license
   get_url:


### PR DESCRIPTION
Copy fails when src/dest paths are identical.