### PR TITLE
Refactoring how vars are organized + layered

### DIFF
--- a/roles/splunk_heavy_forwarder/molecule/default/group_vars/all.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/group_vars/all.yml
@@ -1,0 +1,7 @@
+---
+splunk:
+  role: splunk_heavy_forwarder
+  build_location: https://download.splunk.com/products/splunk/releases/8.0.3/linux/splunk-8.0.3-a6754d8441bf-Linux-x86_64.tgz
+  hec:
+    token: abcd1234
+  password: helloworld

--- a/roles/splunk_heavy_forwarder/molecule/default/molecule.yml
+++ b/roles/splunk_heavy_forwarder/molecule/default/molecule.yml
@@ -30,109 +30,12 @@ platforms:
       - "/opt/splunk/var"
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_HASH_BEHAVIOUR: merge
   inventory:
-    hosts:
-      all:
-        vars:
-          ansible_post_tasks: null
-          ansible_pre_tasks: null
-          cert_prefix: https
-          dmc_asset_interval: 3,18,33,48 * * * *
-          dmc_forwarder_monitoring: false
-          hide_password: false
-          java_download_url: null
-          java_update_version: null
-          java_version: null
-          retry_delay: 6
-          retry_num: 60
-          shc_sync_retry_num: 60
-          splunk:
-            role: splunk_heavy_forwarder
-            license_uri: null
-            preferred_captaincy: true
-            build_location: https://download.splunk.com/products/splunk/releases/8.0.3/linux/splunk-8.0.3-a6754d8441bf-Linux-x86_64.tgz
-            ignore_license: true
-            apps_location: null
-            admin_user: admin
-            allow_upgrade: true
-            app_paths:
-              default: /opt/splunk/etc/apps
-              deployment: /opt/splunk/etc/deployment-apps
-              httpinput: /opt/splunk/etc/apps/splunk_httpinput
-              idxc: /opt/splunk/etc/master-apps
-              shc: /opt/splunk/etc/shcluster/apps
-            asan: false
-            build_url_bearer_token: null
-            cluster_master_url: null
-            deployer_url: null
-            dfs:
-              dfc_num_slots: 4
-              dfw_num_slots: 10
-              dfw_num_slots_enabled: false
-              enable: false
-              port: 9000
-              spark_master_host: 127.0.0.1
-              spark_master_webui_port: 8080
-            enable_service: false
-            exec: /opt/splunk/bin/splunk
-            group: splunk
-            hec:
-              cert: null
-              enable: true
-              password: null
-              port: 8088
-              ssl: true
-              token: abcd1234
-            home: /opt/splunk
-            http_enableSSL: false
-            http_enableSSL_cert: null
-            http_enableSSL_privKey: null
-            http_enableSSL_privKey_password: null
-            http_port: 8000
-            idxc:
-              label: idxc_label
-              pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-              replication_factor: 3
-              replication_port: 9887
-              search_factor: 3
-              secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-            launch: {}
-            license_download_dest: /tmp/splunk.lic
-            license_master_url: null
-            multisite_master_port: 8089
-            multisite_replication_factor_origin: 2
-            multisite_replication_factor_total: 3
-            multisite_search_factor_origin: 1
-            multisite_search_factor_total: 3
-            opt: /opt
-            pass4SymmKey: null
-            password: helloworld
-            pid: /opt/splunk/var/run/splunk/splunkd.pid
-            root_endpoint: null
-            s2s:
-              ca: null
-              cert: null
-              enable: true
-              password: null
-              port: 9997
-              ssl: false
-            search_head_captain_url: null
-            secret: null
-            service_name: null
-            set_search_peers: true
-            shc:
-              label: shc_label
-              pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-              replication_factor: 3
-              replication_port: 9887
-              secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-            smartstore: null
-            svc_port: 8089
-            tar_dir: splunk
-            user: splunk
-            wildcard_license: false
-          splunk_home_ownership_enforcement: true
-          wait_for_splunk_retry_num: 60
+    links:
+      hosts: ../hosts.yml
+      group_vars: ./group_vars/
 verifier:
   name: testinfra
   options:

