### PR TITLE
Remove clustering stanza for idxc and shc

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -122,6 +122,10 @@
 - include_tasks: enable_dsp.yml
   when: "'dsp' in splunk and 'enable' in splunk.dsp and splunk.dsp.enable"
 
+- include_tasks: remove_clustering.yml
+  when:
+    - splunk_indexer_cluster or splunk.role == "splunk_search_head"
+
 - include_tasks: start_splunk.yml
 
 - include_tasks: set_certificate_prefix.yml

--- a/roles/splunk_common/tasks/remove_clustering.yml
+++ b/roles/splunk_common/tasks/remove_clustering.yml
@@ -1,0 +1,18 @@
+---
+- name: Remove indexer clustering stanza in order to reconfigure
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: "clustering"
+    state: absent
+    owner: "{{ splunk.user }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Remove search head clustering stanza in order to reconfigure
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: "shclustering"
+    state: absent
+    owner: "{{ splunk.user }}"
+  become: yes
+  become_user: "{{ splunk.user }}"


### PR DESCRIPTION
Proposing a change to clean out the [clustering] & [shclustering] stanzas as a part of the role splunk_common's tasks. The indexer clustering and search head clustering role specific tasks will take care of populating these stanzas.

The change is required in situations when the container is restarted with persistent volumes. The clean start of a container is prevented as the Splunk instance on the pod uses the clustering stanzas(which persisted from previous runs) instead of using the newly read ansible variables from disk/env variables.