### PR TITLE
hide pass4symmkey value

### DIFF
--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -17,6 +17,8 @@
     - item.value | length > 0
   no_log: "{{ hide_password }}"
   register: indexer_discovery
+  loop_control:
+    label: "{{ item.key }}"
 
 - name: Setup tcpout group for index-clustering
   ini_file:


### PR DESCRIPTION
Avoid printing the pass4symmkey value in debug output. We use this approach elsewhere (https://github.com/splunk/splunk-ansible/blob/develop/roles/splunk_deployer/tasks/main.yml#L14) however it seems we missed one instance of this.