### PR TITLE
Added handling for mission control app installation

### DIFF
--- a/roles/splunk_common/tasks/provision_apps.yml
+++ b/roles/splunk_common/tasks/provision_apps.yml
@@ -3,6 +3,10 @@
   vars:
     app_url: "{{ item }}"
   loop: "{{ app_list }}"
+  when:
+    - '("missioncontrol" not in item) or 
+    (("ta_missioncontrol" in item) and (splunk.role == "splunk_indexer")) or 
+    (("ta_missioncontrol" not in item) and ("missioncontrol" in item) and (splunk.role == "splunk_search_head"))'
 
 - name: Flush restart handlers
   meta: flush_handlers


### PR DESCRIPTION
We need a specific installation flow for mission control and TA mission control apps. This change handles additional conditions to check whether or not to install the MC related app depending on whether or not the app is a search head/indexer. All other apps should get installed as usual.