### PR TITLE
Support for empty sections

### DIFF
--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -1,9 +1,10 @@
 ---
 - name: "Set stanza {{ stanza_name }}"
-  ini_file:
+  lineinfile:
     path: "{{ conf_directory }}/{{ conf_file }}"
-    section: "{{ stanza_name }}"
+    line: "[{{ stanza_name }}]"
     state: present
+    create: yes
     mode: 0660
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"


### PR DESCRIPTION
I lied in my last PR https://github.com/splunk/splunk-ansible/pull/442 - empty, option-less stanzas still didn't work. They should now with these changes, and I manually verified this using the test I made https://github.com/splunk/docker-splunk/pull/356