--- a/roles/splunk_heavy_forwarder/molecule/hosts.yml
+++ b/roles/splunk_heavy_forwarder/molecule/hosts.yml
@@ -1,0 +1,100 @@
+---
+all:
+  vars:
+    ansible_post_tasks: null
+    ansible_pre_tasks: null
+    cert_prefix: https
+    dmc_asset_interval: 3,18,33,48 * * * *
+    dmc_forwarder_monitoring: false
+    hide_password: false
+    java_download_url: null
+    java_update_version: null
+    java_version: null
+    retry_delay: 6
+    retry_num: 60
+    shc_sync_retry_num: 60
+    splunk:
+      license_uri: null
+      preferred_captaincy: true
+      ignore_license: true
+      apps_location: null
+      admin_user: admin
+      allow_upgrade: true
+      app_paths:
+        default: /opt/splunk/etc/apps
+        deployment: /opt/splunk/etc/deployment-apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+      asan: false
+      build_url_bearer_token: null
+      cluster_master_url: null
+      deployer_url: null
+      dfs:
+        dfc_num_slots: 4
+        dfw_num_slots: 10
+        dfw_num_slots_enabled: false
+        enable: false
+        port: 9000
+        spark_master_host: 127.0.0.1
+        spark_master_webui_port: 8080
+      enable_service: false
+      exec: /opt/splunk/bin/splunk
+      group: splunk
+      hec:
+        cert: null
+        enable: true
+        password: null
+        port: 8088
+        ssl: true
+        token: 1b61a0cd-3f00-4261-a75e-ab5766c59860
+      home: /opt/splunk
+      http_enableSSL: false
+      http_enableSSL_cert: null
+      http_enableSSL_privKey: null
+      http_enableSSL_privKey_password: null
+      http_port: 8000
+      idxc:
+        label: idxc_label
+        pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
+        replication_factor: 3
+        replication_port: 9887
+        search_factor: 3
+        secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
+      launch: {}
+      license_download_dest: /tmp/splunk.lic
+      license_master_url: null
+      multisite_master_port: 8089
+      multisite_replication_factor_origin: 2
+      multisite_replication_factor_total: 3
+      multisite_search_factor_origin: 1
+      multisite_search_factor_total: 3
+      opt: /opt
+      pass4SymmKey: null
+      password: P/IrhvMEANXD58gpVuaJbtFAS+x0Q8y8
+      pid: /opt/splunk/var/run/splunk/splunkd.pid
+      root_endpoint: null
+      s2s:
+        ca: null
+        cert: null
+        enable: true
+        password: null
+        port: 9997
+        ssl: false
+      search_head_captain_url: null
+      secret: null
+      service_name: null
+      set_search_peers: true
+      shc:
+        label: shc_label
+        pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
+        replication_factor: 3
+        replication_port: 9887
+        secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
+      smartstore: null
+      svc_port: 8089
+      tar_dir: splunk
+      user: splunk
+      wildcard_license: false
+    splunk_home_ownership_enforcement: true
+    wait_for_splunk_retry_num: 60

--- a/roles/splunk_heavy_forwarder/molecule/java/group_vars/all.yml
+++ b/roles/splunk_heavy_forwarder/molecule/java/group_vars/all.yml
@@ -1,0 +1,10 @@
+---
+java_download_url: https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+java_update_version: 11.0.2
+java_version: openjdk:11
+splunk:
+  role: splunk_heavy_forwarder
+  build_location: https://download.splunk.com/products/splunk/releases/7.2.10/linux/splunk-7.2.10-a6dfcc62f450-Linux-x86_64.tgz
+  hec:
+    token: abcd1234
+  password: helloworld

--- a/roles/splunk_heavy_forwarder/molecule/java/molecule.yml
+++ b/roles/splunk_heavy_forwarder/molecule/java/molecule.yml
@@ -24,109 +24,12 @@ platforms:
       - "/opt/splunk/var"
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_HASH_BEHAVIOUR: merge
   inventory:
