### PR TITLE
CSPL-1685 Removing paging for splunk_monitor tasks

### DIFF
--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Fetch clusterMaster peers
   uri:
-    url: "{{ cert_prefix }}://{{ splunk.cluster_master_url }}:{{ splunk.svc_port }}/services/cluster/master/peers?output_mode=json"
+    url: "{{ cert_prefix }}://{{ splunk.cluster_master_url }}:{{ splunk.svc_port }}/services/cluster/master/peers?output_mode=json&count=0"
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -49,7 +49,7 @@
 
 - name: Fetch distributed peers when cm is defined
   uri:
-    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/peers?output_mode=json"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/peers?output_mode=json&count=0"
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
@@ -70,7 +70,7 @@
 
 - name: Fetch distributed peers
   uri:
-    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/peers?output_mode=json"
+    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/search/distributed/peers?output_mode=json&count=0"
     method: GET
     user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"


### PR DESCRIPTION
### Problem
Tasks within the splunk_monitor role fails due to pagination on REST APIs for fetching cluster members.  Namely when we collect the distribute search peers list and spot check it against the cluster master member list, this can fail due to the lists being in different orders and ansible only grabbing the first 30 (default) results.  

We do not check that the full lists are the same, only spot check that the first entry in the CM peer list is in the distributed search list.  This is by design as once this peer is in each list, all peers should be available in the list.  If this assumption is incorrect we can add additional logic in the future to better check all peers.

### Solution
Add parameter `count=0` to the REST API call to allow for the maximum results in a single response so no pagination is needed.

### Unit Test

 - Validate the the MC comes up properly with fixed ansible image:

```
NAME                                  READY   STATUS    RESTARTS   AGE     
splunk-cm-aws-cluster-master-0        1/1     Running   0          6h43m
splunk-default-monitoring-console-0   1/1     Running   0          6h31m
splunk-idc-aws-indexer-0              1/1     Running   0          6h41m
splunk-idc-aws-indexer-1              1/1     Running   0          6h41m
splunk-idc-aws-indexer-2              1/1     Running   0          6h41m
splunk-lm1-license-master-0           1/1     Running   0          6h43m
splunk-operator-6fc84675d7-2ggzw      1/1     Running   0          34h 
```

 - Validate that the counts don't require paging: 

```
TASK [splunk_monitor : Fetch clusterMaster peers] *****************************************************************************************************************
task path: /opt/ansible/roles/splunk_monitor/tasks/main.yml:26
ok: [localhost] => {
    "cache_control": "no-store, no-cache, must-revalidate, max-age=0",
    "changed": false,
    "connection": "Close",
    "content": "{\"links\":{\"create\":\"/services/cluster/master/peers/_new\"},\"origin\":\"https://splunk-cm-aws-cluster-master-service:8089/services/cluster/master/peers\",\"updated\":\"2022-04-05T23:10:34+00:00\",\"generator\":{\"build\":\"77015bc7a462\",\"version\":\"8.2.5\"},\"entry\":[{\"name\":\"311B0932-145C-4156-A4BB-55EEFF604724\",\"id\":\"https://splunk-cm-aws-cluster-master-
...<snip>...{\"PendingSearchable\":0,\"PendingUnsearchable\":0,\"Searchable\":10,\"SearchablePendingMask\":0,\"Unknown\":0,\"Unsearchable\":0},\"site\":\"default\",\"splunk_version\":\"8.2.5\",\"status\":\"Up\",\"status_counter\":{\"Complete\":4,\"NonStreamingTarget\":0,\"PendingDiscard\":0,\"PendingTruncate\":0,\"StreamingError\":0,\"StreamingSource\":2,\"StreamingTarget\":4,\"Unset\":0},\"summary_replication_count\":0,\"transient_job_count\":0}}],\"paging\":{\"total\":3,\"perPage\":10000000,\"offset\":0},\"messages\":[]}",
...<snip>...
    "invocation": {
        "module_args": {
            "attributes": null,
            "body": null,
...<snip>...
            "unsafe_writes": false,
            "url": "https://splunk-cm-aws-cluster-master-service:8089/services/cluster/master/peers?output_mode=json&count=0",
...<snip>...
```

