### PR TITLE
Added additional path to verify if running in container (podman)

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -90,7 +90,7 @@ def getSplunkInventory(inventory, reName=r"(.*)_URL"):
     inventory["all"]["vars"] = getDefaultVars()
     inventory["all"]["vars"]["docker"] = False
 
-    if os.path.isfile("/.dockerenv") or os.path.isdir("/var/run/secrets/kubernetes.io") or os.environ.get("KUBERNETES_SERVICE_HOST"):
+    if os.path.isfile("/.dockerenv") or os.path.isfile("/run/.containerenv") or os.path.isdir("/var/run/secrets/kubernetes.io") or os.environ.get("KUBERNETES_SERVICE_HOST"):
         inventory["all"]["vars"]["docker"] = True
         if "localhost" not in inventory["all"]["children"]:
             inventory["all"]["hosts"].append("localhost")


### PR DESCRIPTION
The latest Ansible playbook (with image splunk/splunk:8.0.3) breaks deployments that use Podman instead of Docker. The environ.py file checks if the .dockerenv file is present, which is not the case with Podman. Instead, a simple check for /run/.containerenv should work :) 