### PR TITLE
Prevent duplicate MC search peers

### DIFF
--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -29,7 +29,28 @@
 
 - name: Create list of peers
   set_fact:
-    group_list: "{{ (groups['splunk_indexer']| default([])) + (groups['splunk_search_head'] | default([])) + (groups['splunk_search_head_captain'] | default([])) + (groups['splunk_cluster_master'] | default([])) + (groups['splunk_deployment_server']| default([])) + (groups['splunk_license_master'] | default([])) + (groups['splunk_standalone'] | default([])) }}"
+    group_list: "{{ (groups['splunk_indexer'] | default([])) + (groups['splunk_search_head'] | default([])) + (groups['splunk_search_head_captain'] | default([])) + (groups['splunk_cluster_master'] | default([])) + (groups['splunk_deployment_server']| default([])) + (groups['splunk_license_master'] | default([])) + (groups['splunk_standalone'] | default([])) }}"
+
+- name: Fetch existing peers
+  splunk_api:
+    method: GET
+    url: "/services/search/distributed/peers?output_mode=json&count=0"
+    cert_prefix: "{{ cert_prefix }}"
+    username: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    svc_port: "{{ splunk.svc_port }}"
+    status_code: [200]
+    timeout: 10
+    return_content: yes
+    use_proxy: no
+  register: existing_peers
+  no_log: "{{ hide_password }}"
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+
+- name: Remove existing peers from group_list
+  set_fact:
+    group_list: "{{ group_list | difference(existing_peers['json']['entry'] | selectattr('content.status', 'search', 'Up') | map(attribute='content.peerName') | list) }}"
 
 - name: Update group_list
   vars:

--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -14,6 +14,7 @@
     use_proxy: no
   register: distsearch_server_info
   no_log: "{{ hide_password }}"
+
 - name: Initialize lists
   set_fact:
     current_group_list: []

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -1,6 +1,4 @@
 ---
-- include_tasks: ../../../roles/splunk_monitor/tasks/adding_peers.yml
-
 - include_tasks: ../../../roles/splunk_common/tasks/set_as_deployment_client.yml
   when:
     - splunk.deployment_server is defined

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -18,12 +18,6 @@
   vars:
     app_list: "{{ splunk.app_paths_install.default }}"
 
-- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
-  when:
-    - splunk_indexer_cluster or splunk.multisite_master is defined
-    - splunk.set_search_peers is defined
-    - splunk.set_search_peers | bool
-
 - include_tasks: setup_multisite.yml
   when:
     - splunk.site is defined

--- a/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
+++ b/roles/splunk_monitor/tasks/initialize_standalone_search_head.yml
@@ -18,6 +18,12 @@
   vars:
     app_list: "{{ splunk.app_paths_install.default }}"
 
+- include_tasks: ../../splunk_common/tasks/peer_cluster_master.yml
+  when:
+    - splunk_indexer_cluster or splunk.multisite_master is defined
+    - splunk.set_search_peers is defined
+    - splunk.set_search_peers | bool
+
 - include_tasks: setup_multisite.yml
   when:
     - splunk.site is defined

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -4,6 +4,8 @@
 - name: Flush restart handlers
   meta: flush_handlers
 
+- include_tasks: ../../../roles/splunk_monitor/tasks/adding_peers.yml
+
 - name: Fetch server info
   splunk_api:
     method: GET


### PR DESCRIPTION
Similar issue described in: https://github.com/splunk/splunk-ansible/pull/864

The monitoring console role performs 2 peering steps:
1. When indexer clustering is enabled, peer the cluster master. This automatically registers indexers as search peers
2. Manually add every instance as a search peer

This caused duplicate search peers for the indexers, where 1 set of search peers always has the status `Down` / `Sick`. This ultimately causes checks in `adding_peers.yml` to fail.

This PR makes the following changes:
- change the order of above steps so that peering the cluster master happens first
- before adding the remaining search peers, check for existing peers and remove them from our target list