-    hosts:
-      all:
-        vars:
-          ansible_post_tasks: null
-          ansible_pre_tasks: null
-          cert_prefix: https
-          dmc_asset_interval: 3,18,33,48 * * * *
-          dmc_forwarder_monitoring: false
-          hide_password: false
-          java_download_url: https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
-          java_update_version: 11.0.2
-          java_version: openjdk:11
-          retry_delay: 6
-          retry_num: 60
-          shc_sync_retry_num: 60
-          splunk:
-            role: splunk_heavy_forwarder
-            license_uri: null
-            preferred_captaincy: true
-            build_location: https://download.splunk.com/products/splunk/releases/7.2.10/linux/splunk-7.2.10-a6dfcc62f450-Linux-x86_64.tgz
-            ignore_license: true
-            apps_location: null
-            admin_user: admin
-            allow_upgrade: true
-            app_paths:
-              default: /opt/splunk/etc/apps
-              deployment: /opt/splunk/etc/deployment-apps
-              httpinput: /opt/splunk/etc/apps/splunk_httpinput
-              idxc: /opt/splunk/etc/master-apps
-              shc: /opt/splunk/etc/shcluster/apps
-            asan: false
-            build_url_bearer_token: null
-            cluster_master_url: null
-            deployer_url: null
-            dfs:
-              dfc_num_slots: 4
-              dfw_num_slots: 10
-              dfw_num_slots_enabled: false
-              enable: false
-              port: 9000
-              spark_master_host: 127.0.0.1
-              spark_master_webui_port: 8080
-            enable_service: false
-            exec: /opt/splunk/bin/splunk
-            group: splunk
-            hec:
-              cert: null
-              enable: true
-              password: null
-              port: 8088
-              ssl: true
-              token: abcd1234
-            home: /opt/splunk
-            http_enableSSL: false
-            http_enableSSL_cert: null
-            http_enableSSL_privKey: null
-            http_enableSSL_privKey_password: null
-            http_port: 8000
-            idxc:
-              label: idxc_label
-              pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-              replication_factor: 3
-              replication_port: 9887
-              search_factor: 3
-              secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-            launch: {}
-            license_download_dest: /tmp/splunk.lic
-            license_master_url: null
-            multisite_master_port: 8089
-            multisite_replication_factor_origin: 2
-            multisite_replication_factor_total: 3
-            multisite_search_factor_origin: 1
-            multisite_search_factor_total: 3
-            opt: /opt
-            pass4SymmKey: null
-            password: helloworld
-            pid: /opt/splunk/var/run/splunk/splunkd.pid
-            root_endpoint: null
-            s2s:
-              ca: null
-              cert: null
-              enable: true
-              password: null
-              port: 9997
-              ssl: false
-            search_head_captain_url: null
-            secret: null
-            service_name: null
-            set_search_peers: true
-            shc:
-              label: shc_label
-              pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-              replication_factor: 3
-              replication_port: 9887
-              secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-            smartstore: null
-            svc_port: 8089
-            tar_dir: splunk
-            user: splunk
-            wildcard_license: false
-          splunk_home_ownership_enforcement: true
-          wait_for_splunk_retry_num: 60
+    links:
+      hosts: ../hosts.yml
+      group_vars: ./group_vars/
 verifier:
   name: testinfra
   options:

--- a/roles/splunk_standalone/molecule/default/group_vars/all.yml
+++ b/roles/splunk_standalone/molecule/default/group_vars/all.yml
@@ -1,0 +1,7 @@
+---
+splunk:
+  role: splunk_standalone
+  build_location: https://download.splunk.com/products/splunk/releases/8.0.3/linux/splunk-8.0.3-a6754d8441bf-Linux-x86_64.tgz
+  hec:
+    token: abcd1234
+  password: helloworld

--- a/roles/splunk_standalone/molecule/default/molecule.yml
+++ b/roles/splunk_standalone/molecule/default/molecule.yml
@@ -30,109 +30,12 @@ platforms:
       - "/opt/splunk/var"
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_HASH_BEHAVIOUR: merge
   inventory:
