### PR TITLE
move splunk_launch.conf to before first launch

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -58,6 +58,10 @@
   when:
     - first_run | bool
 
+- include_tasks: set_launch_conf.yml
+  when:
+    - "'launch' in splunk and splunk.launch"
+
 - include_tasks: pre_splunk_start_commands.yml
   ignore_errors: true
   when:
@@ -67,10 +71,6 @@
   when:
     - "('s2s_enable' in splunk) or ('s2s' in splunk and 'enable' in splunk.s2s)"
     - "('s2s_port' in splunk and splunk.s2s_port) or ('s2s' in splunk and 'port' in splunk.s2s and splunk.s2s.port)"
-
-- include_tasks: set_launch_conf.yml
-  when:
-    - "'launch' in splunk and splunk.launch"
 
 - include_tasks: enable_service.yml
   when:


### PR DESCRIPTION
When attempting to use the splunk/splunk:latest docker image I ran into a problem. I use zfs on my system so I need to set  OPTIMISTIC_ABOUT_FILE_LOCKING = 1 in splunk_launch.conf. This has to happen before splunk launches or it will crash out. I had to move the splunk_launch.conf config to before the s2s setup as s2s will attempt to launch splunk.