### PR TITLE
Splunk Monitor update distsearch.conf

### DIFF
--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -1,4 +1,42 @@
 ---
+- name: Fetch distsearch server info
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/servicesNS/nobody/search/configs/conf-distsearch/distributedSearch?output_mode=json"
+    method: GET
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    validate_certs: false
+    status_code: 200
+    return_content: yes
+    body_format: json
+  register: distsearch_server_info
+
+- name: Initialize current group list
+  set_fact:
+    current_group_list: []
+
+- name: Create list of current peers
+  set_fact:
+    current_group_list: "{{ current_group_list }} + [ '{{ item }}' ]"
+  with_items: "{{ distsearch_server_info['json']['entry'][0]['content']['servers'].split(',') }}"
+  when: distsearch_server_info['json']['entry'][0]['content']['servers'] is defined and (distsearch_server_info['json']['entry'][0]['content']['servers']| length > 0)
+
+- name: Remove search peers
+  command: "{{ splunk.exec }} remove search-server {{ item }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  register: remove_as_peer
+  until: remove_as_peer.rc == 0 or 'already exists' in remove_as_peer.stderr
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  changed_when: remove_as_peer.rc == 0
+  failed_when: remove_as_peer.rc != 0 and 'already exists' not in remove_as_peer.stderr
+  notify:
+    - Restart the splunkd service
+  no_log: "{{ hide_password }}"
+  with_items: "{{ current_group_list }}"
+  when: current_group_list is defined and (current_group_list| length > 0)
+
 - name: Create list of peers
   set_fact:
     group_list: "{{ groups['splunk_indexer'] | default([]) }} + {{ groups['splunk_search_head'] | default([]) }} + {{ groups['splunk_search_head_captain'] | default([]) }} + {{ groups['splunk_cluster_master'] | default([]) }} + {{ groups['splunk_deployment_server']| default([]) }} + {{ groups['splunk_license_master'] | default([]) }} + {{ groups['splunk_standalone'] | default([]) }}"

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -13,6 +13,12 @@
     - not splunk_search_head_cluster | bool
     - splunk.deployment_server is not defined or not splunk.deployment_server
 
+- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
+  when:
+    - splunk_indexer_cluster or splunk.multisite_master is defined
+    - splunk.set_search_peers is defined
+    - splunk.set_search_peers | bool
+
 - include_tasks: setup_multisite.yml
   when:
     - splunk.site is defined

--- a/roles/splunk_monitor/tasks/post_calls.yml
+++ b/roles/splunk_monitor/tasks/post_calls.yml
@@ -18,6 +18,7 @@
     body: "{{ item }}"
     validate_certs: false
     status_code: 201,409
+  register: distributed_groups
   loop:
     - "{{ dmc_group_cluster_master }}"
     - "{{ dmc_group_indexer }}"
@@ -26,6 +27,25 @@
     - "{{ dmc_group_license_master }}"
     - "{{ dmc_group_search_head }}"
     - "{{ dmc_group_shc_deployer }}"
+
+- name: Update DMC Groups
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/groups/{{ item }}/edit"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    body: "{{ item }}"
+    validate_certs: false
+    status_code: 201,409
+  loop:
+    - "{{ dmc_group_cluster_master }}"
+    - "{{ dmc_group_indexer }}"
+    - "{{ dmc_group_deployment_server }}"
+    - "{{ dmc_group_kv_store }}"
+    - "{{ dmc_group_license_master }}"
+    - "{{ dmc_group_search_head }}"
+    - "{{ dmc_group_shc_deployer }}"
+  when: distributed_groups.results[0].status == 409
 
 - name: Cluster Label POST Requests
   uri:
@@ -37,4 +57,17 @@
     validate_certs: false
     status_code: 201,409
   loop: "{{ cluster_label_list_of_dicts }}"
+  register: cluster_label
   when: cluster_label_list_of_dicts is defined and item.cluster_label | length > 0
+
+- name: Update Cluster Label POST Requests
+  uri:
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/groups"
+    method: POST
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    body: "member={{ item.name }}&default=false&name=dmc_indexerclustergroup_{{ item.cluster_label }}/edit"
+    validate_certs: false
+    status_code: 201,409
+  loop: "{{ cluster_label_list_of_dicts }}"
+  when: cluster_label_list_of_dicts is defined and item.cluster_label | length > 0 and cluster_label.results[0].status == 409

--- a/roles/splunk_monitor/tasks/setup_multisite.yml
+++ b/roles/splunk_monitor/tasks/setup_multisite.yml
@@ -1,0 +1,43 @@
+---
+- include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
+  vars:
+    splunk_instance_address: "{{ splunk.multisite_master }}"
+
+- name: Convert Extrenal Cluster Master Name into Internal URI
+  set_fact:
+      multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
+
+- name: Setup SH - Multisite
+  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  register: set_new_master
+  until: set_new_master.rc == 0 or (set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." in set_new_master.stderr)
+  failed_when: set_new_master.rc != 0 and "Cannot edit this searchhead. Use 'splunk edit cluster-master' to edit information for this searchhead." not in set_new_master.stderr
+  changed_when: set_new_master.rc == 0
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  ignore_errors: yes
+  notify:
+    - Restart the splunkd service
+  no_log: "{{ hide_password }}"
+
+- name: Flush restart handlers
+  meta: flush_handlers
+
+- include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_process.yml
+
+- name: Setup SH with Associated Site
+  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -multisite True"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  register: set_associated_site
+  until: set_associated_site.rc == 0 or (set_associated_site.rc == 22 and 'No change in master or secret or site' in set_associated_site.stderr)
+  changed_when: set_associated_site.rc == 0
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  ignore_errors: yes
+  notify:
+    - Restart the splunkd service
+  no_log: "{{ hide_password }}"
+  failed_when: set_associated_site.rc != 0 and 'No change in master or secret or site' not in set_associated_site.stderr


### PR DESCRIPTION
- Removing stale distributed peers info from distsearch.conf
- Updating dmc groups after they have been created