### PR TITLE
fix conditionals for python requirements

### DIFF
--- a/roles/splunk_common/tasks/install_python_requirements.yml
+++ b/roles/splunk_common/tasks/install_python_requirements.yml
@@ -22,11 +22,11 @@
     name: "requests_unixsocket"
   when:
     - requests_unixsocket_check.stdout is defined
-    - requests_unixsocket_check.stdout | length == 0 or requests_unixsocket_check.stdout.find("requests-unixsocket") == -1)
+    - requests_unixsocket_check.stdout | length == 0 or requests_unixsocket_check.stdout.find("requests-unixsocket") == -1
 
 - name: Install missing requests_unixsocket PY3
   ansible.builtin.pip:
     name: "requests_unixsocket"
   when:
     - requests_unixsocket_check_py3.stdout is defined
-    - requests_unixsocket_check_py3.stdout | length == 0 or requests_unixsocket_check_py3.stdout.find("requests-unixsocket") == -1)
+    - requests_unixsocket_check_py3.stdout | length == 0 or requests_unixsocket_check_py3.stdout.find("requests-unixsocket") == -1

--- a/roles/splunk_common/tasks/install_python_requirements.yml
+++ b/roles/splunk_common/tasks/install_python_requirements.yml
@@ -9,12 +9,12 @@
     name: pip
     extra_args: --upgrade
     executable: pip3
-  when: requests_unixsocket_check is failed
+  when: requests_unixsocket_check.stdout is undefined
 
 - name: Check if pip3 unixsocket exits
   command: "pip3 list | grep 'requests-unixsocket'"
   register: requests_unixsocket_check_py3
-  when: requests_unixsocket_check is failed
+  when: requests_unixsocket_check.stdout is undefined
   ignore_errors: true
 
 - name: Install missing requests_unixsocket

--- a/roles/splunk_common/tasks/install_python_requirements.yml
+++ b/roles/splunk_common/tasks/install_python_requirements.yml
@@ -20,9 +20,13 @@
 - name: Install missing requests_unixsocket
   ansible.builtin.pip:
     name: "requests_unixsocket"
-  when: requests_unixsocket_check is succeeded and (requests_unixsocket_check.stdout | length == 0 or requests_unixsocket_check.stdout.find("requests-unixsocket") == -1)
+  when:
+    - requests_unixsocket_check.stdout is defined
+    - requests_unixsocket_check.stdout | length == 0 or requests_unixsocket_check.stdout.find("requests-unixsocket") == -1)
 
 - name: Install missing requests_unixsocket PY3
   ansible.builtin.pip:
     name: "requests_unixsocket"
-  when: requests_unixsocket_check_py3 is succeeded and (requests_unixsocket_check_py3.stdout | length == 0 or requests_unixsocket_check_py3.stdout.find("requests-unixsocket") == -1)
+  when:
+    - requests_unixsocket_check_py3.stdout is defined
+    - requests_unixsocket_check_py3.stdout | length == 0 or requests_unixsocket_check_py3.stdout.find("requests-unixsocket") == -1)


### PR DESCRIPTION
`is succeeded` will always pass because of `ignore_errors` value.
This causes us to run the last play even if `requests_unixsocket_check_py3.stdout` is undefined