### PR TITLE
Monitor Bug: MC to install apps when SHC is present

### DIFF
--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -10,7 +10,6 @@
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
     - "'apps_location' in splunk and splunk.apps_location"
-    - not splunk_search_head_cluster | bool
     - splunk.deployment_server is not defined or not splunk.deployment_server
   vars:
     app_list: "{{ splunk.apps_location }}"
@@ -18,8 +17,6 @@
 - include_tasks: ../../../roles/splunk_common/tasks/provision_apps.yml
   when:
     - "'app_paths_install' in splunk and 'default' in splunk.app_paths_install and splunk.app_paths_install.default"
-    - not splunk_search_head_cluster | bool
-    - splunk.deployment_server is not defined or not splunk.deployment_server
   vars:
     app_list: "{{ splunk.app_paths_install.default }}"
 


### PR DESCRIPTION
Related to Splunk Operator bug CSPL-1375
For the monitor role what we tested that if the monitor was present with shc, it was not downloading the apps because this condition was getting true `- not splunk_search_head_cluster | bool`  and when this condition becomes true is `splunk_search_head_cluster: "{{ True if 'search_head_captain_url' in splunk and splunk.search_head_captain_url else False }}"`
For monitor `search_head_captain_url` can be present, to configure the monitor, but it would NOT be a part of shc so this condition is not needed for the monitor role