### PR TITLE
Revert "Fix Typo and Update Multisite SHC Setup"

### DIFF
--- a/roles/splunk_cluster_master/tasks/setup_multisite.yml
+++ b/roles/splunk_cluster_master/tasks/setup_multisite.yml
@@ -3,7 +3,7 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
 
-- name: Convert External Cluster Master Name into Internal URI
+- name: Convert Extrenal Cluster Master Name into Internal URI
   set_fact:
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 

--- a/roles/splunk_indexer/tasks/setup_multisite.yml
+++ b/roles/splunk_indexer/tasks/setup_multisite.yml
@@ -3,7 +3,7 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
 
-- name: Convert External Cluster Master Name into Internal URI
+- name: Convert Extrenal Cluster Master Name into Internal URI
   set_fact:
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 

--- a/roles/splunk_monitor/tasks/setup_multisite.yml
+++ b/roles/splunk_monitor/tasks/setup_multisite.yml
@@ -3,7 +3,7 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
 
-- name: Convert External Cluster Master Name into Internal URI
+- name: Convert Extrenal Cluster Master Name into Internal URI
   set_fact:
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 

--- a/roles/splunk_search_head/tasks/setup_multisite.yml
+++ b/roles/splunk_search_head/tasks/setup_multisite.yml
@@ -3,12 +3,12 @@
   vars:
     splunk_instance_address: "{{ splunk.multisite_master }}"
 
-- name: Convert External Cluster Master Name into Internal URI
+- name: Convert Extrenal Cluster Master Name into Internal URI
   set_fact:
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 
 - name: Setup SHC - Multisite
-  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.pass4SymmKey }}"
+  command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ multisite_master_uri }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_new_master
@@ -28,7 +28,7 @@
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_process.yml
 
 - name: Setup SHC with Associated Site
-  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.shc.pass4SymmKey }} -multisite True"
+  command: "{{ splunk.exec }} edit cluster-master -old_master_uri {{ multisite_master_uri }} -site {{ splunk.site }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }} -multisite True"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_associated_site


### PR DESCRIPTION
Reverts splunk/splunk-ansible#702 due to regression. Because we're connecting to the Cluster Manager, using the idxc pass4symmkey is the correct setup.