### PR TITLE
add hide_password to the stanza settings;

### DIFF
--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -29,3 +29,4 @@
   loop_control:
     loop_var: stanza_setting
   when: stanza_name and stanza_settings
+  no_log: "{{ hide_password }}"


### PR DESCRIPTION
Add hide_password value to the `no_log` option in stanza settings. It will help to avoid logging sensitive information as raised here - https://github.com/splunk/splunk-operator/issues/1082