### PR TITLE
Multisite - Fix failing edit cluster-config on reschedule of search-head pods

### DIFF
--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -12,7 +12,8 @@
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_new_master
-  until: set_new_master.rc == 0
+  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." in set_new_master.stderr)
+  failed_when: set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." not in set_new_master.stderr
   changed_when: set_new_master.rc == 0
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"


### PR DESCRIPTION
This PR is related to the [PR for multisite indexer cluster support](https://github.com/splunk/splunk-operator/pull/99) on the splunk-operator for Kubernetes.
When connecting search-heads to a multisite indexer cluster using the splunk-operator, the ansible playbook works perfectly for the initial setup.
However, if a seach-head pod is rescheduled, the playbook fails on the "Setup SHC - Multisite" task, with error message "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead."
I am not sure if it is a best practice to rely on the error message to ignore the error, but I followed the pattern already used in the following task "Setup SHC with Associated Site".

