### PR TITLE
Handling edge case of missing variable

### DIFF
--- a/roles/splunk_cluster_master/tasks/main.yml
+++ b/roles/splunk_cluster_master/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - splunk.deployment_server is not defined or not splunk.deployment_server
 
 - include_tasks: ../../../roles/splunk_common/tasks/set_as_deployment_client.yml
   when: splunk.deployment_server is defined and splunk.deployment_server
 
 - include_tasks: prepare_apps_bundle.yml
-  when: splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: initialize_cluster_master.yml
 
@@ -17,10 +17,10 @@
 # This installed_apps list gets mutated by ESS bundle generation, hence we
 # need to refresh this array of apps before disabling them all
 - include_tasks: ../../../roles/splunk_common/tasks/find_installed_apps.yml
-  when: splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: ../../../roles/splunk_common/tasks/disable_installed_apps.yml
-  when: splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: setup_multisite.yml
   when:

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -51,22 +51,20 @@
   delay: "{{ retry_delay }}"
   when:
     - splunk_search_head_cluster | bool
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - splunk.deployment_server is not defined or not splunk.deployment_server
 
 - include_tasks: ../../../roles/splunk_common/tasks/set_as_deployment_client.yml
   when: splunk.deployment_server is defined and splunk.deployment_server
 
 - include_tasks: push_apps_to_search_heads.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: ../../../roles/splunk_common/tasks/disable_installed_apps.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml

--- a/roles/splunk_deployment_server/tasks/main.yml
+++ b/roles/splunk_deployment_server/tasks/main.yml
@@ -2,8 +2,7 @@
 - include_tasks: ../../../roles/splunk_common/tasks/enable_forwarding.yml
 
 - include_tasks: create_deployment_apps.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - include_tasks: generate_server_classes.yml
 

--- a/roles/splunk_heavy_forwarder/tasks/main.yml
+++ b/roles/splunk_heavy_forwarder/tasks/main.yml
@@ -13,8 +13,7 @@
   when: splunk.add is defined
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - name: Execute Splunk commands
   command: "{{ splunk.exec }} {{ item }} -auth {{ splunk.admin_user }}:{{ splunk.password }}"

--- a/roles/splunk_indexer/tasks/main.yml
+++ b/roles/splunk_indexer/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - not splunk_indexer_cluster | bool
     - splunk.deployment_server is not defined or not splunk.deployment_server
 

--- a/roles/splunk_license_master/tasks/main.yml
+++ b/roles/splunk_license_master/tasks/main.yml
@@ -2,8 +2,7 @@
 - include_tasks: ../../splunk_common/tasks/enable_forwarding.yml
 
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 - name: Enable license master local indexing
   ini_file:

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -9,7 +9,7 @@
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - not splunk_search_head_cluster | bool
     - splunk.deployment_server is not defined or not splunk.deployment_server
 

--- a/roles/splunk_search_head/tasks/main.yml
+++ b/roles/splunk_search_head/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - not splunk_search_head_cluster | bool
     - splunk.deployment_server is not defined or not splunk.deployment_server
 

--- a/roles/splunk_standalone/tasks/main.yml
+++ b/roles/splunk_standalone/tasks/main.yml
@@ -36,7 +36,7 @@
 
 - include_tasks: ../../splunk_common/tasks/provision_apps.yml
   when:
-    - splunk.apps_location
+    - "'apps_location' in splunk and splunk.apps_location"
     - splunk.deployment_server is not defined or not splunk.deployment_server
 
 - include_tasks: ../../../roles/splunk_common/tasks/enable_dfs.yml

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -13,8 +13,7 @@
   when: splunk.add is defined
 
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
-  when:
-    - splunk.apps_location
+  when: "'apps_location' in splunk and splunk.apps_location"
 
 # Execute other Splunk commands
 - name: Execute Splunk commands


### PR DESCRIPTION
This PR corrects a small syntactical issue that some new users hit during onboarding. In this particular case, our setup docs don't work because of an excluded value in the `default.yml` which prevents Ansible from exiting cleanly. 