### PR TITLE
Feature/apps v2 electric boogaloo

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -461,6 +461,11 @@ splunk:
     * Determine the secret used to configure search head clustering. This is REQUIRED when setting up search head clustering. This is pass4SymmKey in the `[shclustering]` stanza of server.conf.
     * Default: null
 
+    deployer_push_mode: <str>
+    * Change the strategy used by the deployer when bundling apps and distributing them across the search head cluster. The acceptable modes are: full, local_only, default_only, and merge_to_default (merge_to_default is the default unless otherwise specified).
+    * For more information, please see: https://docs.splunk.com/Documentation/Splunk/latest/DistSearch/PropagateSHCconfigurationchanges#Set_the_deployer_push_mode
+    * Default: null
+
   dfs:
     enable: <bool>
     * Enable Data Fabric Search (DFS)

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -74,6 +74,7 @@ splunk:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
+        deployer_push_mode:
     idxc:
         secret:
         pass4SymmKey:

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -74,6 +74,7 @@ splunk:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
+        deployer_push_mode:
     idxc:
         secret:
         pass4SymmKey:

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -75,6 +75,7 @@ splunk:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
+        deployer_push_mode:
     idxc:
         enable: False
         secret:

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -75,6 +75,7 @@ splunk:
         label: "shc_label"
         replication_factor: 3
         replication_port: 9887
+        deployer_push_mode:
     idxc:
         enable: False
         secret:

--- a/roles/splunk_common/tasks/copy_installed_apps.yml
+++ b/roles/splunk_common/tasks/copy_installed_apps.yml
@@ -1,9 +1,9 @@
 ---
 # TODO: Might be better to use synchronize here, but we'll need rsync installed
-# ESS requires installation on the local node before distributing the bundle out, which contains local
+# Copy everything over except local/app.conf because some apps are disabled after installation
 - name: "Copy installed apps to {{ dest }}"
   shell:
-    cmd: "set -o pipefail && tar -c {% if item not in ess_apps %}--exclude=local{% endif %} {{ item }} | tar -x -C {{ dest }}"
+    cmd: "set -o pipefail && tar -c --exclude=local/app.conf {{ item }} | tar -x -C {{ dest }}"
     chdir: "{{ splunk.app_paths.default }}"
     executable: /bin/bash
   become: yes

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -20,72 +20,70 @@
     - splunkbase_token != None
   no_log: "{{ hide_password }}"
 
-- name: Check app source
-  stat:
-    path: "{{ app_url }}"
-  register: app_source
-
-- name: Move generic app
-  command: "cp {{ app_url }} /tmp/app.spl"
-  when: app_source.stat.exists
-
-- name: Download generic app
-  get_url:
-    url: "{{ app_url }}"
-    dest: /tmp/app.spl
-    mode: 0777
-    timeout: 120
-    validate_certs: no
-    force: yes
-  when:
-    - "'splunkbase.splunk.com' not in app_url"
-    - app_url is match("^(https?|file)://.*")
-
-# Some premium apps require installation via untar command, while others can be installed normally.
-# We'll need to verify the contents of the package to see if it's a premium app
-
-- name: Check app contents
-  shell: "set -o pipefail && tar --exclude='*/*/*' --exclude='*.*' -tf /tmp/app.spl | awk -F'/' '{ print$1 }' | uniq"
-  args:
-    executable: /bin/bash
-  register: app_contents
+- name: Install generic app
   when: "'splunkbase.splunk.com' not in app_url"
+  block:
+  - name: Check local app
+    stat:
+      path: "{{ app_url }}"
+    register: app_local
 
-- name: Install app via extraction
-  unarchive:
-    src: "{% if 'http' in app_url %}/tmp/app.spl{% else %}{{ app_url }}{% endif %}"
-    dest: "{{ splunk.app_paths.default }}"
-    remote_src: true
-  become: yes
-  become_user: "{{ splunk.user }}"
-  no_log: "{{ hide_password }}"
-  when:
-    - "'splunkbase.splunk.com' not in app_url"
-    - "'itsi' in app_contents.stdout_lines"
-  notify:
-    - Restart the splunkd service
+  - name: Download remote app
+    get_url:
+      url: "{{ app_url }}"
+      dest: /tmp/
+      mode: 0777
+      timeout: 120
+      validate_certs: no
+      force: yes
+    register: app_remote
+    when:
+      - app_url is match("^(https?|file)://.*")
 
