### PR TITLE
Use splunk_api for Remove existing HEC token

### DIFF
--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -36,12 +36,13 @@
 
 # The REST API does not support modifying tokens in-place, so we'll need to delete/re-create
 - name: Remove existing HEC token
-  uri:
-    url: "{{ cert_prefix }}://127.0.0.1:{{ splunk.svc_port }}/services/data/inputs/http/splunk_hec_token"
+  splunk_api:
+    url: "/services/data/inputs/http/splunk_hec_token"
     method: DELETE
-    user: "{{ splunk.admin_user }}"
+    cert_prefix: "{{ cert_prefix }}"
+    username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
-    status_code: 200,404
+    status_code: [200, 404]
     timeout: 60
     use_proxy: no
   register: delete_hec_token

--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -43,6 +43,7 @@
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     status_code: [200, 404]
+    svc_port: "{{ splunk.svc_port }}"
     timeout: 60
     use_proxy: no
   register: delete_hec_token


### PR DESCRIPTION
Addresses https://github.com/splunk/splunk-ansible/issues/814, using splunk_api which does not verify certs by default and uses the same module as the surrounding tasks.