### PR TITLE
Set clientName for deployment client

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -173,6 +173,14 @@ splunk:
   * Hostname of Splunk Enterprise deployer instance. May be overridden using SPLUNK_DEPLOYER_URL environment variable.
   * Default: null
 
+  deployment_client: <dict>
+  * Deployment client object that configures `deployment-client` stanza of `deploymentclient.conf` file.
+  * Default: null
+
+    name: null
+    * Client name for deployment client. May be overridden using SPLUNK_DEPLOYMENT_CLIENT_NAME environment variable.
+    * Default: null
+
   search_head_captain_url: null
   * Hostname of Splunk Enterprise search head cluster captain instance. May be overridden using SPLUNK_SEARCH_HEAD_CAPTAIN_URL environment variable.
   * Default: null

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -559,7 +559,9 @@ def getUFSplunkVariables(vars_scope):
     if os.environ.get("SPLUNK_CMD"):
         vars_scope["splunk"]["cmd"] = os.environ.get("SPLUNK_CMD").split(",")
     if os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME"):
-        vars_scope["splunk"]["deployment_client"] = os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME")
+        vars_scope["splunk"]["deployment_client"] = {
+            "name": os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME")
+        }
 
 def getRandomString():
     """

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -558,6 +558,8 @@ def getUFSplunkVariables(vars_scope):
         vars_scope["splunk"]["before_start_cmd"] = os.environ.get("SPLUNK_BEFORE_START_CMD").split(",")
     if os.environ.get("SPLUNK_CMD"):
         vars_scope["splunk"]["cmd"] = os.environ.get("SPLUNK_CMD").split(",")
+    if os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME"):
+        vars_scope["splunk"]["deployment_client"] = os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME")
 
 def getRandomString():
     """

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -109,6 +109,8 @@ splunk:
     auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
+    deployment_client:
+        name:
     connection_timeout: 0
     enable_service: False
     disable_popups: False

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -101,6 +101,8 @@ splunk:
     auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
+    deployment_client:
+        name:
     connection_timeout: 180
     enable_service: False
     disable_popups: False

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -101,6 +101,8 @@ splunk:
     auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
+    deployment_client:
+        name:
     connection_timeout: 0
     enable_service: False
     disable_popups: False

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -101,6 +101,8 @@ splunk:
     auxiliary_cluster_masters: []
     search_head_captain_url:
     deployer_url:
+    deployment_client:
+        name:
     connection_timeout: 180
     enable_service: False
     disable_popups: False

--- a/roles/splunk_common/tasks/set_as_deployment_client.yml
+++ b/roles/splunk_common/tasks/set_as_deployment_client.yml
@@ -20,18 +20,20 @@
   ignore_errors: yes
   no_log: "{{ hide_password }}"
 
-- name: Set deployment client
+- name: Set deployment client name
   ini_file:
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     dest: "{{ splunk.home }}/etc/system/local/deploymentclient.conf"
     section: deployment-client
     option: "clientName"
-    value: "{{ splunk.deployment_client }}"
+    value: "{{ splunk.deployment_client.name }}"
   become: yes
   become_user: "{{ splunk.user }}"
   notify:
     - Restart the splunkd service
   ignore_errors: yes
   no_log: "{{ hide_password }}"
-  when: splunk.deployment_client is defined
+  when:
+    - splunk.deployment_client is defined and splunk.deployment_client
+    - splunk.deployment_client.name is defined and splunk.deployment_client.name

--- a/roles/splunk_common/tasks/set_as_deployment_client.yml
+++ b/roles/splunk_common/tasks/set_as_deployment_client.yml
@@ -19,3 +19,19 @@
     - Restart the splunkd service
   ignore_errors: yes
   no_log: "{{ hide_password }}"
+
+- name: Set deployment client
+  ini_file:
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    dest: "{{ splunk.home }}/etc/system/local/deploymentclient.conf"
+    section: deployment-client
+    option: "clientName"
+    value: "{{ splunk.deployment_client }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  notify:
+    - Restart the splunkd service
+  ignore_errors: yes
+  no_log: "{{ hide_password }}"
+  when: splunk.deployment_client is defined

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -912,28 +912,31 @@ def test_getDFS(default_yml, os_env, output):
     assert type(vars_scope["splunk"]["dfs"]["spark_master_webui_port"]) == int
     assert vars_scope["splunk"]["dfs"] == output
 