-- name: Install app via REST
-  uri:
-    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
-    method: POST
-    user: "{{ splunk.admin_user }}"
-    password: "{{ splunk.password }}"
-    validate_certs: false
-    body:
-      name: "/tmp/app.spl"
-      update: "true"
-      filename: "true"
-    body_format: "form-urlencoded"
-    status_code: [ 200, 201 ]
-    timeout: 90
-  when:
-    - "'splunkbase.splunk.com' not in app_url"
-    - "'itsi' not in app_contents.stdout_lines"
-  no_log: "{{ hide_password }}"
+  - name: Infer app filepath
+    set_fact:
+      app_filepath: "{% if 'http' in app_url %}{{ app_remote.dest }}{% else %}{{ app_local.stat.path }}{% endif %}"
 
-- name: Remove downloaded app
-  file:
-    dest: /tmp/app.spl
-    state: absent
-  ignore_errors: true
+  # ITSI require installation via extraction - others can be installed normally.
+  # Verify the contents of the package and check for ITSI
+  - name: Check app contents
+    shell: "set -o pipefail && tar --exclude='*/*/*' --exclude='*.*' -tf {{ app_filepath }} | awk -F'/' '{ print$1 }' | uniq"
+    args:
+      executable: /bin/bash
+    register: app_contents
+    when: "'splunkbase.splunk.com' not in app_url"
+
+  - name: Install app via extraction
+    unarchive:
+      src: "{{ app_filepath }}"
+      dest: "{{ splunk.app_paths.default }}"
+      remote_src: true
+    become: yes
+    become_user: "{{ splunk.user }}"
+    no_log: "{{ hide_password }}"
+    when:
+      - "'itsi' in app_contents.stdout_lines"
+      - app_remote is changed or app_local.stat.exists
+    notify:
+      - Restart the splunkd service
+
+  - name: Install app via REST
+    uri:
+      url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local"
+      method: POST
+      user: "{{ splunk.admin_user }}"
+      password: "{{ splunk.password }}"
+      validate_certs: false
+      body:
+        name: "{{ app_filepath }}"
+        update: "true"
+        filename: "true"
+      body_format: "form-urlencoded"
+      status_code: [ 200, 201 ]
+      timeout: 90
+    register: post_apps_local
+    changed_when: post_apps_local.status == 201
+    when:
+      - "'itsi' not in app_contents.stdout_lines"
+      - app_remote is changed or app_local.stat.exists
+    no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/set_general_symmkey_password.yml
+++ b/roles/splunk_common/tasks/set_general_symmkey_password.yml
@@ -4,5 +4,7 @@
     section: "general"
     option: "pass4SymmKey"
     value: "{{ splunk.pass4SymmKey }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
   notify:
     - Restart the splunkd service

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -18,6 +18,22 @@
   notify:
     - Restart the splunkd service
 
+# https://docs.splunk.com/Documentation/Splunk/latest/DistSearch/PropagateSHCconfigurationchanges#Set_the_deployer_push_mode
+- name: Set deployer push mode
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/system/configs/conf-app/shclustering"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    body:
+      deployer_push_mode: "{{ splunk.shc.deployer_push_mode }}"
+    body_format: "form-urlencoded"
+    status_code: 200
+    timeout: 10
+  when: "'deployer_push_mode' in splunk.shc and splunk.shc.deployer_push_mode"
+  no_log: "{{ hide_password }}"
+
 - name: Flush restart handlers
   meta: flush_handlers
 


### PR DESCRIPTION
Addressing #480

When copying apps from etc/apps (for deployer, deployment_server, and cluster_master roles only), we are currently ignoring everything in the `local` dir of each app. This is in part in-line with how Splunk expects apps, but also because these playbooks disable installed apps on these roles in order to prevent unwanted things enabled (ex: ESS ships with a lot of savedsearches enabled, which hinders the performance of the cluster master).

I'm slightly changing this behavior: now we include `local` but ignore `local/app.conf` to prevent copying the disabled=1 app.conf to downstream peers. 

I'm also introducing a way to configure the `deployer_push_mode` for finer granularity of how users want to merge their configurations. Since this change does support moving almost-everything in `local`, this can be used by the deployer to govern the existence of `local` configs in the bundle being distributed.