### PR TITLE
Monitoring console idx cluster support

### DIFF
--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -63,7 +63,7 @@
 - include_tasks: ../../../roles/splunk_common/tasks/wait_for_splunk_instance.yml
   vars:
     splunk_instance_address: "{{ item }}"
-  with_items: "{{ group_list }}"
+  with_items: "{{ groups['splunk_indexer'] }}"
 
 - name: Set search peers
   command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
@@ -78,5 +78,5 @@
   notify:
     - Restart the splunkd service
   no_log: "{{ hide_password }}"
-  with_items: "{{ group_list }}"
+  with_items: "{{ groups['splunk_indexer'] }}"
 #INFRA-38882: Update exec?

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -1,6 +1,4 @@
 ---
-- include_tasks: ../../../roles/splunk_monitor/tasks/adding_peers.yml
-
 - include_tasks: ../../../roles/splunk_common/tasks/set_as_deployment_client.yml
   when:
     - splunk.deployment_server is defined
@@ -20,6 +18,13 @@
   vars:
     app_list: "{{ splunk.app_paths_install.default }}"
 
+# Non Indexer Clustering peering
+- include_tasks: ../../../roles/splunk_monitor/tasks/adding_peers.yml
+  when:
+    - not splunk_indexer_cluster
+    - splunk.multisite_master is not defined
+
+# Indexer Clustering peering
 - include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
   when:
     - splunk_indexer_cluster or splunk.multisite_master is defined

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -23,14 +23,14 @@
     cluster_master_peers: []
 
 - name: Fetch clusterMaster peers
-  splunk_api:
+  uri:
+    url: "{{ cert_prefix }}://{{ splunk.cluster_master_url }}:{{ splunk.svc_port }}/services/cluster/master/peers?output_mode=json&count=0"
     method: GET
-    url: "/services/cluster/master/peers?output_mode=json&count=0"
-    cert_prefix: "{{ cert_prefix }}"
-    username: "{{ splunk.admin_user }}"
+    user: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
-    svc_port: "{{ splunk.svc_port }}"
-    status_code: [200]
+    force_basic_auth: yes
+    validate_certs: false
+    status_code: 200
     timeout: 10
     return_content: yes
     use_proxy: no


### PR DESCRIPTION
Fixes errors reported when deploying dedicated monitoring console with indexer clustering enabled:

- `Fetch clusterMaster peers` now correctly targets the cluster master instead of the local instance
- Skips peering indexers when peering the indexer cluster master
- Peering indexers (without indexer clustering) only targets indexers