### PR TITLE
add audit_trail to default apps

### DIFF
--- a/roles/splunk_common/vars/main.yml
+++ b/roles/splunk_common/vars/main.yml
@@ -4,7 +4,8 @@ default_apps: [ "legacy", "splunk_gdi", "SplunkForwarder", "SplunkLightForwarder
                 "appsbrowser", "framework", "learned", "launcher", "alert_logevent", "sample_app", "python_upgrade_readiness_app",
                 "splunk_instrumentation", "search", "splunk_archiver", "splunk_monitoring_console", "splunk_rapid_diag",
                 "_splunk_config", "splunk_enterprise_on_docker", "splunk_forwarder_on_docker", "journald_input",
-                "splunk_metrics_workspace", "splunk_internal_metrics", "splunk_telemetry", "splunk_secure_gateway", "splunk_assist" ]
+                "splunk_metrics_workspace", "splunk_internal_metrics", "splunk_telemetry", "splunk_secure_gateway", "splunk_assist",
+                "audit_trail" ]
 itsi_apps: [ "DA-ITSI-APPSERVER", "DA-ITSI-DATABASE", "DA-ITSI-EUEM", "DA-ITSI-LB", "DA-ITSI-OS",
               "DA-ITSI-STORAGE", "DA-ITSI-VIRTUALIZATION", "DA-ITSI-WEBSERVER", "SA-ITOA", "SA-ITSI-ATAD", "SA-UserAccess",
             "SA-ITSI-CustomModuleViz", "SA-ITSI-MetricAD", "SA-ITSI-Licensechecker", "itsi", "splunk_app_infrastructure" ]


### PR DESCRIPTION
This addresses a new behavior in Splunk 9.4.0 where the `audit_trail` app is shipped with Splunk by default. Updating the default apps here allows us to skip disabling the app on the deployer (shc) and cluster_master (idxc) roles.

In our prelim testing of 9.4.0 with SHC enabled, we observed that `audit_trail` cannot be disabled on the deployer and throws a cgroup error in the ansible.log.