-    hosts:
-      all:
-        vars:
-          ansible_post_tasks: null
-          ansible_pre_tasks: null
-          cert_prefix: https
-          dmc_asset_interval: 3,18,33,48 * * * *
-          dmc_forwarder_monitoring: false
-          hide_password: false
-          java_download_url: null
-          java_update_version: null
-          java_version: null
-          retry_delay: 6
-          retry_num: 60
-          shc_sync_retry_num: 60
-          splunk:
-            role: splunk_standalone
-            license_uri: null
-            preferred_captaincy: true
-            build_location: https://download.splunk.com/products/splunk/releases/8.0.3/linux/splunk-8.0.3-a6754d8441bf-Linux-x86_64.tgz
-            ignore_license: true
-            apps_location: null
-            admin_user: admin
-            allow_upgrade: true
-            app_paths:
-              default: /opt/splunk/etc/apps
-              deployment: /opt/splunk/etc/deployment-apps
-              httpinput: /opt/splunk/etc/apps/splunk_httpinput
-              idxc: /opt/splunk/etc/master-apps
-              shc: /opt/splunk/etc/shcluster/apps
-            asan: false
-            build_url_bearer_token: null
-            cluster_master_url: null
-            deployer_url: null
-            dfs:
-              dfc_num_slots: 4
-              dfw_num_slots: 10
-              dfw_num_slots_enabled: false
-              enable: false
-              port: 9000
-              spark_master_host: 127.0.0.1
-              spark_master_webui_port: 8080
-            enable_service: false
-            exec: /opt/splunk/bin/splunk
-            group: splunk
-            hec:
-              cert: null
-              enable: true
-              password: null
-              port: 8088
-              ssl: true
-              token: abcd1234
-            home: /opt/splunk
-            http_enableSSL: false
-            http_enableSSL_cert: null
-            http_enableSSL_privKey: null
-            http_enableSSL_privKey_password: null
-            http_port: 8000
-            idxc:
-              label: idxc_label
-              pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-              replication_factor: 3
-              replication_port: 9887
-              search_factor: 3
-              secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-            launch: {}
-            license_download_dest: /tmp/splunk.lic
-            license_master_url: null
-            multisite_master_port: 8089
-            multisite_replication_factor_origin: 2
-            multisite_replication_factor_total: 3
-            multisite_search_factor_origin: 1
-            multisite_search_factor_total: 3
-            opt: /opt
-            pass4SymmKey: null
-            password: helloworld
-            pid: /opt/splunk/var/run/splunk/splunkd.pid
-            root_endpoint: null
-            s2s:
-              ca: null
-              cert: null
-              enable: true
-              password: null
-              port: 9997
-              ssl: false
-            search_head_captain_url: null
-            secret: null
-            service_name: null
-            set_search_peers: true
-            shc:
-              label: shc_label
-              pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-              replication_factor: 3
-              replication_port: 9887
-              secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-            smartstore: null
-            svc_port: 8089
-            tar_dir: splunk
-            user: splunk
-            wildcard_license: false
-          splunk_home_ownership_enforcement: true
-          wait_for_splunk_retry_num: 60
+    links:
+      hosts: ../hosts.yml
+      group_vars: ./group_vars/
 verifier:
   name: testinfra
   options:

--- a/roles/splunk_standalone/molecule/hosts.yml
+++ b/roles/splunk_standalone/molecule/hosts.yml
@@ -1,0 +1,100 @@
+---
+all:
+  vars:
+    ansible_post_tasks: null
+    ansible_pre_tasks: null
+    cert_prefix: https
+    dmc_asset_interval: 3,18,33,48 * * * *
+    dmc_forwarder_monitoring: false
+    hide_password: false
+    java_download_url: null
+    java_update_version: null
+    java_version: null
+    retry_delay: 6
+    retry_num: 60
+    shc_sync_retry_num: 60
+    splunk:
+      license_uri: null
+      preferred_captaincy: true
+      ignore_license: true
+      apps_location: null
+      admin_user: admin
+      allow_upgrade: true
+      app_paths:
+        default: /opt/splunk/etc/apps
+        deployment: /opt/splunk/etc/deployment-apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+      asan: false
+      build_url_bearer_token: null
+      cluster_master_url: null
+      deployer_url: null
+      dfs:
+        dfc_num_slots: 4
+        dfw_num_slots: 10
+        dfw_num_slots_enabled: false
+        enable: false
+        port: 9000
+        spark_master_host: 127.0.0.1
+        spark_master_webui_port: 8080
+      enable_service: false
+      exec: /opt/splunk/bin/splunk
+      group: splunk
+      hec:
+        cert: null
+        enable: true
+        password: null
+        port: 8088
+        ssl: true
+        token: 1b61a0cd-3f00-4261-a75e-ab5766c59860
+      home: /opt/splunk
+      http_enableSSL: false
+      http_enableSSL_cert: null
+      http_enableSSL_privKey: null
+      http_enableSSL_privKey_password: null
+      http_port: 8000
+      idxc:
+        label: idxc_label
+        pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
+        replication_factor: 3
+        replication_port: 9887
+        search_factor: 3
+        secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
+      launch: {}
+      license_download_dest: /tmp/splunk.lic
+      license_master_url: null
+      multisite_master_port: 8089
+      multisite_replication_factor_origin: 2
+      multisite_replication_factor_total: 3
+      multisite_search_factor_origin: 1
+      multisite_search_factor_total: 3
+      opt: /opt
+      pass4SymmKey: null
+      password: P/IrhvMEANXD58gpVuaJbtFAS+x0Q8y8
+      pid: /opt/splunk/var/run/splunk/splunkd.pid
+      root_endpoint: null
+      s2s:
+        ca: null
+        cert: null
+        enable: true
+        password: null
+        port: 9997
+        ssl: false
+      search_head_captain_url: null
+      secret: null
+      service_name: null
+      set_search_peers: true
+      shc:
+        label: shc_label
+        pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
+        replication_factor: 3
+        replication_port: 9887
+        secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
+      smartstore: null
+      svc_port: 8089
+      tar_dir: splunk
+      user: splunk
+      wildcard_license: false
+    splunk_home_ownership_enforcement: true
+    wait_for_splunk_retry_num: 60

--- a/roles/splunk_standalone/molecule/snowflake/group_vars/all.yml
+++ b/roles/splunk_standalone/molecule/snowflake/group_vars/all.yml
@@ -1,0 +1,28 @@
+---
+splunk:
+  role: splunk_standalone
+  build_location: https://download.splunk.com/products/splunk/releases/7.3.5/linux/splunk-7.3.5-86fd62efc3d7-Linux-x86_64.tgz
+  conf:
+  - key: user-prefs
+    value:
+      directory: /opt/splunk/etc/users/admin/user-prefs/local
+      content:
+        general:
+          default_namespace: appboilerplate
+          search_syntax_highlighting: dark
+          search_assistant:
+        "serverClass:secrets:app:test": {}
+  hec:
+    port: 8099
+    ssl: false
+    token: qwerty789
+  http_port: 8080
+  launch:
+    OPTIMISTIC_ABOUT_FILE_LOCKING: 1
+    TEST: A=B
+  password: helloworld2
+  root_endpoint: /splunkui
+  s2s:
+    port: 9999
+  secret: "pewpewpew"
+  svc_port: 8090

--- a/roles/splunk_standalone/molecule/snowflake/molecule.yml
+++ b/roles/splunk_standalone/molecule/snowflake/molecule.yml
@@ -18,122 +18,13 @@ platforms:
       - "/opt/splunk/var"
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_HASH_BEHAVIOUR: merge
   inventory:
