### PR TITLE
CSPL-1368 Ensure splunk-ansible gracefully handles ES app upgrades

### DIFF
--- a/roles/splunk_common/tasks/premium_apps/configure_ess.yml
+++ b/roles/splunk_common/tasks/premium_apps/configure_ess.yml
@@ -1,4 +1,9 @@
 ---
+- name: Enable SplunkEnterpriseSecuriteSuite app
+  command: "{{ splunk.exec }} enable app SplunkEnterpriseSecuritySuite -auth {{ splunk.admin_user }}:{{ splunk.password }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
 - name: Get ESS version
   uri:
     url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/apps/local/SplunkEnterpriseSecuritySuite?output_mode=json"


### PR DESCRIPTION
Currently when attempting to install a new version of ES over an older version of ES through ansible on a SHC deployer or Cluster Manager, the "Run ESS post-install setup" task which is responsible for running the essinstall command will fail.

The failure occurs because ansible will disable the SplunkEnterpriseSecurity app on the deployer and cluster manager instances as one of the last steps of the initial install. This means that when the "Run ESS post-install setup" is attempted during the upgrade, the SplunkEnterpriseSecuritySuite app is in the disabled state, and the essinstall command cannot be found and therefore executed.

Fix: The simple fix for this is to add one more task to configure_ess.yml to ensure the SplunkEnterpriseSecuritySuite app is enabled prior to attempting to run essinstall.