### PR TITLE
remove HEC provisioning from UF role

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -112,7 +112,7 @@ ansible-playbook --inventory hosts --connection local site.yml --extra-vars "@de
 ---
 
 ## Provision HEC
-The HTTP Event Collector (HEC) enables sending data directly to Splunk via a HTTP endpoint and a token. Here's how you can enable it with a user-defined token (`abcd-1234-efgh-5678`).
+The HTTP Event Collector (HEC) enables sending data directly to Splunk via a HTTP endpoint and a token. Here's how you can enable it with a user-defined token (`abcd-1234-efgh-5678`). See the [Splunk docs](https://docs.splunk.com/Documentation/Splunk/latest/Data/ScaleHTTPEventCollector) for guidance on where HEC should be enabled, depending on your setup.
 <details><summary markdown='span'><code>hosts</code> file inventory</summary><p></p>
 
 ```

--- a/roles/splunk_universal_forwarder/tasks/main.yml
+++ b/roles/splunk_universal_forwarder/tasks/main.yml
@@ -37,6 +37,4 @@
   notify:
     - Restart the splunkd service
 
-- include_tasks: ../../../roles/splunk_common/tasks/set_as_hec_receiver.yml
-
 - include_tasks: ../../../roles/splunk_common/tasks/check_for_required_restarts.yml


### PR DESCRIPTION
Enabling a UF 9.1.0+ as a HEC receiver breaks a lot of functionality because of UDS behavior.

According to the Splunk docs, UF is not supported for HEC receiving: https://docs.splunk.com/Documentation/SplunkCloud/9.2.2406/Data/ScaleHTTPEventCollector