### PR TITLE
CM wait for peer before applying bundle

### DIFF
--- a/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
@@ -1,4 +1,18 @@
 ---
+- name: Wait for cluster peers to join
+  splunk_api:
+    method: GET
+    url: "services/cluster/master/peers?output_mode=json"
+    cert_prefix: "{{ cert_prefix }}"
+    username: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    svc_port: "{{ splunk.svc_port }}"
+    status_code: [200]
+  register: peer_list
+  until: peer_list.json.entry | length == groups['splunk_indexer'] | length
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+
 # Fails if a cluster bundle did not already exist and yet we did not apply a new bundle.
 # The failed condition is basically eventHasError && bundleNotAlreadyExists.
 # The changed condition is basically !eventHasError && bundleNotAlreadyExists.

--- a/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
@@ -2,7 +2,7 @@
 - name: Wait for cluster peers to join
   splunk_api:
     method: GET
-    url: "services/cluster/master/peers?output_mode=json"
+    url: "/services/cluster/master/peers?output_mode=json"
     cert_prefix: "{{ cert_prefix }}"
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"


### PR DESCRIPTION
Issue was found in multisite scenario (2 indexer clusters). 1 cluster master fails with the following error:
```
2024-10-17 22:10:43,748 p=8688 u=ansible n=ansible | TASK [splunk_cluster_master : Apply cluster bundle] ****************************
2024-10-17 22:10:43,749 p=8688 u=ansible n=ansible | fatal: [localhost]: FAILED! => {
    "changed": false,
    "cmd": [
        "/opt/splunk/bin/splunk",
        "apply",
        "cluster-bundle",
        "-auth",
        "admin:Chang3d!",
        "--skip-validation",
        "--answer-yes"
    ],
    "delta": "0:00:00.750903",
    "end": "2024-10-17 22:10:43.718065",
    "failed_when_result": true,
    "rc": 0,
    "start": "2024-10-17 22:10:42.967162"
}

STDOUT:


Encountered some errors while applying the bundle.


STDERR:

Cannot set location using location=auto, error=Error code="Cgroups detection error", function=detectMount, error="Expected non-empty cpcontroller mount point in file=/proc/self/mountinfo"
WARNING: Server Certificate Hostname Validation is disabled. Please see server.conf/[sslConfig]/cliVerifyServerName for details.
Cannot apply bundle, because replication factor number of peers are not up
```

In multisite scenarios, the list of indexers in `groups['splunk_indexers']` only includes the indexers in the site local to the CM.