### PR TITLE
Adding auxiliary_cluster_masters to enable search heads peering suppl…

### DIFF
--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -96,10 +96,10 @@ splunk:
     multisite_search_factor_total: 2
     license_master_url:
     cluster_master_url:
+    auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
     connection_timeout: 0
-
     enable_service: False
     service_name:
     smartstore:

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -88,6 +88,7 @@ splunk:
     multisite_search_factor_total: 2
     license_master_url:
     cluster_master_url:
+    auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
     connection_timeout: 180

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -69,14 +69,12 @@ splunk:
         cert:
         password:
     shc:
-        enable: False
         secret:
         pass4SymmKey:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
     idxc:
-        enable: False
         secret:
         pass4SymmKey:
         discoveryPass4SymmKey:
@@ -84,6 +82,15 @@ splunk:
         search_factor: 3
         replication_factor: 3
         replication_port: 9887
+    multisite_replication_factor_origin: 2
+    multisite_replication_factor_total: 3
+    multisite_search_factor_origin: 1
+    multisite_search_factor_total: 2
+    license_master_url:
+    cluster_master_url:
+    auxiliary_cluster_masters: []
+    search_head_captain_url:
+    deployer_url:
     connection_timeout: 0
     enable_service: False
     service_name:

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -69,14 +69,12 @@ splunk:
         cert:
         password:
     shc:
-        enable: False
         secret:
         pass4SymmKey:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
     idxc:
-        enable: False
         secret:
         pass4SymmKey:
         discoveryPass4SymmKey:
@@ -84,10 +82,15 @@ splunk:
         search_factor: 3
         replication_factor: 3
         replication_port: 9887
-    multisite_replication_factor_origin: 3
+    multisite_replication_factor_origin: 2
     multisite_replication_factor_total: 3
-    multisite_search_factor_origin: 3
-    multisite_search_factor_total: 3
+    multisite_search_factor_origin: 1
+    multisite_search_factor_total: 2
+    license_master_url:
+    cluster_master_url:
+    auxiliary_cluster_masters: []
+    search_head_captain_url:
+    deployer_url:
     connection_timeout: 180
     enable_service: False
     service_name:

--- a/roles/splunk_common/tasks/peer_cluster_master.yml
+++ b/roles/splunk_common/tasks/peer_cluster_master.yml
@@ -17,3 +17,18 @@
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
+
+# https://docs.splunk.com/Documentation/Splunk/latest/Indexer/Configuremulti-clustersearch
+- name: Set auxiliary cluster master peer
+  command: "{{ splunk.exec }} add cluster-master {{ item.url }} -secret '{{ item.pass4SymmKey }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  register: set_aux_cluster_master_peer
+  until: set_aux_cluster_master_peer.rc == 0
+  changed_when: set_aux_cluster_master_peer.rc == 0
+  with_items: "{{ splunk.auxiliary_cluster_masters }}"
+  when: "'auxiliary_cluster_masters' in splunk and splunk.auxiliary_cluster_masters and splunk.auxiliary_cluster_masters | length > 0"
+  ignore_errors: yes
+  notify:
+    - Restart the splunkd service
+  no_log: "{{ hide_password }}"


### PR DESCRIPTION
Fixes #464 

Adding a new variable to expose the ability to set additional cluster masters for search heads to search over. Note any masters defined here will *not* be the primary cluster master where the Splunk node forwarding data too - it's just for search.

Opening the PR to see if there are test failures, but I'll need to do some more extensive testing and docs. Essentially the YAML to add a cluster master would look like:
```
splunk:
  auxiliary_cluster_masters:
  - url: https://10.0.0.1:8089
     pass4SymmKey: thisisasecret
  - url: https://10.0.0.2:8089
     pass4SymmKey: thisisanothersecret
```