### PR TITLE
Support reading role from default.yml if available

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -124,7 +124,7 @@ def getDefaultVars():
     getSplunkdSSL(defaultVars)
     getDistributedTopology(defaultVars)
     getLicenses(defaultVars)
-    defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', 'splunk_standalone')
+    defaultVars["splunk"]["role"] = os.environ.get('SPLUNK_ROLE', defaultVars["splunk"].get("role") or "splunk_standalone")
     # Determine DMC settings
     defaultVars["dmc_forwarder_monitoring"] = os.environ.get('DMC_FORWARDER_MONITORING', False)
     defaultVars["dmc_asset_interval"] = os.environ.get('DMC_ASSET_INTERVAL', '3,18,33,48 * * * *')


### PR DESCRIPTION
Addressing #577

Out of the box, `splunk.role` is not set or defined. So this should still preserve the existing behavior of falling back to "splunk_standalone" while also adding the functionality to set the role via default.yml