### PR TITLE
Handling errors when build_location is a none-type

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -71,7 +71,7 @@
   set_fact:
     splunk_current_version: "{{ manifests.files[0].path | regex_search(regexp, '\\1') if (manifests.matched == 1) else '0' }}"
     splunk_current_build_hash: "{{ manifests.files[0].path | regex_search(regexp, '\\3') if (manifests.matched == 1) else '0' }}"
-    splunk_target_build_hash: "{{ splunk.build_location | regex_search(regexp, '\\3') | default('0') }}"
+    splunk_target_build_hash: "{{ splunk.build_location | string | regex_search(regexp, '\\3') | default('0') }}"
   vars:
     regexp: 'splunk\D*?-(\d+\.\d+\.\d+(\.\d+)?)-(.*?)-.*?'
 


### PR DESCRIPTION
This can cause errors like this in certain environments:
```
TASK [splunk_common : Set current version fact]
fatal: [localhost]: FAILED! => {}

MSG:

Unexpected templating type error occurred on ({{ splunk.build_location | regex_search(regexp, '\\3') | default('0') }}): expected string or buffer
```