### PR TITLE
Draft: Add play to set cpu/vcpu and memory limits

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -113,6 +113,7 @@ def getDefaultVars():
     getASan(defaultVars)
     getDisablePopups(defaultVars)
     getHEC(defaultVars)
+    getCpuMemLimits(defaultVars)
     getSecrets(defaultVars)
     getSplunkPaths(defaultVars)
     getIndexerClustering(defaultVars)
@@ -422,6 +423,14 @@ def getSplunkAppPathInstall(vars_scope):
                     appList = vars_scope["splunk"]["app_paths_install"][path]
 
             vars_scope["splunk"]["app_paths_install"][path] = appList
+
+def getCpuMemLimits(vars_scope):
+    """
+    Get the configured max cpu, vcpu, and system memory
+    """
+    vars_scope["splunk"]["total_cpus"] = os.environ.get("SPLUNK_MAX_CPUS", vars_scope["splunk"].get("total_cpus"))
+    vars_scope["splunk"]["total_vcpus"] = os.environ.get("SPLUNK_MAX_VCPUS", vars_scope["splunk"].get("total_vcpus"))
+    vars_scope["splunk"]["total_sys_memory"] = os.environ.get("SPLUNK_MAX_SYSMEM", vars_scope["splunk"].get("total_sys_memory"))
 
 def getSecrets(vars_scope):
     """

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -118,6 +118,10 @@
     - (splunk.role != "splunk_standalone" and splunk.role != "splunk_search_head") or
         (splunk_indexer_cluster | bool or splunk_forward_servers is defined)
 
+- include_tasks: set_cpusysmem_limits.yml
+  when:
+    - "('total_cpus' in splunk) or ('total_vcpus' in splunk) or ('total_sys_memory' in splunk)"
+
 - include_tasks: enable_dsp.yml
   when: "'dsp' in splunk and 'enable' in splunk.dsp and splunk.dsp.enable"
 

--- a/roles/splunk_common/tasks/set_cpusysmem_limits.yml
+++ b/roles/splunk_common/tasks/set_cpusysmem_limits.yml
@@ -1,0 +1,36 @@
+---
+- name: Set CPU limit
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/limits.conf"
+    section: default
+    option: "total_cpus"
+    value: "{{ splunk.total_cpus }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when:
+    - splunk.total_cpus is defined
+    - splunk.total_cpus != 0
+
+- name: Set vCPU limit
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/limits.conf"
+    section: default
+    option: "total_vcpus"
+    value: "{{ splunk.total_vcpus }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when:
+    - splunk.total_vcpus is defined
+    - splunk.total_vcpus != 0
+
+- name: Set system memory limit
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/limits.conf"
+    section: default
+    option: "total_sys_memory"
+    value: "{{ splunk.total_sys_memory }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when:
+    - splunk.total_sys_memory is defined
+    - splunk.total_sys_memory != 0


### PR DESCRIPTION
Ansible plays to setup experimental cpu, vcpu, and system memory limits in splunk.