### PR TITLE
modify regexp to find target build in new download format

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -73,7 +73,7 @@
     splunk_current_build_hash: "{{ manifests.files[0].path | regex_search(regexp, '\\3') if (manifests.matched == 1) else '0' }}"
     splunk_target_build_hash: "{{ splunk.build_location | string | regex_search(regexp, '\\3') | default('0') }}"
   vars:
-    regexp: 'splunk\D*?-(\d+\.\d+\.\d+(\.\d+)?)-(.*?)-.*?'
+    regexp: 'splunk\D*?-(\d+\.\d+\.\d+(\.\d+)?)-(.*?)[-\.].*?'
 
 # We are upgrading if it is not a fresh installation and the current version is different from the target version,
 # and allowing upgrades between new and old hashes of the same version.


### PR DESCRIPTION
The splunk universal forwarder filename format has changed and it breaks the splunk_target_build_hash detection. 

old format:
```
splunkforwarder-9.0.2-17e00c557dc1-Linux-x86_64.tgz
```
new format:
```
splunkforwarder-9.2.0.1-d8ae995bf219.x86_64.rpm
```
