### PR TITLE
Adding special handling for ESS

### DIFF
--- a/roles/splunk_cluster_master/tasks/generate_ess_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_ess_bundle.yml
@@ -52,18 +52,6 @@
     - ta_location is success
     - ansible_system is match("CYGWIN*|Win32NT")
 
-- name: Determine ESS default apps
-  set_fact:
-    ess_apps: ["DA-ESS-AccessProtection", "DA-ESS-EndpointProtection", "DA-ESS-IdentityManagement", "DA-ESS-NetworkProtection",
-               "DA-ESS-ThreatIntelligence", "SA-AccessProtection", "SA-AuditAndDataProtection", "SA-EndpointProtection", "SA-IdentityManagement",
-               "SA-NetworkProtection", "SA-ThreatIntelligence", "SA-UEBA", "SA-Utils", "SplunkEnterpriseSecuritySuite", "Splunk_SA_CIM",
-               "Splunk_SA_ExtremeSearch", "Splunk_TA_bluecoat-proxysg", "Splunk_TA_bro", "Splunk_TA_flowfix", "Splunk_TA_juniper",
-               "Splunk_TA_mcafee", "Splunk_TA_nessus", "Splunk_TA_nix", "Splunk_TA_oracle", "Splunk_TA_ossec", "Splunk_TA_rsa-securid",
-               "Splunk_TA_sophos", "Splunk_TA_sourcefire", "Splunk_TA_symantec-ep", "Splunk_TA_ueba", "Splunk_TA_websense-cg", "Splunk_TA_windows",
-               "TA-airdefense", "TA-alcatel", "TA-cef", "TA-fortinet", "TA-ftp", "TA-nmap", "TA-tippingpoint", "TA-trendmicro",
-               "Splunk_ML_Toolkit", "Splunk_SA_Scientific_Python_linux_x86_64", "Splunk_SA_Scientific_Python_linux_x86",
-               "Splunk_SA_Scientific_Python_darwin_x86_64", "Splunk_SA_Scientific_Python_windows_x86_64"]
-
 - name: Remove ESS apps from installed apps list
   set_fact:
     installed_apps: "{{ installed_apps | difference(ess_apps) | unique }}"

--- a/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_itsi_bundle.yml
@@ -1,10 +1,4 @@
 ---
-- name: Determine ITSI default apps
-  set_fact:
-    itsi_apps: ["DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
-                "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", "SA-UserAccess",
-                "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "SA-ITSI-Licensechecker", "itsi", "splunk_app_infrastructure"]
-
 - name: Remove ITSI apps from installed apps list
   set_fact:
     installed_apps: "{{ installed_apps | difference(itsi_apps) | unique }}"

--- a/roles/splunk_common/tasks/copy_installed_apps.yml
+++ b/roles/splunk_common/tasks/copy_installed_apps.yml
@@ -1,8 +1,9 @@
 ---
 # TODO: Might be better to use synchronize here, but we'll need rsync installed
+# ESS requires installation on the local node before distributing the bundle out, which contains local
 - name: "Copy installed apps to {{ dest }}"
   shell:
-    cmd: "set -o pipefail && tar -c --exclude=local {{ item }} | tar -x -C {{ dest }}"
+    cmd: "set -o pipefail && tar -c {% if item not in ess_apps %}--exclude=local{% endif %} {{ item }} | tar -x -C {{ dest }}"
     chdir: "{{ splunk.app_paths.default }}"
     executable: /bin/bash
   become: yes

--- a/roles/splunk_common/tasks/find_installed_apps.yml
+++ b/roles/splunk_common/tasks/find_installed_apps.yml
@@ -1,13 +1,4 @@
 ---
-- name: Determine Splunk default apps
-  set_fact:
-    default_apps: [ "legacy", "splunk_gdi", "SplunkForwarder", "SplunkLightForwarder", "gettingstarted",
-                    "alert_webhook", "splunk_httpinput", "introspection_generator_addon", "user-prefs",
-                    "appsbrowser", "framework", "learned", "launcher", "alert_logevent", "sample_app",
-                    "splunk_instrumentation", "search", "splunk_archiver", "splunk_monitoring_console",
-                    "_splunk_config", "splunk_enterprise_on_docker", "splunk_forwarder_on_docker",
-                    "splunk_metrics_workspace", "splunk_internal_metrics" ]
-
 - name: Find all apps
   find:
     paths: "{{ splunk.app_paths.default }}"

--- a/roles/splunk_common/vars/main.yml
+++ b/roles/splunk_common/vars/main.yml
@@ -1,0 +1,19 @@
+---
+default_apps: [ "legacy", "splunk_gdi", "SplunkForwarder", "SplunkLightForwarder", "gettingstarted",
+                "alert_webhook", "splunk_httpinput", "introspection_generator_addon", "user-prefs",
+                "appsbrowser", "framework", "learned", "launcher", "alert_logevent", "sample_app",
+                "splunk_instrumentation", "search", "splunk_archiver", "splunk_monitoring_console",
+                "_splunk_config", "splunk_enterprise_on_docker", "splunk_forwarder_on_docker",
+                "splunk_metrics_workspace", "splunk_internal_metrics", "splunk_telemetry" ]
+itsi_apps: [ "DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
+              "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", "SA-UserAccess",
+            "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "SA-ITSI-Licensechecker", "itsi", "splunk_app_infrastructure" ]
+ess_apps: [ "DA-ESS-AccessProtection", "DA-ESS-EndpointProtection", "DA-ESS-IdentityManagement", "DA-ESS-NetworkProtection",
+            "DA-ESS-ThreatIntelligence", "SA-AccessProtection", "SA-AuditAndDataProtection", "SA-EndpointProtection", "SA-IdentityManagement",
+            "SA-NetworkProtection", "SA-ThreatIntelligence", "SA-UEBA", "SA-Utils", "SplunkEnterpriseSecuritySuite", "Splunk_SA_CIM",
+            "Splunk_SA_ExtremeSearch", "Splunk_TA_bluecoat-proxysg", "Splunk_TA_bro", "Splunk_TA_flowfix", "Splunk_TA_juniper",
+            "Splunk_TA_mcafee", "Splunk_TA_nessus", "Splunk_TA_nix", "Splunk_TA_oracle", "Splunk_TA_ossec", "Splunk_TA_rsa-securid",
+            "Splunk_TA_sophos", "Splunk_TA_sourcefire", "Splunk_TA_symantec-ep", "Splunk_TA_ueba", "Splunk_TA_websense-cg", "Splunk_TA_windows",
+            "TA-airdefense", "TA-alcatel", "TA-cef", "TA-fortinet", "TA-ftp", "TA-nmap", "TA-tippingpoint", "TA-trendmicro",
+            "Splunk_ML_Toolkit", "Splunk_SA_Scientific_Python_linux_x86_64", "Splunk_SA_Scientific_Python_linux_x86",
+            "Splunk_SA_Scientific_Python_darwin_x86_64", "Splunk_SA_Scientific_Python_windows_x86_64" ]


### PR DESCRIPTION
Apparently we can't exclude the `local` dir when installing ESS through the deployer. This is mainly the way ESS is packaged, which requires the use of a Splunk search command to actually extract all the dependencies and finish the installation. 