### PR TITLE
Changing source for debian openjdk-8 package

### DIFF
--- a/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk8_jdk.yml
@@ -11,7 +11,7 @@
 - name: Adding source for Debian Buster
   lineinfile:
     path: /etc/apt/sources.list
-    line: deb http://ftp.us.debian.org/debian sid main
+    line: deb http://security.debian.org/debian-security stretch/updates main
   when:
     - ansible_distribution == 'Debian'
     - "'10' in ansible_distribution_version"


### PR DESCRIPTION
Something broke in this upstream openjdk that no longer makes it compatible with our base images. Changing out to a different source seems to fix it.