### PR TITLE
Adding force_basic_auth to reduce client requests

### DIFF
--- a/roles/splunk_cluster_master/tasks/generate_ess_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/generate_ess_bundle.yml
@@ -17,6 +17,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10

--- a/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
+++ b/roles/splunk_cluster_master/tasks/initialize_cluster_master.yml
@@ -5,6 +5,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: False
     body:
       name: "indexer_discovery"

--- a/roles/splunk_common/tasks/check_for_required_restarts.yml
+++ b/roles/splunk_common/tasks/check_for_required_restarts.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,404
     timeout: 10

--- a/roles/splunk_common/tasks/disable_popups.yml
+++ b/roles/splunk_common/tasks/disable_popups.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10
@@ -19,6 +20,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "{{ item.value }}"
     validate_certs: false
     status_code: 200,201,409

--- a/roles/splunk_common/tasks/enable_dfs.yml
+++ b/roles/splunk_common/tasks/enable_dfs.yml
@@ -5,6 +5,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       disabled: "false"
@@ -24,6 +25,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       dfc_num_slots: "{{ splunk.dfs.dfc_num_slots }}"
@@ -42,6 +44,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       phased_execution: "true"
@@ -59,6 +62,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     use_proxy: no
   register: check_dfs_job_extractor_result
@@ -71,6 +75,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       name: "search_optimization::dfs_job_extractor"
@@ -90,6 +95,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       enabled: "true"

--- a/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
+++ b/roles/splunk_common/tasks/enable_forwarder_monitoring.yml
@@ -9,6 +9,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,201
     timeout: 10
@@ -22,6 +23,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body:
       search: "{{ dmc_forwarder_build_assets.json['entry'][0]['content']['search'] }}"
       request.ui_dispatch_app: splunk_monitoring_console
@@ -41,6 +43,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,201
     use_proxy: no

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -5,6 +5,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       name: "{{ app_url }}"
@@ -75,6 +76,7 @@
       method: POST
       user: "{{ splunk.admin_user }}"
       password: "{{ splunk.password }}"
+      force_basic_auth: yes
       validate_certs: false
       body:
         name: "{{ app_filepath }}"

--- a/roles/splunk_common/tasks/licenses/enable_forwarder_license.yml
+++ b/roles/splunk_common/tasks/licenses/enable_forwarder_license.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,404
     timeout: 10
@@ -19,6 +20,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       is_active: 1

--- a/roles/splunk_common/tasks/licenses/enable_free_license.yml
+++ b/roles/splunk_common/tasks/licenses/enable_free_license.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,404
     timeout: 10
@@ -19,6 +20,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       is_active: 1

--- a/roles/splunk_common/tasks/premium_apps/configure_ess.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_ess.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10

--- a/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_itsi.yml
@@ -5,6 +5,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body: "name=itsi_admin&imported_roles=itoa_user&imported_roles=itoa_analyst&imported_roles=itoa_admin"
     headers:
@@ -27,6 +28,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body: "roles=itsi_admin&roles=admin"
     headers:

--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -7,6 +7,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       disabled: "{% if ('hec' in splunk and 'enable' in splunk.hec and splunk.hec.enable | bool) or ('hec_disabled' in splunk and not splunk.hec_disabled | bool) %}0{% else %}1{% endif %}"
@@ -26,6 +27,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,404
     timeout: 60
@@ -41,6 +43,7 @@
     method: DELETE
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200,404
     timeout: 60
@@ -58,6 +61,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       name: "splunk_hec_token"

--- a/roles/splunk_deployer/tasks/main.yml
+++ b/roles/splunk_deployer/tasks/main.yml
@@ -25,6 +25,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       deployer_push_mode: "{{ splunk.shc.deployer_push_mode }}"

--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     return_content: yes

--- a/roles/splunk_monitor/tasks/initialize_dmc.yml
+++ b/roles/splunk_monitor/tasks/initialize_dmc.yml
@@ -5,6 +5,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     return_content: yes
@@ -17,6 +18,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body:
       trigger_actions: true
       dispatch.auto_cancel: "{{ dmc_asset_build_full.json['entry'][0]['content']['dispatch.auto_cancel'] }}"
@@ -33,6 +35,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     return_content: yes
@@ -45,6 +48,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body:
       eai:data: "{{ settings.json['entry'][0]['content']['eai:data'] }}"
     body_format: "form-urlencoded"
@@ -58,6 +62,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body:
       configuredPeers: "{{ configured_peers }}"
       disabled: "{{ settings.json['entry'][0]['content']['disabled'] }}"
@@ -75,6 +80,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "author=Splunk&check_for_updates=1&configured=1&label=Monitoring+Console&version={{ settings.json['generator']['version'] }}&visible=1"
     validate_certs: false
     status_code: 200,201,409

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -10,6 +10,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10
@@ -28,6 +29,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10
@@ -51,6 +53,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10
@@ -71,6 +74,7 @@
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     status_code: 200
     timeout: 10

--- a/roles/splunk_monitor/tasks/post_calls.yml
+++ b/roles/splunk_monitor/tasks/post_calls.yml
@@ -15,6 +15,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "{{ item }}"
     validate_certs: false
     status_code: 201,409
@@ -35,6 +36,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "{{ item }}"
     validate_certs: false
     status_code: 201,409
@@ -55,6 +57,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "member={{ item.name }}&default=false&name=dmc_indexerclustergroup_{{ item.cluster_label }}"
     validate_certs: false
     status_code: 201,409
@@ -69,6 +72,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     body: "member={{ item.name }}&default=false&name=dmc_indexerclustergroup_{{ item.cluster_label }}/edit"
     validate_certs: false
     status_code: 201,409

--- a/roles/splunk_search_head/tasks/search_head_clustering.yml
+++ b/roles/splunk_search_head/tasks/search_head_clustering.yml
@@ -22,6 +22,7 @@
     method: POST
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
+    force_basic_auth: yes
     validate_certs: false
     body:
       preferred_captain: "{{ splunk_search_head_captain | bool | lower }}"


### PR DESCRIPTION
Per https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html#parameter-force_basic_auth, changing the default behavior on this option because it ends up in some unnecessary requests made to splunkd.

<img width="1193" alt="Screen Shot 2021-06-16 at 2 57 53 PM" src="https://user-images.githubusercontent.com/6201822/122437570-ae15e000-cf4e-11eb-9b16-af1227f2673c.png">
