### PR TITLE
refactor encoded splunk_api body entries

### DIFF
--- a/roles/splunk_common/tasks/disable_popups.yml
+++ b/roles/splunk_common/tasks/disable_popups.yml
@@ -15,13 +15,24 @@
 - name: Disable Popups
   splunk_api:
     method: POST
-    url: "{{ item.key }}"
+    url: "{{ item.url }}"
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
-    body: "{{ item.value }}"
+    body: "{{ item.body }}"
+    body_format: "form-urlencoded"
     status_code: 200,201,409
   with_items:
-    - { key: "/servicesNS/admin/user-prefs/data/user-prefs/general", value: "hideInstrumentationOptInModal=1&notification_python_3_impact=false&showWhatsNew=0" }
-    - { key: "/servicesNS/nobody/splunk_instrumentation/admin/telemetry/general", value: "showOptInModal=0&optInVersionAcknowledged={{ telemetry['json']['entry'][0]['content']['optInVersion'] }}" }
-    - { key: "/servicesNS/admin/search/data/ui/ui-tour/search-tour", value: "tourPage=search&viewed=1" }
+    - url: "/servicesNS/admin/user-prefs/data/user-prefs/general"
+      body:
+        hideInstrumentationOptInModal: 1
+        notification_python_3_impact: false
+        showWhatsNew: 0
+    - url: "/servicesNS/nobody/splunk_instrumentation/admin/telemetry/general"
+      body:
+        showOptInModal: 0
+        optInVersionAcknowledged: "{{ telemetry['json']['entry'][0]['content']['optInVersion'] }}"
+    - url: "/servicesNS/admin/search/data/ui/ui-tour/search-tour"
+      body:
+        tourPage: search
+        viewed: 1

--- a/roles/splunk_monitor/tasks/initialize_dmc.yml
+++ b/roles/splunk_monitor/tasks/initialize_dmc.yml
@@ -75,6 +75,12 @@
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
-    body: "author=Splunk&check_for_updates=1&configured=1&label=Monitoring+Console&version={{ settings.json['generator']['version'] }}&visible=1"
-    body_format: "form"
+    body:
+      author: Splunk
+      check_for_updates: 1
+      configured: 1
+      label: "Monitoring Console"
+      version: "{{ settings.json['generator']['version'] }}"
+      visible: 1
+    body_format: "form-urlencoded"
     status_code: "200,201,409"

--- a/roles/splunk_monitor/tasks/post_calls.yml
+++ b/roles/splunk_monitor/tasks/post_calls.yml
@@ -17,6 +17,7 @@
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
     body: "{{ item }}"
+    body_format: "form-urlencoded"
     status_code: "201,409"
     timeout: 10
     use_proxy: no
@@ -63,6 +64,7 @@
       member: {{ item.name }}
       default: false
       name: dmc_indexerclustergroup_{{ item.cluster_label }}"
+    body_format: "form-urlencoded"
     status_code: "201,409"
     timeout: 10
     use_proxy: no
@@ -81,6 +83,7 @@
       member: {{ item.name }}
       default: false
       name: dmc_indexerclustergroup_{{ item.cluster_label }}/edit"
+    body_format: "form-urlencoded"
     status_code: "201,409"
     timeout: 10
     use_proxy: no

--- a/roles/splunk_monitor/tasks/post_calls.yml
+++ b/roles/splunk_monitor/tasks/post_calls.yml
@@ -17,7 +17,6 @@
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
     body: "{{ item }}"
-    body_format: "form-urlencoded"
     status_code: "201,409"
     timeout: 10
     use_proxy: no
@@ -60,8 +59,10 @@
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
-    body: "member={{ item.name }}&default=false&name=dmc_indexerclustergroup_{{ item.cluster_label }}"
-    body_format: "form-urlencoded"
+    body:
+      member: {{ item.name }}
+      default: false
+      name: dmc_indexerclustergroup_{{ item.cluster_label }}"
     status_code: "201,409"
     timeout: 10
     use_proxy: no
@@ -76,8 +77,10 @@
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
-    body: "member={{ item.name }}&default=false&name=dmc_indexerclustergroup_{{ item.cluster_label }}/edit"
-    body_format: "form-urlencoded"
+    body:
+      member: {{ item.name }}
+      default: false
+      name: dmc_indexerclustergroup_{{ item.cluster_label }}/edit"
     status_code: "201,409"
     timeout: 10
     use_proxy: no


### PR DESCRIPTION
The `splunk_api` library script being used always tries to unpack the `body` content as a dictionary, which does not work for pre-encoded forms.

This should resolve: https://github.com/splunk/docker-splunk/issues/660

Tested by patching the existing 9.0.9 docker-splunk image with these changes (disable_popups shown as an example):
```
TASK [splunk_common : Disable Popups] ******************************************
changed: [localhost] => (item={'url': '/servicesNS/admin/user-prefs/data/user-prefs/general', 'body': {'hideInstrumentationOptInModal': 1, 'notification_python_3_impact': False, 'showWhatsNew': 0}})
changed: [localhost] => (item={'url': '/servicesNS/nobody/splunk_instrumentation/admin/telemetry/general', 'body': {'showOptInModal': 0, 'optInVersionAcknowledged': '4'}})
changed: [localhost] => (item={'url': '/servicesNS/admin/search/data/ui/ui-tour/search-tour', 'body': {'tourPage': 'search', 'viewed': 1}})
```

I was unable to validate changes made by the first/third tasks, however the second is clearly visible:
```
[splunk@a24eddb343d1 splunk]$ cat /opt/splunk/etc/apps/splunk_instrumentation/local/telemetry.conf
[general]
optInVersionAcknowledged = 4
showOptInModal = 0
telemetrySalt = 80036d40-a00a-41e4-bbe1-b93481f8f758
deploymentID = 2ef3ac79-7cc3-5d32-a470-f7fb0353750b
```