### PR TITLE
Configure splunk.secret before first call to splunk status

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -42,11 +42,11 @@
   when:
     - java_version is defined and java_version
 
+# This needs to be done before any encrypted passkeys are generated, and before first call to splunk status
+- include_tasks: set_splunk_secret.yml
+
 - include_tasks: set_general_symmkey_password.yml
   when: "'pass4SymmKey' in splunk and splunk.pass4SymmKey"
-
-# This needs to be done before any encrypted passkeys are generated
-- include_tasks: set_splunk_secret.yml
 
 - include_tasks: enable_admin_auth.yml
 


### PR DESCRIPTION
In version 8.1.0.1 (not sure from which version this changed), the first call to ```splunk status``` generates a ```splunk.secret``` together with the ```sslPassword``` property in server.conf encrypted with it. ```splunk status``` is called [just before set_splunk_secret.yml](https://github.com/splunk/splunk-ansible/blob/dfae723d847175d532c50a8eeb21b6003c3ef973/roles/splunk_common/tasks/main.yml#L45) from task [set_general_symmkey_password.yml](https://github.com/splunk/splunk-ansible/blob/dfae723d847175d532c50a8eeb21b6003c3ef973/roles/splunk_common/tasks/set_general_symmkey_password.yml), through [trigger_restart.yml](https://github.com/splunk/splunk-ansible/blob/dfae723d847175d532c50a8eeb21b6003c3ef973/roles/splunk_common/tasks/trigger_restart.yml) and [get_splunk_status.yml](https://github.com/splunk/splunk-ansible/blob/dfae723d847175d532c50a8eeb21b6003c3ef973/roles/splunk_common/tasks/get_splunk_status.yml).

The impact is that Splunk fails to start as unable to decrypt the passphrase of the server SSL certificate private key:
* In ```var/log/splunk/splunkd_stderr.log``` is logged the messaged "Enter PEM pass phrase:"
* When just calling ```bin/splunk help```:
   ```
   Text decryption - error in finalizing: No errors in queue
   AES-GCM Decryption failed!
   Decryption operation failed: AES-GCM Decryption failed!
   ```

This makes the parameter ```splunk.secret``` of splunk-ansible unusable.

To fix this problem, ```set_splunk_secret.yml``` must be called before ```set_general_symmkey_password.yml```. We experienced the issue and tested this fix on two different environments managed with the splunk-operator (in Azure and private Openstack cloud). I also verified that the change was coming from ```splunk status```, forcing the call to ```/sbin/updateetc.sh``` and ```splunk status``` immediately at startup through docker exec with both ```8.0.6``` and ```8.1.0.1```. I observed with these tests that ```splunk.secret``` and ```sslPassword``` were not generated by ```splunk status``` with version ```8.0.6```.