### PR TITLE
Config options require a value

### DIFF
--- a/roles/splunk_common/tasks/set_config_stanza.yml
+++ b/roles/splunk_common/tasks/set_config_stanza.yml
@@ -18,7 +18,7 @@
     section: "{{ stanza_name }}"
     option: "{{ stanza_setting.key }}"
     value: "{{ stanza_setting.value }}"
-    allow_no_value: True
+    allow_no_value: False
     state: present
     mode: 0660
     owner: "{{ splunk.user }}"


### PR DESCRIPTION
Hi,

this PR address https://github.com/splunk/docker-splunk/issues/601.

However, as stated in the issue, I am not sure why this was explicitly allowed. I personally cannot think of any Splunk setting that would require or utilize option flag - but maybe I am missing something?