### PR TITLE
Fixing unparsed inventory error

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -21,6 +21,10 @@ action_warnings = False
 allow_world_readable_tmpfiles = True
 stderr_callback=debug
 stdout_callback=debug
+localhost_warning = False
+
+[inventory]
+unparsed_is_failed = True
 
 [privilege_escalation]
 become = true

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -69,7 +69,7 @@ $ docker cp . splcontainer:/tmp/splunk-ansible/
 
 2. Run the following command
 ```
-$ docker exec -it splcontainer bash -c 'cd /tmp/splunk-ansible; ansible-playbook --connection local site.yml --extra-vars "@default.yml"'
+$ docker exec -it splcontainer bash -c 'cd /tmp/splunk-ansible; ansible-playbook --inventory localhost, --connection local site.yml --extra-vars "@default.yml"'
 ```
 You should see streaming Ansible output in your terminal. Here is what is happening when you run the above command:
 * `ansible-playbook` command is invoked using the playbook `site.yml`


### PR DESCRIPTION
Addresses #532 

This was fixed by https://github.com/splunk/splunk-ansible/pull/518/files but I asked @sarahotis to revert it in her PR https://github.com/splunk/splunk-ansible/pull/521/files. The change I made broke something in the setup docs, which is fixed by the addition of a `--inventory localhost,`. 

I even made a comment to say I would revisit this but never did, so thanks to github issues for keeping me honest.