### PR TITLE
ES App post setup should not fail on essinstall on resets

### DIFF
--- a/roles/splunk_common/tasks/premium_apps/configure_ess.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_ess.yml
@@ -20,6 +20,6 @@
   become_user: "{{ splunk.user }}"
   register: essinstall
   changed_when: essinstall.rc == 0
-  failed_when: essinstall.rc != 0
+  failed_when: essinstall.rc != 0 and 'Unknown search command' not in essinstall.stderr
   notify:
     - Restart the splunkd service


### PR DESCRIPTION
Once the ES app is installed, essinstall command is available for post-setup. Once the post-setup is done, the command is not available anymore. So, the Ansible should just ignore and continue for all Pod reset scenarios.

Ex:
1. Deployer is configured with the ES App.
2. Deployer installs the ES app locally, does the post-setup configuration, distributes to all the SHCs. By this time, the ES app is configured and deployed to all the SHC members, and everything is OK
3. Now, If the Deployer Pod resets for any reason, Ansible tries to do the post-setup again for the ES app, but can't find the essinstall command, so the Pod never comes up.