-    hosts:
-      all:
-        vars:
-          ansible_post_tasks: null
-          ansible_pre_tasks: null
-          cert_prefix: https
-          dmc_asset_interval: 3,18,33,48 * * * *
-          dmc_forwarder_monitoring: false
-          hide_password: false
-          java_download_url: null
-          java_update_version: null
-          java_version: null
-          retry_delay: 6
-          retry_num: 60
-          shc_sync_retry_num: 60
-          splunk:
-            role: splunk_standalone
-            license_uri: null
-            preferred_captaincy: true
-            build_location: https://download.splunk.com/products/splunk/releases/7.3.5/linux/splunk-7.3.5-86fd62efc3d7-Linux-x86_64.tgz
-            ignore_license: true
-            apps_location: null
-            admin_user: admin
-            allow_upgrade: true
-            app_paths:
-              default: /opt/splunk/etc/apps
-              deployment: /opt/splunk/etc/deployment-apps
-              httpinput: /opt/splunk/etc/apps/splunk_httpinput
-              idxc: /opt/splunk/etc/master-apps
-              shc: /opt/splunk/etc/shcluster/apps
-            asan: false
-            build_url_bearer_token: null
-            cluster_master_url: null
-            conf:
-            - key: user-prefs
-              value:
-                directory: /opt/splunk/etc/users/admin/user-prefs/local
-                content:
-                  general:
-                    default_namespace: appboilerplate
-                    search_syntax_highlighting: dark
-                    search_assistant:
-                  "serverClass:secrets:app:test": {}
-            deployer_url: null
-            dfs:
-              dfc_num_slots: 4
-              dfw_num_slots: 10
-              dfw_num_slots_enabled: false
-              enable: false
-              port: 9000
-              spark_master_host: 127.0.0.1
-              spark_master_webui_port: 8080
-            enable_service: false
-            exec: /opt/splunk/bin/splunk
-            group: splunk
-            hec:
-              cert: null
-              enable: true
-              password: null
-              port: 8099
-              ssl: false
-              token: qwerty789
-            home: /opt/splunk
-            http_enableSSL: false
-            http_enableSSL_cert: null
-            http_enableSSL_privKey: null
-            http_enableSSL_privKey_password: null
-            http_port: 8080
-            idxc:
-              label: idxc_label
-              pass4SymmKey: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-              replication_factor: 3
-              replication_port: 9887
-              search_factor: 3
-              secret: Bh/lsn+CsqvmkXBhE9GtoXOWYNVbpTUV
-            launch:
-              OPTIMISTIC_ABOUT_FILE_LOCKING: 1
-              TEST: A=B
-            license_download_dest: /tmp/splunk.lic
-            license_master_url: null
-            multisite_master_port: 8089
-            multisite_replication_factor_origin: 2
-            multisite_replication_factor_total: 3
-            multisite_search_factor_origin: 1
-            multisite_search_factor_total: 3
-            opt: /opt
-            pass4SymmKey: null
-            password: helloworld2
-            pid: /opt/splunk/var/run/splunk/splunkd.pid
-            root_endpoint: /splunkui
-            s2s:
-              ca: null
-              cert: null
-              enable: true
-              password: null
-              port: 9999
-              ssl: false
-            search_head_captain_url: null
-            secret: "pewpewpew"
-            service_name: null
-            set_search_peers: true
-            shc:
-              label: shc_label
-              pass4SymmKey: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-              replication_factor: 3
-              replication_port: 9887
-              secret: g7DcnxHIA60dj86HWrh38VdaFYdXESw2
-            smartstore: null
-            svc_port: 8090
-            tar_dir: splunk
-            user: splunk
-            wildcard_license: false
-          splunk_home_ownership_enforcement: true
-          wait_for_splunk_retry_num: 60
+    links:
+      hosts: ../hosts.yml
+      group_vars: ./group_vars/
 verifier:
   name: testinfra
   options:
-    junit-xml: ../../../../tests/results/standalone-default-results.xml
+    junit-xml: ../../../../tests/results/standalone-snowflake-results.xml


### PR DESCRIPTION
This is a follow-up to https://github.com/splunk/splunk-ansible/pull/467#discussion_r420483444

I found there was an option to provide symlinks to files mapping to `hosts`, `group_vars`, and `host_vars`. The latter isn't used, but I'm taking advantage of the former 2 such that:
* All base variables are defined in a `hosts.yml` file
* All scenario-specific variables are defined in a `group_vars` directory and merged/overwritten on top of `hosts.yml`

The key thing I had to set was this `ANSIBLE_HASH_BEHAVIOUR: merge` - using the config option `hash_behaviour` didn't seem to work. 