### PR TITLE
Add checks for splunk preinstall logic

### DIFF
--- a/roles/splunk_common/tasks/get_facts.yml
+++ b/roles/splunk_common/tasks/get_facts.yml
@@ -75,6 +75,13 @@
   vars:
     regexp: 'splunk\D*?-(\d+\.\d+\.\d+(\.\d+)?)-(.*?)-.*?'
 
+- name: "Determine if Splunk has preinstall checks"
+  set_fact:
+    splunk_preinstall: "true"
+  vars:
+    target_version: "{{ splunk_target_version | first }}"
+  when: "splunk_target_version is defined and target_version is version('9.4.0', '>=')"
+
 # We are upgrading if it is not a fresh installation and the current version is different from the target version,
 # and allowing upgrades between new and old hashes of the same version.
 - name: "Setting upgrade fact"

--- a/roles/splunk_common/tasks/install_splunk.yml
+++ b/roles/splunk_common/tasks/install_splunk.yml
@@ -8,7 +8,7 @@
   become_user: "{{ privileged_user }}"
   with_items:
   - "{{ manifests.files }}"
-  when: splunk_upgrade | bool
+  when: splunk_upgrade | bool and splunk_preinstall is not defined
 
 - name: Remove old directories
   file:
@@ -22,7 +22,7 @@
     - "{{ splunk.home }}/lib"
     - "{{ splunk.home }}/share"
     - "{{ splunk.home }}/Python-2.7"
-  when: splunk_upgrade | bool
+  when: splunk_upgrade | bool and splunk_preinstall is not defined
 
 - name: Find all files to clean up in Splunk home for fresh install
   find:
@@ -32,7 +32,7 @@
   become: yes
   become_user: "{{ privileged_user }}"
   register: cleanup_files
-  when: not splunk_upgrade
+  when: not splunk_upgrade and splunk_preinstall is not defined
 
 - name: Clean up Splunk home for fresh install
   file:
@@ -42,7 +42,7 @@
   become: yes
   become_user: "{{ privileged_user }}"
   with_items: "{{ cleanup_files.files }}"
-  when: not splunk_upgrade
+  when: not splunk_upgrade and splunk_preinstall is not defined
 
 - name: Install Splunk
   include_tasks: install_splunk_{{ splunk_build_type }}.yml

--- a/roles/splunk_common/tasks/install_splunk_apt.yml
+++ b/roles/splunk_common/tasks/install_splunk_apt.yml
@@ -1,7 +1,7 @@
 - name: Install Splunk (apt)
   apt:
     name: "{{{{ splunk.build_location }}}}"
-    state: "{{{{ 'latest' if splunk_upgrade else 'present' }}}}"
+    state: "{{{{ 'latest' if splunk_upgrade and not splunk_preinstall else 'present' }}}}"
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"

--- a/roles/splunk_common/tasks/install_splunk_deb.yml
+++ b/roles/splunk_common/tasks/install_splunk_deb.yml
@@ -2,7 +2,7 @@
 - name: Install Splunk (deb)
   apt:
     deb: "{{ splunk.build_location }}"
-    state: "{{ 'latest' if splunk_upgrade else 'present' }}"
+    state: "{{ 'latest' if splunk_upgrade and not splunk_preinstall else 'present' }}"
   register: install_result
   until: install_result is succeeded
   retries: "{{ retry_num }}"


### PR DESCRIPTION
Splunk 9.4.0 will have preinstall checks to handle upgrades, so it is not necessary to remove any files from the old installation.  Add logic to not run these tasks when installing a version >=9.4.0