### PR TITLE
fix monitor check for cm peers

### DIFF
--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: Create list of clusterMaster peers
   set_fact:
     cluster_master_peers: "{{ cluster_master_peers + [ item ] }}"
-  with_items: "{{ clusterMaster_peers_info['json']['entry'] | selectattr('content.host_port_pair','defined') | map(attribute='content.host_port_pair') |list}}"
+  with_items: "{{ clusterMaster_peers_info['json']['entry'] | selectattr('content.label','defined') | map(attribute='content.label') |list}}"
   when: splunk_indexer_cluster or splunk.multisite_master is defined
 
 - name: Fetch distributed peers when cm is defined
@@ -63,7 +63,7 @@
   when:
     - splunk_indexer_cluster or splunk.multisite_master is defined
     - cluster_master_peers is defined and (cluster_master_peers | length > 0)
-  until: distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Down') | map(attribute='name') | list | length == 0 and (cluster_master_peers[0] in (distributed_info['json']['entry'] | map(attribute='name') | list))
+  until: cluster_master_peers | length == (cluster_master_peers | intersect(distributed_info['json']['entry'] | selectattr('content.status','defined') | selectattr('content.status', 'search', 'Up') | map(attribute='content.peerName') | list) | length)
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
 


### PR DESCRIPTION
We have noticed failures on certain indexer cluster SVAs (C1 and C3) after introducing a dedicated instance/container for the monitoring console. Some background on the failure:

- Failure occurs on the `Fetch distributed peers when cm is defined` play
- Prior to this play, the monitoring console role compiles a list called `cluster_master_peers` that looks like the following: ["ip-address1:8089", "ip-address2:8089", "ip-address3:8089"]. These values represent idx1, idx2, and idx3 respectively.
- The failing play attempts to query that these indexer peers are up using the `name` and `content.status` fields from the API response. This response contains somewhat duplicate entries for each peer. For example, there will be one entry with the name `idx1:8089` and the status `Up` and one entry with the name `ip-address1:8089` and the status `Down`.
- Since we are comparing against the IP and not the fqdn (idx1, idx2, idx3), the task comes to the conclusion that all peers are `Down`, and it retries until the failure.

I have adjusted the 2 plays mentioned to use the fqdn (denoted by `label` and `peerName`) instead of the ip address assigned to each peer.