### PR TITLE
Update wait_for_splunk_process.yml

### DIFF
--- a/roles/splunk_common/tasks/wait_for_splunk_process.yml
+++ b/roles/splunk_common/tasks/wait_for_splunk_process.yml
@@ -9,4 +9,4 @@
   wait_for:
     host: 127.0.0.1
     port: "{{ splunk.svc_port }}"
-    timeout: 180
+    timeout: 900


### PR DESCRIPTION
We need an increase of this timeout because with large searchhead cluster with lot of users and apps this results into a loop during upgrade or scaling