-@pytest.mark.parametrize(("os_env", "deployment_server", "add", "before_start_cmd", "cmd"),
+@pytest.mark.parametrize(("os_env", "deployment_server", "deployment_client", "add", "before_start_cmd", "cmd"),
                          [
-                            ({}, None, None, None, None),
+                            ({}, None, None, None, None, None),
                             # Check environment variable parameters
-                            ({"SPLUNK_DEPLOYMENT_SERVER": ""}, None, None, None, None),
-                            ({"SPLUNK_DEPLOYMENT_SERVER": "something"}, "something", None, None, None),
-                            ({"SPLUNK_ADD": ""}, None, None, None, None),
-                            ({"SPLUNK_ADD": "echo 1"}, None, ["echo 1"], None, None),
-                            ({"SPLUNK_ADD": "echo 1,echo 2"}, None, ["echo 1", "echo 2"], None, None),
-                            ({"SPLUNK_BEFORE_START_CMD": ""}, None, None, None, None),
-                            ({"SPLUNK_BEFORE_START_CMD": "echo 1"}, None, None, ["echo 1"], None),
-                            ({"SPLUNK_BEFORE_START_CMD": "echo 1,echo 2"}, None, None, ["echo 1", "echo 2"], None),
-                            ({"SPLUNK_CMD": ""}, None, None, None, None),
-                            ({"SPLUNK_CMD": "echo 1"}, None, None, None, ["echo 1"]),
-                            ({"SPLUNK_CMD": "echo 1,echo 2"}, None, None, None, ["echo 1", "echo 2"]),
+                            ({"SPLUNK_DEPLOYMENT_SERVER": ""}, None, None, None, None, None),
+                            ({"SPLUNK_DEPLOYMENT_SERVER": "something"}, "something", None, None, None, None),
+                            ({"SPLUNK_DEPLOYMENT_CLIENT_NAME": ""}, None, None, None, None, None),
+                            ({"SPLUNK_DEPLOYMENT_CLIENT_NAME": "client_name"}, None, "client_name", None, None, None),
+                            ({"SPLUNK_ADD": ""}, None, None, None, None, None),
+                            ({"SPLUNK_ADD": "echo 1"}, None, None, ["echo 1"], None, None),
+                            ({"SPLUNK_ADD": "echo 1,echo 2"}, None, None, ["echo 1", "echo 2"], None, None),
+                            ({"SPLUNK_BEFORE_START_CMD": ""}, None, None, None, None, None),
+                            ({"SPLUNK_BEFORE_START_CMD": "echo 1"}, None, None, None, ["echo 1"], None),
+                            ({"SPLUNK_BEFORE_START_CMD": "echo 1,echo 2"}, None, None, None, ["echo 1", "echo 2"], None),
+                            ({"SPLUNK_CMD": ""}, None, None, None, None, None),
+                            ({"SPLUNK_CMD": "echo 1"}, None, None, None, None, ["echo 1"]),
+                            ({"SPLUNK_CMD": "echo 1,echo 2"}, None, None, None, None, ["echo 1", "echo 2"]),
                          ]
                         )
-def test_getUFSplunkVariables(os_env, deployment_server, add, before_start_cmd, cmd):
+def test_getUFSplunkVariables(os_env, deployment_server, deployment_client, add, before_start_cmd, cmd):
     vars_scope = {"splunk": {}}
     with patch("os.environ", new=os_env):
         environ.getUFSplunkVariables(vars_scope)
     assert vars_scope["splunk"].get("deployment_server") == deployment_server
+    assert vars_scope["splunk"].get("deployment_client") == deployment_client
     assert vars_scope["splunk"].get("add") == add
     assert vars_scope["splunk"].get("before_start_cmd") == before_start_cmd
     assert vars_scope["splunk"].get("cmd") == cmd

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -919,7 +919,7 @@ def test_getDFS(default_yml, os_env, output):
                             ({"SPLUNK_DEPLOYMENT_SERVER": ""}, None, None, None, None, None),
                             ({"SPLUNK_DEPLOYMENT_SERVER": "something"}, "something", None, None, None, None),
                             ({"SPLUNK_DEPLOYMENT_CLIENT_NAME": ""}, None, None, None, None, None),
-                            ({"SPLUNK_DEPLOYMENT_CLIENT_NAME": "client_name"}, None, "client_name", None, None, None),
+                            ({"SPLUNK_DEPLOYMENT_CLIENT_NAME": "client_name"}, None, {"name": "client_name"}, None, None, None),
                             ({"SPLUNK_ADD": ""}, None, None, None, None, None),
                             ({"SPLUNK_ADD": "echo 1"}, None, None, ["echo 1"], None, None),
                             ({"SPLUNK_ADD": "echo 1,echo 2"}, None, None, ["echo 1", "echo 2"], None, None),


### PR DESCRIPTION
To address #612. If environment variable `SPLUNK_DEPLOYMENT_CLIENT_NAME` present, will populate `deploymentclient.conf` with:
```
[deployment-client]
...
clientName = ${SPLUNK_DEPLOYMENT_CLIENT_NAME}
```
No CLI command: 
* https://community.splunk.com/t5/Getting-Data-In/Can-I-set-the-clientName-in-deploymentclient-conf-through-the/m-p/227222
* https://docs.splunk.com/Documentation/Splunk/8.1.2/Admin/CLIadmincommands
so populating ini_file directly.