### PR TITLE
Fixing handling for empty peers list

### DIFF
--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -35,7 +35,7 @@
     use_proxy: no
   register: clusterMaster_peers_info
   no_log: "{{ hide_password }}"
-  when: splunk_indexer_cluster is defined or splunk.multisite_master is defined
+  when: splunk_indexer_cluster or splunk.multisite_master is defined
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
 
@@ -59,7 +59,7 @@
   register: distributed_info
   no_log: "{{ hide_password }}"
   when:
-    - splunk_indexer_cluster is defined or splunk.multisite_master
+    - splunk_indexer_cluster or splunk.multisite_master is defined
     - cluster_master_peers is defined and (cluster_master_peers | length > 0)
   until: distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Down') | map(attribute='name') | list | length == 0 and (cluster_master_peers[0] in (distributed_info['json']['entry'] | map(attribute='name') | list))
   retries: "{{ retry_num }}"

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -35,7 +35,7 @@
     use_proxy: no
   register: clusterMaster_peers_info
   no_log: "{{ hide_password }}"
-  when: splunk_indexer_cluster or splunk.multisite_master is defined
+  when: splunk_indexer_cluster is defined or splunk.multisite_master is defined
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
 
@@ -58,8 +58,10 @@
     use_proxy: no
   register: distributed_info
   no_log: "{{ hide_password }}"
-  when: splunk_indexer_cluster or splunk.multisite_master is defined
-  until: distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Down') | map(attribute='name') | list | length == 0 and cluster_master_peers is defined and (cluster_master_peers| length > 0) and (cluster_master_peers[0] in (distributed_info['json']['entry'] | map(attribute='name') | list))
+  when: 
+    - splunk_indexer_cluster is defined or splunk.multisite_master
+    - cluster_master_peers is defined and (cluster_master_peers | length > 0) 
+  until: distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Down') | map(attribute='name') | list | length == 0 and (cluster_master_peers[0] in (distributed_info['json']['entry'] | map(attribute='name') | list))
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
 

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -58,9 +58,9 @@
     use_proxy: no
   register: distributed_info
   no_log: "{{ hide_password }}"
-  when: 
+  when:
     - splunk_indexer_cluster is defined or splunk.multisite_master
-    - cluster_master_peers is defined and (cluster_master_peers | length > 0) 
+    - cluster_master_peers is defined and (cluster_master_peers | length > 0)
   until: distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Down') | map(attribute='name') | list | length == 0 and (cluster_master_peers[0] in (distributed_info['json']['entry'] | map(attribute='name') | list))
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"


### PR DESCRIPTION
Fixing an issue causing docker-splunk CI failures.

This edge case occurs when DMC is spun up with a CM that doesn't have any peers. 