### PR TITLE
Increase the timeouts on API calls for Splunk HEC configuration

### DIFF
--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -16,7 +16,7 @@
       sslPassword: "{% if 'hec' in splunk and 'password' in splunk.hec and splunk.hec.password %}{{ splunk.hec.password }}{% endif %}"
     body_format: "form-urlencoded"
     status_code: 200
-    timeout: 10
+    timeout: 60
   no_log: "{{ hide_password }}"
 
 - name: Get existing HEC token
@@ -27,7 +27,7 @@
     password: "{{ splunk.password }}"
     validate_certs: false
     status_code: 200,404
-    timeout: 10
+    timeout: 60
   register: hec_token
   when: ('hec' in splunk and 'token' in splunk.hec) or ('hec_token' in splunk)
   no_log: "{{ hide_password }}"
@@ -41,7 +41,7 @@
     password: "{{ splunk.password }}"
     validate_certs: false
     status_code: 200,404
-    timeout: 10
+    timeout: 60
   register: delete_hec_token
   changed_when: delete_hec_token.status == 200
   when:
@@ -61,7 +61,7 @@
       token: "{% if 'hec' in splunk and 'token' in splunk.hec and splunk.hec.token %}{{ splunk.hec.token }}{% else %}{{ splunk.hec_token }}{% endif %}"
     body_format: "form-urlencoded"
     status_code: 201,409
-    timeout: 10
+    timeout: 60
   register: create_hec_token
   changed_when: create_hec_token.status == 201
   when: ('hec' in splunk and 'token' in splunk.hec and splunk.hec.token) or ('hec_token' in splunk and splunk.hec_token)


### PR DESCRIPTION
Hello,

I got some problems on different clustered environments in Kubernetes, running on different cloud infrastructure providers. Some indexer pods would not start because the ansible playbook was failing on this 10s timeout.

Our indexers are connecting to a license master. This is configured just before the HEC (at the end of the splunk_common role), and triggers a restart of the indexers. I assume that Splunk performs some tasks at restart (e.g. fsck) possibly causing the API to respond very slowly. One case was for instance occurred for instance after a complete Splunk site was shut down for infrastructure maintenance. After this operation, the API call was always reaching the timeout, causing playbook and pod failure (the indexers successfully restarted after this and reconnected to the master, but the readinessProbe of the pods depends on playbook success). After patching the timeout, they restarted successfully, with a response time of 18s on one instance. Other cases didn't have a so obvious cause for slow response time after restart.

I only hit this problem on the first task ```Setup global HEC```, but I thought that it would be safer to increase the timeout of all these API calls, to increase the chances that indexers successfully recover after heavy maintenance operations.