### PR TITLE
Fix fresh install splunk vs upgrade

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -79,7 +79,7 @@
 # and allowing upgrades between new and old hashes of the same version.
 - name: "Setting upgrade fact"
   set_fact:
-    splunk_upgrade: "{{ 'build_location' in splunk and splunk.build_location and not splunk_install and splunk_target_version and ((splunk_target_version != splunk_current_version) or (splunk_current_build_hash != splunk_target_build_hash))| default(False) }}"
+    splunk_upgrade: "{{ not first_run and 'build_location' in splunk and splunk.build_location and not splunk_install and splunk_target_version and ((splunk_target_version != splunk_current_version) or (splunk_current_build_hash != splunk_target_build_hash))| default(False) }}"
 
 # determine if we need to set up indexer clusters
 - name: "Setting indexer cluster fact from config"

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -24,6 +24,17 @@
     - "{{ splunk.home }}/Python-2.7"
   when: splunk_upgrade | bool
 
+- name: Clean up Splunk home for fresh install
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  ignore_errors: yes
+  become: yes
+  become_user: "{{ privileged_user }}"
+  with_items:
+    - "{{ splunk.home }}"
+  when: splunk_install
+
 - name: Install Splunk
   include_tasks: install_splunk_{{ splunk_build_type }}.yml
 

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -24,15 +24,24 @@
     - "{{ splunk.home }}/Python-2.7"
   when: splunk_upgrade | bool
 
+- name: Find all files to clean up in Splunk home for fresh install
+  find:
+    path: "{{ splunk.home }}"
+    file_type: file
+  ignore_errors: yes
+  become: yes
+  become_user: "{{ privileged_user }}"
+  register: cleanup_files
+  when: not splunk_upgrade
+
 - name: Clean up Splunk home for fresh install
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: "absent"
   ignore_errors: yes
   become: yes
   become_user: "{{ privileged_user }}"
-  with_items:
-    - "{{ splunk.home }}"
+  with_items: "{{ cleanup_files.files }}"
   when: not splunk_upgrade
 
 - name: Install Splunk

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -33,7 +33,7 @@
   become_user: "{{ privileged_user }}"
   with_items:
     - "{{ splunk.home }}"
-  when: splunk_install
+  when: splunk_install | bool or first_run | bool
 
 - name: Install Splunk
   include_tasks: install_splunk_{{ splunk_build_type }}.yml

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -33,7 +33,7 @@
   become_user: "{{ privileged_user }}"
   with_items:
     - "{{ splunk.home }}"
-  when: splunk_install | bool or first_run | bool
+  when: not splunk_upgrade
 
 - name: Install Splunk
   include_tasks: install_splunk_{{ splunk_build_type }}.yml


### PR DESCRIPTION
In docker-splunk and consequently orca, whenever we specify a build location (either url or file), splunk-ansible will always indicate it as an 'upgrade' because we have splunk files and dirs pre-existing inside the container.
'upgrade' logic will delete some existing files except for config, and non-upgrade does nothing because it assumes we start from clean slate. Unfortunately this causes some fresh package install to break because we have existing stuff and Splunk thinks it's a migration.

Here I modified the logic so that it qualifies as 'upgrade' if it is not a first time run (indicated by the existence of splunk secret file). And if it it not an 'upgrade', we clean up Splunk directories.
However we do not delete directories because it won't work if some directories are mounted as volume in containers.

This logic will hurt this specific scenario: A user manually install splunk and creates splunk config change in their instance but never run it, then later use splunk-ansible to provision a splunk package. Previously that manual config change will be kept, but now those will be nuked as this is a fresh install. This is probably safe because why would someone do that.