### PR TITLE
Correcting response types after python3 migration

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -351,6 +351,8 @@ def getSplunkbaseToken(vars_scope):
         if resp.status_code != 200:
             raise Exception("Invalid Splunkbase credentials - will not download apps from Splunkbase")
         output = resp.content
+        if isinstance(output, bytes):
+            output = output.decode("utf-8", "ignore")
         splunkbase_token = re.search("<id>(.*)</id>", output, re.IGNORECASE)
         vars_scope["splunkbase_token"] = splunkbase_token.group(1) if splunkbase_token else None
 
@@ -644,7 +646,10 @@ def mergeDefaultsFromURL(vars_scope, url, headers=None, verify=False):
             resp = requests.get(url.format(hostname=HOSTNAME, platform=PLATFORM),
                                 headers=headers, timeout=max_timeout, verify=verify)
             resp.raise_for_status()
-            vars_scope = merge_dict(vars_scope, yaml.load(resp.content, Loader=yaml.Loader))
+            output = resp.content
+            if isinstance(output, bytes):
+                output = output.decode("utf-8", "ignore")
+            vars_scope = merge_dict(vars_scope, yaml.load(output, Loader=yaml.Loader))
             break
         except Exception as err:
             if unlimited_retries or current_retry < max_retries:

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -698,19 +698,24 @@ def test_getSplunkBuild(default_yml, os_env, build, build_url_bearer_token):
     assert vars_scope["splunk"]["build_location"] == build
     assert vars_scope["splunk"]["build_url_bearer_token"] == build_url_bearer_token
 
-@pytest.mark.parametrize(("default_yml", "trigger_splunkbase"),
+@pytest.mark.parametrize(("default_yml", "response_content", "trigger_splunkbase"),
                          [
-                            ({}, False),
-                            ({"splunkbase_username": "ocho"}, False),
-                            ({"splunkbase_password": "cinco"}, False),
-                            ({"splunkbase_username": "ocho", "splunkbase_password": "cinco"}, True),
-                            ({"splunkbase_username": "", "splunkbase_password": ""}, False),
+                            ({}, "<id>123abc</id>", False),
+                            ({"splunkbase_username": "ocho"}, "<id>123abc</id>", False),
+                            ({"splunkbase_password": "cinco"}, "<id>123abc</id>", False),
+                            ({"splunkbase_username": "ocho", "splunkbase_password": "cinco"}, "<id>123abc</id>", True),
+                            ({"splunkbase_username": "", "splunkbase_password": ""}, "<id>123abc</id>", False),
+                            ({}, "<id>123abc</id>", False),
+                            ({"splunkbase_username": "ocho"}, b"<id>123abc</id>", False),
+                            ({"splunkbase_password": "cinco"}, b"<id>123abc</id>", False),
+                            ({"splunkbase_username": "ocho", "splunkbase_password": "cinco"}, b"<id>123abc</id>", True),
+                            ({"splunkbase_username": "", "splunkbase_password": ""}, b"<id>123abc</id>", False),
                          ]
                         )
-def test_getSplunkbaseToken(default_yml, trigger_splunkbase):
+def test_getSplunkbaseToken(default_yml, response_content, trigger_splunkbase):
     vars_scope = default_yml
     with patch("environ.requests.post") as mock_post:
-        mock_post.return_value = MagicMock(status_code=200, content="<id>123abc</id>")
+        mock_post.return_value = MagicMock(status_code=200, content=response_content)
         with patch("os.environ", new=dict()):
             environ.getSplunkbaseToken(vars_scope)
         # Make sure Splunkbase token is populated when appropriate


### PR DESCRIPTION
This should address #604

Admittedly the CircleCI testing around this feature is poor since it interfaces directly with Splunkbase. I know a few folks are using this internally, but I don't think they're currently on python3 across the board. 