### PR TITLE
Adding extra stop condition on monitor; adding license check flags on…

### DIFF
--- a/roles/splunk_common/tasks/add_forward_server.yml
+++ b/roles/splunk_common/tasks/add_forward_server.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Enable forwarding to {{ forward_servers }}"
-  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s.port if splunk.s2s.port is defined else splunk.s2s_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  command: "{{ splunk.exec }} add forward-server {{ item }}:{{ splunk.s2s.port if splunk.s2s.port is defined else splunk.s2s_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} --accept-license --answer-yes --no-prompt"
   become: yes
   become_user: "{{ splunk.user }}"
   with_items: "{{ forward_servers }}"

--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -13,7 +13,7 @@
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_as_peer
-  until: set_as_peer.rc == 0
+  until: set_as_peer.rc == 0 or 'already exists' in set_as_peer.stderr
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
   changed_when: set_as_peer.rc == 0


### PR DESCRIPTION
The `{{ splunk.exec }} add forward-server` command can fail under a specific scenario where it's not a first-time run + Splunk has not started. This causes a prompt for the EULA acceptance, which isn't captured here. I'm wondering if we should just revert to generating the config ourselves, but that may be a future nice-to-have.

Adding an extra termination condition when the monitor adds search peers.