### PR TITLE
Don't hammer splunkd with restart

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,5 +1,6 @@
 hide_password: false
 retry_delay: 3
+restart_retry_delay: 30
 retry_num: 60
 wait_for_splunk_retry_num: 60
 shc_sync_retry_num: 60

--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -42,6 +42,10 @@ retry_delay: <int>
 * Duration of waits between each of the aforementioned retries (in seconds)
 * Default: 6
 
+restart_retry_delay: <int>
+* Duration of waits between retries to issue restart command for splunkd (in seconds)
+* Default: 30
+
 splunk_home_ownership_enforcement: true
 * Boolean that to control and enable UAC on $SPLUNK_HOME (recommended to be enabled)
 * Default: true

--- a/docs/execution_patterns/remote/default.yml
+++ b/docs/execution_patterns/remote/default.yml
@@ -1,5 +1,6 @@
 ---
 retry_delay: 6
+restart_retry_delay: 30
 retry_num: 60
 shc_sync_retry_num: 60
 

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -3,6 +3,7 @@ ansible_pre_tasks:
 ansible_post_tasks:
 ansible_environment: {}
 retry_delay: 6
+restart_retry_delay: 30
 retry_num: 60
 hide_password: false
 wait_for_splunk_retry_num: 60

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -3,6 +3,7 @@ ansible_pre_tasks:
 ansible_post_tasks:
 ansible_environment: {}
 retry_delay: 10
+restart_retry_delay: 30
 retry_num: 60
 hide_password: false
 wait_for_splunk_retry_num: 150

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -3,6 +3,7 @@ ansible_pre_tasks:
 ansible_post_tasks:
 ansible_environment: {}
 retry_delay: 6
+restart_retry_delay: 30
 retry_num: 60
 hide_password: false
 wait_for_splunk_retry_num: 60

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -3,6 +3,7 @@ ansible_pre_tasks:
 ansible_post_tasks:
 ansible_environment: {}
 retry_delay: 10
+restart_retry_delay: 30
 retry_num: 60
 hide_password: false
 wait_for_splunk_retry_num: 150

--- a/roles/splunk_common/handlers/restart_splunk.yml
+++ b/roles/splunk_common/handlers/restart_splunk.yml
@@ -6,7 +6,7 @@
   register: task_result
   until: task_result.rc == 0
   retries: "{{ retry_num }}"
-  delay: "{{ retry_delay }}"
+  delay: "{{ restart_retry_delay }}"
   when: not splunk.enable_service
 
 - name: "Restart the splunkd service - Via Linux systemd or init"


### PR DESCRIPTION
There's a long time bug in splunkd where it needs time to properly ShutDown multiple components.
This usually manifest as failing to bind to KVStore port 8191: https://community.splunk.com/t5/Knowledge-Management/ERROR-kvstore-port-8191-port-is-already-bound-Splunk-needs-to/m-p/293324

In ansible, we need to space out the retry when issuing restart command to give it time, otherwise the consecutive try will keep failing due to this.