### PR TITLE
Fixing test failures from dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,27 +12,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run linting
-          command: make lint
-      - run:
-          name: Run py3k linting
-          command: make py3k-lint
-      - run:
-          name: Run small tests
-          command: make small-tests
-      - run:
-          name: Run large (molecule) tests
-          command: make large-tests
-      - store_artifacts:
-          path: tests/results
-          destination: tests/results
-      - store_test_results:
-          path: tests/results
-  py3k-splunk-ansible-test:
-    executor: circleci_xlarge
-    steps:
-      - checkout
-      - run:
           name: Setup Python3
           command: |
             pyenv global 2.7.18 3.7.8
@@ -57,4 +36,3 @@ workflows:
   run_tests:
     jobs:
       - splunk-ansible-test
-      - py3k-splunk-ansible-test

--- a/roles/splunk_common/tasks/install_splunk_yum.yml
+++ b/roles/splunk_common/tasks/install_splunk_yum.yml
@@ -1,5 +1,10 @@
 # added the environment section due to bug:
 # https://github.com/ansible/ansible/issues/18979
+- name: Import Splunk key
+  rpm_key:
+    key: https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub
+    state: present
+
 - name: Install Splunk (yum)
   yum:
     name: "{{ splunk.build_location }}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,10 +4,9 @@ pylint
 mock
 docker
 requests
-molecule==3.0.2
+molecule==3.0.8
 coverage
 caniusepython3
-ansible==2.10.0
+ansible==2.10.7
 ansible-lint>=4.2.0
 testinfra
-sh==1.12.14


### PR DESCRIPTION
Fixing the test failures from dependabot. 

Specific changes here are:
* Adding GPG key validation for yum installation
* Removing python2 testing from CircleCI
* Updating ansible dependency to 2.10.7