### PR TITLE
support callbacks in ansible-core>=2.15

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -16,6 +16,7 @@ retry_files_save_path = /opt/container_artifact/ansible-retry
 system_warnings = True
 hash_behaviour = merge
 callback_whitelist = profile_tasks
+callbacks_enabled = profile_tasks
 timeout = 30
 action_warnings = False
 allow_world_readable_tmpfiles = True


### PR DESCRIPTION
Found after upgrading to ansible-core 2.15

The `callback_whitelist` key was deprecated in favor of the new `callbacks_enabled` key (mentioned here: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_8.html#id60)

This ensures that we print the time each play takes in the summary of the ansible execution.