### PR TITLE
fix netstat for debian images

### DIFF
--- a/roles/splunk_common/tasks/check_mgmt_mode_status.yml
+++ b/roles/splunk_common/tasks/check_mgmt_mode_status.yml
@@ -5,7 +5,7 @@
   register: client_socket_file
 
 - name: Check if listening on SVC Port {{ splunk.svc_port }}
-  shell: "netstat -plnt"
+  shell: "netstat -lnt"
   register: port_status
   #when: not client_socket_file.stat.exists
 

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -133,3 +133,4 @@
   when: "'disable_popups' in splunk and splunk.disable_popups | bool"
 
 - include_tasks: check_mgmt_mode_status.yml
+  when: splunk.role == "splunk_universal_forwarder"


### PR DESCRIPTION
Fixed:
- netstat command
- include check_mgmt_mode_status only for UFs


fatal: [localhost]: FAILED! => {
    "changed": true,
    "cmd": "netstat -plnt",
    "delta": "0:00:00.004656",
    "end": "2024-03-15 17:18:34.466894",
    "rc": 1,
    "start": "2024-03-15 17:18:34.462238"
}

STDERR:

netstat: invalid option -- 'p'
BusyBox v1.30.1 (Debian 1:1.30.1-6+b3) multi-call binary.

Usage: netstat [-ral] [-tuwx] [-en]

Display networking information

	-r	Routing table
	-a	All sockets
	-l	Listening sockets
		Else: connected sockets
	-t	TCP sockets
	-u	UDP sockets
	-w	Raw sockets
	-x	Unix sockets
		Else: all socket types
	-e	Other/more information
	-n	Don't resolve names


MSG:

non-zero return code