### PR TITLE
CSPL-2088: [Splunk 9.0.x]KV store fails to come up on a pod reset

### DIFF
--- a/roles/splunk_common/tasks/get_splunk_status.yml
+++ b/roles/splunk_common/tasks/get_splunk_status.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Restrict permissions on splunk.key for Status"
+  include_tasks: restrict_permissions.yml
+  vars:
+    file_path: "{{ item }}"
+  with_items:
+    - "{{ splunk.home }}/var/lib/splunk/kvstore/mongo/splunk.key"
+
 - name: Get Splunk status
   command: "{{ splunk.exec }} status --accept-license --answer-yes --no-prompt"
   become: yes

--- a/roles/splunk_common/tasks/restrict_permissions.yml
+++ b/roles/splunk_common/tasks/restrict_permissions.yml
@@ -10,7 +10,7 @@
 
 - name: "Restrict permissions on {{ file_path }}"
   file:
-    mode: "go-rwx"
+    mode: u+rw,g-rwx,o-rwx
     path: "{{ file_path }}"
   become: yes
   become_user: "{{ splunk.user }}"


### PR DESCRIPTION
When a Pod resets, a new pod comes up and uses the same persistent `etc` and `var` locations. Pod reset causes the file permissions to change. Open permissions on `var/lib/splunk/kvstore/mongo/splunk.key` causing the Mongod 4.2.17 to NOT come up during the migration path, that way the mongod is marked to start with 3.6.x, and that fails forever as the existing mongod db is already 4.2.x compatiable.