### PR TITLE
adjust forwarder splunk_api response check

### DIFF
--- a/roles/splunk_common/tasks/licenses/enable_forwarder_license.yml
+++ b/roles/splunk_common/tasks/licenses/enable_forwarder_license.yml
@@ -24,4 +24,4 @@
     body_format: "form-urlencoded"
     status_code: [200]
     timeout: 10
-  when: not check_fwd_lic.content.json.entry[0].content.is_active
+  when: not check_fwd_lic.json.entry[0].content.is_active


### PR DESCRIPTION
Fixes the following reported issues:
- docker-splunk: https://github.com/splunk/docker-splunk/issues/662
- splunk-ansible: https://github.com/splunk/splunk-ansible/issues/813

`splunk_api` response does not contain key `content`.

Here is the full json output from the response on a heavy forwarder:
```
{'changed': False, 'status': 200, 'json': {'links': {}, 'origin': 'https://127.0.0.1:8089/services/licenser/groups', 'updated': '2024-05-07T21:33:16+00:00', 'generator': {'build': 'b985591d12fd', 'version': '9.0.7'}, 'entry': [{'name': 'Forwarder', 'id': 'https://127.0.0.1:8089/services/licenser/groups/Forwarder', 'updated': '1970-01-01T00:00:00+00:00', 'links': {'alternate': '/services/licenser/groups/Forwarder', 'list': '/services/licenser/groups/Forwarder', 'edit': '/services/licenser/groups/Forwarder'}, 'author': 'system', 'acl': {'app': '', 'can_list': True, 'can_write': True, 'modifiable': False, 'owner': 'system', 'perms': {'read': ['admin', 'splunk-system-role'], 'write': ['admin', 'splunk-system-role']}, 'removable': False, 'sharing': 'system'}, 'fields': {'required': ['is_active'], 'optional': [], 'wildcard': []}, 'content': {'eai:acl': None, 'is_active': False, 'stack_ids': ['forwarder']}}], 'paging': {'total': 1, 'perPage': 30, 'offset': 0}, 'messages': []}, 'excep_str': 'No Exception', 'failed': False}
```