### PR TITLE
Changing internal environ parsing data structure from set to array

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -340,19 +340,22 @@ def getSplunkApps(vars_scope):
     """
     Determine the set of Splunk apps to install as union of defaults.yml and environment variables
     """
-    appSet = set()
+    appList = []
     if not "apps_location" in vars_scope["splunk"]:
         vars_scope["splunk"]["apps_location"] = []
     # From default.yml
     elif type(vars_scope["splunk"]["apps_location"]) == str:
-        appSet.update(vars_scope["splunk"]["apps_location"].split(","))
+        appList = vars_scope["splunk"]["apps_location"].split(",")
     elif type(vars_scope["splunk"]["apps_location"]) == list:
-        appSet.update(vars_scope["splunk"]["apps_location"])
+        appList = vars_scope["splunk"]["apps_location"]
     # From environment variables
     apps = os.environ.get("SPLUNK_APPS_URL")
     if apps:
-        appSet.update(apps.split(","))
-    vars_scope["splunk"]["apps_location"] = list(appSet)
+        apps = apps.split(",")
+        for app in apps:
+            if app not in appList:
+                appList.append(app)
+    vars_scope["splunk"]["apps_location"] = appList
 
 def getSecrets(vars_scope):
     """


### PR DESCRIPTION
Partially addressing #545, particularly around app installation order. Although it shouldn't matter, it seems like the installation order can impact other apps. I would hazard a guess as to say this is some problem with Splunk itself - adding an app with certain auth/proxy information might inherently cause subsequent API calls to take longer. Ideally this doesn't happen, but not sure if there's some setting in the app itself that controls this or a problem in Splunk. 

In any case, preserving order does seem to mitigate it, so that's as much as we can do here. 