### PR TITLE
Basic auth Splunk tarball download

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -145,6 +145,7 @@ def getDefaultVars():
     getJava(defaultVars)
     getSplunkBuild(defaultVars)
     getSplunkbaseToken(defaultVars)
+    getSplunkBuildAuth(defaultVars)
     getSplunkApps(defaultVars)
     getSplunkAppsLocal(defaultVars)
     getLaunchConf(defaultVars)
@@ -356,6 +357,13 @@ def getSplunkbaseToken(vars_scope):
             output = output.decode("utf-8", "ignore")
         splunkbase_token = re.search("<id>(.*)</id>", output, re.IGNORECASE)
         vars_scope["splunkbase_token"] = splunkbase_token.group(1) if splunkbase_token else None
+
+def getSplunkBuildAuth(vars_scope):
+    """
+    Load username and password to be used in basic auth when fetching splunk build or apps
+    """
+    vars_scope["splunk"]["artifact_auth_user"] = os.environ.get("ARTIFACTORY_USER", vars_scope["splunk"].get("basic_auth_user"))
+    vars_scope["splunk"]["artifact_auth_pass"] = os.environ.get("ARTIFACTORY_TOKEN", vars_scope["splunk"].get("artifact_auth_pass"))
 
 def getSplunkApps(vars_scope):
     """

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -362,7 +362,7 @@ def getSplunkBuildAuth(vars_scope):
     """
     Load username and password to be used in basic auth when fetching splunk build or apps
     """
-    vars_scope["splunk"]["artifact_auth_user"] = os.environ.get("ARTIFACTORY_USER", vars_scope["splunk"].get("basic_auth_user"))
+    vars_scope["splunk"]["artifact_auth_user"] = os.environ.get("ARTIFACTORY_USER", vars_scope["splunk"].get("artifact_auth_user"))
     vars_scope["splunk"]["artifact_auth_pass"] = os.environ.get("ARTIFACTORY_TOKEN", vars_scope["splunk"].get("artifact_auth_pass"))
 
 def getSplunkApps(vars_scope):

--- a/roles/splunk_common/tasks/install_apps.yml
+++ b/roles/splunk_common/tasks/install_apps.yml
@@ -38,8 +38,8 @@
       timeout: 120
       validate_certs: no
       force: yes
-      url_username: "{{ lookup('env', 'ARTIFACTORY_USER') }}"
-      url_password: "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"
+      url_username: "{{ splunk.artifact_auth_user }}"
+      url_password: "{{ splunk.artifact_auth_pass }}"
     register: app_remote
     when:
       - app_url is match("^(https?|file)://.*")

--- a/roles/splunk_common/tasks/install_splunk_tgz.yml
+++ b/roles/splunk_common/tasks/install_splunk_tgz.yml
@@ -8,7 +8,32 @@
     validate_certs: no
     timeout: 900
     mode: 0666
-  when: splunk.build_location is match("^(https?)://.*")
+  when: 
+    - splunk.build_location is match("^(https?)://.*")
+    - splunk.artifact_auth_user is undefined or splunk.artifact_auth_user == ""
+  register: download_result
+  until: download_result is succeeded
+  retries: 5
+  delay: "{{ retry_delay }}"
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Download Splunk using basic auth
+  get_url:
+    url: "{{ splunk.build_location }}"
+    dest: "{{ splunk.opt }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    force_basic_auth: false 
+    url_username: "{{ splunk.artifact_auth_user }}"
+    url_password: "{{ splunk.artifact_auth_pass }}"
+    validate_certs: no
+    timeout: 900
+    mode: 0666
+  when: 
+    - splunk.build_location is match("^(https?)://.*")
+    - splunk.artifact_auth_user is defined
+    - splunk.artifact_auth_user != ""
   register: download_result
   until: download_result is succeeded
   retries: 5


### PR DESCRIPTION
Added a task that downloads a Splunk tarbal using basic auth instead of the bearer token. Also fixed the usage of the user/pass in install apps to conform with our standards of using inventory for variables. 