### PR TITLE
CSPL-1132: Allow disabling splunk web with http_port=0

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -75,7 +75,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNK_APPS_URL | Pass in a comma-separated list of local paths or remote URLs to Splunk apps that will get installed | no | no | no |
 | SPLUNKBASE_USERNAME | Splunkbase username used for authentication when installing an app from [Splunkbase](https://splunkbase.splunk.com/) | no | no | no |
 | SPLUNKBASE_PASSWORD | Splunkbase password used for authentication when installing an app from [Splunkbase](https://splunkbase.splunk.com/) | no | no | no |
-| SPLUNK_HTTP_PORT | Port to run SplunkWeb on. Default: `8000` | no | no | no |
+| SPLUNK_HTTP_PORT | Port to run SplunkWeb on. To disable SplunkWeb, set to `0`. Default: `8000` | no | no | no |
 | SPLUNK_HTTP_ENABLESSL | Enable HTTPS on SplunkWeb | no | no | no |
 | SPLUNK_HTTP_ENABLESSL_CERT | Path to SSL certificate used for SplunkWeb, if HTTPS is enabled | no | no | no |
 | SPLUNK_HTTP_ENABLESSL_PRIVKEY | Path to SSL private key used for SplunkWeb, if HTTPS is enabled | no | no | no |

--- a/roles/splunk_common/tasks/set_http_port.yml
+++ b/roles/splunk_common/tasks/set_http_port.yml
@@ -1,4 +1,14 @@
 ---
+- name: Disable Web UI
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: "startwebserver"
+    value: "{{ splunk.http_port }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when: splunk.http_port == 0
+
 - name: Set HTTP Port
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
@@ -7,3 +17,4 @@
     value: "{{ splunk.http_port }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
+  when: splunk.http_port != 0


### PR DESCRIPTION
### Problem

There is no simple way to disable SplunkWeb aside from adding an app with the `startwebserver = 0` to web.conf.

### Solution

Utilize the http_port variable that sets the port for the web server and if this is set to 0, disable the webserver.

### Unit Test

Verify when no `http_port` is set that the default is enabled on 8000:
```
apiVersion: enterprise.splunk.com/v2
kind: Standalone
metadata:
  name: blank
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
```
```
[splunk@splunk-blank-standalone-0 splunk]$ cat etc/system/local/web.conf 

[settings]
enableSplunkWebSSL = 0
...
AppFramework$ kubectl port-forward splunk-blank-standalone-0 8000:8000
Forwarding from 127.0.0.1:8000 -> 8000
Forwarding from [::1]:8000 -> 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
```
<img width="1201" alt="default_http_port" src="https://user-images.githubusercontent.com/32111934/169892337-ef034b61-610e-4d47-a7c2-ed02ec4fc5c4.png">

Verify that when set `http_port` is set that the web server is abled on the specified port:

```
apiVersion: enterprise.splunk.com/v2
kind: Standalone
metadata:
  name: blank
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
  extraEnv:
  - name: SPLUNK_HTTP_PORT
    value: "8765"
```
```
[splunk@splunk-blank-standalone-0 splunk]$ cat etc/system/local/web.conf 

[settings]
httpport = 8765
enableSplunkWebSSL = 0
...
AppFramework$ kubectl port-forward splunk-blank-standalone-0 8765:8765
Forwarding from 127.0.0.1:8765 -> 8765
Forwarding from [::1]:8765 -> 8765
Handling connection for 8765
Handling connection for 8765
Handling connection for 8765
Handling connection for 8765
Handling connection for 8765
```
<img width="1198" alt="http_port_nondefault" src="https://user-images.githubusercontent.com/32111934/169892582-96f4b646-942a-44e5-b45d-41f354d77162.png">

Verify that when `http_port =0` that the web server is disabled:
```
apiVersion: enterprise.splunk.com/v2
kind: Standalone
metadata:
  name: blank
  finalizers:
  - enterprise.splunk.com/delete-pvc
spec:
  replicas: 1
  - name: SPLUNK_HTTP_PORT
    value: "0"
```
```
splunk-blank-standalone-0             1/1     Running   0          3m39s
```
<img width="1276" alt="http_port_0_web_server_disabled" src="https://user-images.githubusercontent.com/32111934/169892614-08a65e66-2478-4cbf-b887-7b9dde32bb67.png">

```
AppFramework$ kubectl port-forward splunk-blank-standalone-0 8000:8000
Forwarding from 127.0.0.1:8000 -> 8000
Forwarding from [::1]:8000 -> 8000
Handling connection for 8000
E0523 12:10:06.847413   40483 portforward.go:406] an error occurred forwarding 8000 -> 8000: error forwarding port 8000 to pod a643dfc9de873e641d819a931891a790e88816064f8b158a63c1f417fa7d8805, uid : exit status 1: 2022/05/23 19:10:06 socat[28528] E connect(5, AF=2 127.0.0.1:8000, 16): Connection refused
E0523 12:10:06.848464   40483 portforward.go:234] lost connection to pod
AppFramework$ kex-sc pod/splunk-blank-standalone-0
[splunk@splunk-blank-standalone-0 splunk]$ cat etc/system/local/web.conf 

[settings]
startwebserver = 0
enableSplunkWebSSL = 0
```