```
TASK [splunk_monitor : Fetch distributed peers when cm is defined] ************************************************************************************************
task path: /opt/ansible/roles/splunk_monitor/tasks/main.yml:50
ok: [localhost] => {
    "attempts": 1,
    "cache_control": "no-store, no-cache, must-revalidate, max-age=0",
    "changed": false,
    "connection": "Close",
    "content": "{\"links\":{\"create\":\"/services/search/distributed/peers/_new\",\"_reload\":\"/services/search/distributed/peers/_reload\"},\"origin\":\"https://127.0.0.1:8089/services/search/distributed/peers\",\"updated\":\"2022-04-05T23:10:35+00:00\",\"generator\":{\"build\":\"77015bc7a462\",\"version\":\"8.2.5\"},\"entry\":[{\"name\":\"192.168.28.31:8089\",\"id\":\"https://127.0.0.1:8089/services/search/distributed/peers/192.168.28.31%3A8089\",\"updated\":\"1970-01-01T00:00:00+00:00\",\"links\":{\"alternate\":\"/services/search/distributed/peers/192.168.28.31%3A8089\",\"list\":\"/services/search/distributed/peers/
...<snip>...
\"replicationStatus\":\"Successful\",\"rtsearch_enabled\":true,\"search_groups\":[\"dmc_group_indexer\",\"dmc_group_license_master\"],\"searchable_indexes\":[\"_audit\",\"_internal\",\"_introspection\",\"_metrics\",\"_metrics_rollup\",\"_telemetry\",\"_thefishbucket\",\"history\",\"main\",\"summary\"],\"server_roles\":[\"indexer\",\"license_master\",\"kv_store\"],\"shcluster_label\":\"\",\"startup_time\":1649198611,\"status\":\"Up\",\"status_details\":[],\"version\":\"8.2.5\"}}],\"paging\":{\"total\":5,\"perPage\":10000000,\"offset\":0},\"messages\":[]}",
    "content_length": "12236",
...<snip>...
    "invocation": {
        "module_args": {
            "attributes": null,
            "body": null,
...<snip>...
            "unix_socket": null,
            "unsafe_writes": false,
            "url": "https://127.0.0.1:8089/services/search/distributed/peers?output_mode=json&count=0",
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
...<snip>...
```

```
TASK [splunk_monitor : Fetch distributed peers] *******************************************************************************************************************
task path: /opt/ansible/roles/splunk_monitor/tasks/main.yml:71
ok: [localhost] => {
    "attempts": 1,
    "cache_control": "no-store, no-cache, must-revalidate, max-age=0",
    "changed": false,
    "connection": "Close",
    "content": "{\"links\":{\"create\":\"/services/search/distributed/peers/_new\",\"_reload\":\"/services/search/distributed/peers/_reload\"},\"origin\":\"https://127.0.0.1:8089/services/search/distributed/peers\",\"updated\":\"2022-04-05T23:10:36+00:00\",\"generator\":{\"build\":\"77015bc7a462\",\"version\":\"8.2.5\"},\"entry\":[{\"name\":\"192.168.28.31:8089\",\"id\":\"https://127.0.0.1:8089/services/search/distributed/peers/192.168.28.31%3A8089\",\"updated\":\"1970-01-01T00:00:00+00:00\",\"links\":{\"alternate\":\"/services/search/distributed/peers/192.168.28.31%3A8089\",\"list\":\"/services/search/distributed/peers/192.168.28.31%3A8089\",\"_reload\":\"/services/search/distributed/peers/192.168.28.31%3A8089/_reload\",\"edit\":\"/services/search/
...<snip>...
\"replicationStatus\":\"Successful\",\"rtsearch_enabled\":true,\"search_groups\":[\"dmc_group_indexer\",\"dmc_group_license_master\"],\"searchable_indexes\":[\"_audit\",\"_internal\",\"_introspection\",\"_metrics\",\"_metrics_rollup\",\"_telemetry\",\"_thefishbucket\",\"history\",\"main\",\"summary\"],\"server_roles\":[\"indexer\",\"license_master\",\"kv_store\"],\"shcluster_label\":\"\",\"startup_time\":1649198611,\"status\":\"Up\",\"status_details\":[],\"version\":\"8.2.5\"}}],\"paging\":{\"total\":5,\"perPage\":10000000,\"offset\":0},\"messages\":[]}",
    "content_length": "12236",
...<snip>...
    "invocation": {
        "module_args": {
            "attributes": null,
            "body": null,
...<snip>...
            "unix_socket": null,
            "unsafe_writes": false,
            "url": "https://127.0.0.1:8089/services/search/distributed/peers?output_mode=json&count=0",
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
...<snip>...
```
