### PR TITLE
Fixed bugs in list concat 

### DIFF
--- a/roles/splunk_common/tasks/add_splunk_license.yml
+++ b/roles/splunk_common/tasks/add_splunk_license.yml
@@ -5,7 +5,7 @@
 
 - name: Determine available licenses
   set_fact:
-    licenses: "{{ licenses }} + [ '{{ item }}' ]"
+    licenses: "{{ licenses + [ item ] }}"
   with_items: "{{ splunk.license_uri.split(',') }}"
   when: splunk.license_uri is defined and splunk.license_uri
 

--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -21,22 +21,24 @@
 
 - name: Create list of current peers
   set_fact:
-    current_group_list: "{{ current_group_list }} + [ '{{ item }}' ]"
+    current_group_list: "{{ current_group_list +  [ item ] }}"
   with_items: "{{ distsearch_server_info['json']['entry'][0]['content']['servers'].split(',') }}"
   when: distsearch_server_info['json']['entry'][0]['content']['servers'] is defined and (distsearch_server_info['json']['entry'][0]['content']['servers']| length > 0)
 
 - name: Create list of peers
   set_fact:
-    group_list: "{{ groups['splunk_indexer'] | default([]) }} + {{ groups['splunk_search_head'] | default([]) }} + {{ groups['splunk_search_head_captain'] | default([]) }} + {{ groups['splunk_cluster_master'] | default([]) }} + {{ groups['splunk_deployment_server']| default([]) }} + {{ groups['splunk_license_master'] | default([]) }} + {{ groups['splunk_standalone'] | default([]) }}"
+    group_list: "{{ (groups['splunk_indexer']| default([])) + (groups['splunk_search_head'] | default([])) + (groups['splunk_search_head_captain'] | default([])) + (groups['splunk_cluster_master'] | default([])) + (groups['splunk_deployment_server']| default([])) + (groups['splunk_license_master'] | default([])) + (groups['splunk_standalone'] | default([])) }}"
 
 - name: Update group_list
+  vars:
+    append_url: "{{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }}"
   set_fact:
-    updated_group_list: "{{ updated_group_list }} + [ '{{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }}' ]"
+    updated_group_list: "{{ updated_group_list+ [ append_url ] }}"
   with_items: "{{ group_list }}"
 
 - name: Non-existent peers list
   set_fact:
-    remove_peer_list: "{{ remove_peer_list }} + [ '{{ item }}' ]"
+    remove_peer_list: "{{ remove_peer_list + [ item ] }}"
   with_items: "{{ current_group_list }}"
   when: item not in updated_group_list and current_group_list is defined and (current_group_list| length > 0)
 

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: Create list of clusterMaster peers
   set_fact:
-    cluster_master_peers: "{{ cluster_master_peers }} + [ '{{ item }}' ]"
+    cluster_master_peers: "{{ cluster_master_peers + [ item ] }}"
   with_items: "{{ clusterMaster_peers_info['json']['entry'] | selectattr('content.host_port_pair','defined') | map(attribute='content.host_port_pair') |list}}"
   when: splunk_indexer_cluster or splunk.multisite_master is defined
 


### PR DESCRIPTION
I noticed bugs in list concatenation. 
When building `splunk_monitor`, task `Create list of peers` resulted as follows, so next tasks failed. 
```
ok: [192.168.1.10] => {
    "ansible_facts": {
        "group_list": "['192.168.1.15', '192.168.1.16', '192.168.1.17'] + ['192.168.1.13'] + ['192.168.1.11'] + ['192.168.1.14'] + ['192.168.1.10'] + ['192.168.1.10'] + []"
    },
    "changed": false
}
``` 

So I fixed these relevant codes. As a result, the task resulted as follows and I succeeded in building splunk_monitor.
```
ok: [192.168.1.10] => {
    "ansible_facts": {
        "group_list": [
            "192.168.1.15",
            "192.168.1.16",
            "192.168.1.17",
            "192.168.1.13",
            "192.168.1.11",
            "192.168.1.14",
            "192.168.1.10",
            "192.168.1.10"
        ]
    },
    "changed": false
}
```