### PR TITLE
remove unnecessary initialization

### DIFF
--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -1,11 +1,7 @@
 ---
-- name: Initialize licenses array
-  set_fact:
-    licenses: []
-
 - name: Determine available licenses
   set_fact:
-    licenses: "{{ licenses }} + [ '{{ item }}' ]"
+    licenses: "[ '{{ item }}' ]"
   with_items: "{{ splunk.license_uri.split(',') }}"
   when: splunk.license_uri is defined and splunk.license_uri
 


### PR DESCRIPTION
I believe the initialization of the `licenses` is unnecessary because it is overwrited in the next process `Determine available licenses`.
Otherwise, it turned out like `[] + [ 'http://xxxxxx/Splunk.License' ]`.