### PR TITLE
Set http_enableSSL to False if env var is used

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -255,7 +255,7 @@ def getSplunkWebSSL(vars_scope):
     """
     # TODO: Split this into its own splunk.http.* section
     splunk_vars = vars_scope["splunk"]
-    splunk_vars["http_enableSSL"] = bool(os.environ.get('SPLUNK_HTTP_ENABLESSL', splunk_vars.get("http_enableSSL")))
+    splunk_vars["http_enableSSL"] = os.environ.get('SPLUNK_HTTP_ENABLESSL', splunk_vars.get("http_enableSSL"))
     splunk_vars["http_enableSSL_cert"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_CERT', splunk_vars.get("http_enableSSL_cert"))
     splunk_vars["http_enableSSL_privKey"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_PRIVKEY', splunk_vars.get("http_enableSSL_privKey"))
     splunk_vars["http_enableSSL_privKey_password"] = os.environ.get('SPLUNK_HTTP_ENABLESSL_PRIVKEY_PASSWORD', splunk_vars.get("http_enableSSL_privKey_password"))

--- a/roles/splunk_common/tasks/enable_splunkweb_ssl.yml
+++ b/roles/splunk_common/tasks/enable_splunkweb_ssl.yml
@@ -4,7 +4,7 @@
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
     section: settings
     option: "enableSplunkWebSSL"
-    value: "True"
+    value: "{{ splunk.http_enableSSL }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     mode: 0660

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -93,7 +93,6 @@
 - include_tasks: enable_splunkweb_ssl.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"
-    - splunk.http_enableSSL | bool
 
 - include_tasks: enable_splunkd_ssl.yml
   when: "'ssl' in splunk and splunk.ssl"


### PR DESCRIPTION
### Problem

Splunk Ansible is not recognizing `SPLUNK_HTTP_ENABLESSL` properly and is setting `enableSplunkWebSSL` to `True` even when the Splunk containers Env contains `SPLUNK_HTTP_ENABLESSL=False` (CSPL-1231)

### Solution

The env variables are parsed via environ.py.  For `SPLUNK_HTTP_ENABLESSL` the code snippet is:
```
def getSplunkWebSSL(vars_scope):
    """
    Parse and set parameters to define Splunk Web accessibility
    """
    # TODO: Split this into its own splunk.http.* section
    splunk_vars = vars_scope["splunk"]
    splunk_vars["http_enableSSL"] = bool(os.environ.get('SPLUNK_HTTP_ENABLESSL', splunk_vars.get("http_enableSSL")))
...
```

This use of `bool(os.environ.get())` is incorrect.  When `os.environ.get()` finds that `SPLUNK_HTTP_ENABLESSL` exists, it returns the value of that env variable, which makes `bool()` return `True` regardless of what `SPLUNK_HTTP_ENABLESSL` is actually set to (in this case, `False`).

Since we already have a check for `None` in the splunk_common/main.yml tasks, this `bool()` is not needed and we do not need to force this variable to a bool.

Also, we can enhance the `enable_splunkweb_ssl.yml` task to set `enableSplunkWebSSL` to whatever `http_enableSSL` is set to if it is configured, True or False, and leave it as default via not configuring it if it doesn't exist.

### Unit Test

Using the following CR for the operator create an instance setting `SPLUNK_HTTP_ENABLESSL=False`:
```
apiVersion: enterprise.splunk.com/v2
kind: LicenseMaster
metadata:
  name: lm
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  image: docker.io/library/splunk-redhat-8:latest
  imagePullPolicy: IfNotPresent
  extraEnv:
    - name: SPLUNK_HTTP_ENABLESSL
      value: "false"
  defaults: |-
    splunk:
      http_enableSSL: 0
      ssl:
        enable: 0
```

Verify that the env variable is set:
```
jrybczynski:AppFramework$ kex-sc splunk-lm-license-master-0 
[splunk@splunk-lm-license-master-0 splunk]$ export -p
...
declare -x SPLUNK_HTTP_ENABLESSL="false"
...

```

Verify that SplunkWeb uses a nonSSL endpoint:
```
[splunk@splunk-lm-license-master-0 splunk]$ cat etc/system/local/web.conf 

[settings]
enableSplunkWebSSL = false

```
