### PR TITLE
exclude ds from disabled indexing

### DIFF
--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -63,7 +63,9 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   register: index_disabling
-  when: splunk.role != "splunk_license_master"
+  when:
+    - splunk.role != "splunk_license_master"
+    - splunk.role != "splunk_deployment_server"
 
 # set up forward servers set by get_facts
 - name: Add forward_servers


### PR DESCRIPTION
Indexing shouldn't be disabled for deployment_server since it leads to empty list of clients. Adjusted `when` condition so that it does not execute `Disable indexing on the current node` task if `splunk.role` is `deployment_server`.
<img width="757" alt="image" src="https://github.com/user-attachments/assets/7ce53ecc-bc06-48ca-a933-55ec18920de1">
