### PR TITLE
cspl-470: Always issue graceful restarts for Splunk service

### DIFF
--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Restart the splunkd service - Via CLI"
-  command: "{{ splunk.exec }} restart -f --answer-yes --accept-license"
+  command: "{{ splunk.exec }} restart --answer-yes --accept-license"
   become: yes
   become_user: "{{ splunk.user }}"
   register: task_result


### PR DESCRIPTION
Dirty restarts are causing the missing rawdata journal.gz files on S3