### PR TITLE
Add splunk listen on ipv6 variable

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -152,6 +152,7 @@ def getDefaultVars():
     getUFSplunkVariables(defaultVars)
     getESSplunkVariables(defaultVars)
     getDSP(defaultVars)
+    getIPv6(defaultVars)
     return defaultVars
 
 def getSplunkPaths(vars_scope):
@@ -618,6 +619,13 @@ def getUFSplunkVariables(vars_scope):
         vars_scope["splunk"]["deployment_client"] = {
             "name": os.environ.get("SPLUNK_DEPLOYMENT_CLIENT_NAME")
         }
+
+def getIPv6(vars_scope):
+    """
+    Set specific environment variables to apply IPv6 configurations
+    """
+    vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", False)
+
 
 def getRandomString():
     """

--- a/roles/splunk_common/tasks/enable_ipv6.yml
+++ b/roles/splunk_common/tasks/enable_ipv6.yml
@@ -1,0 +1,23 @@
+---
+# Set endpoints to bind and listen to IPv6
+- name: Enable Splunk Enterprise for IPv6
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: general
+    option: listenOnIPv6
+    value: "true"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Enable Splunk Web for IPv6
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/web.conf"
+    section: settings
+    option: listenOnIPv6
+    value: "true"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -34,6 +34,9 @@
     - splunk.allow_upgrade is defined
     - splunk.allow_upgrade | bool
 
+- include_tasks: enable_ipv6.yml
+  when: splunk.listen_on_ipv6 | bool
+
 - include_tasks: enable_asan.yml
   when:
     - "'asan' in splunk and splunk.asan | bool"

--- a/roles/splunk_common/tasks/set_mgmt_port.yml
+++ b/roles/splunk_common/tasks/set_mgmt_port.yml
@@ -9,7 +9,7 @@
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
     section: settings
     option: "mgmtHostPort"
-    value: "{{ localhost_address}}:{{ splunk.svc_port }}"
+    value: "{{ localhost_address }}:{{ splunk.svc_port }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   when:

--- a/roles/splunk_common/tasks/set_mgmt_port.yml
+++ b/roles/splunk_common/tasks/set_mgmt_port.yml
@@ -1,10 +1,15 @@
 ---
+- name: Set localhost address for mgmt port
+  set_fact:
+    localhost_address: "{% if splunk.listen_on_ipv6 %}{{ '[::1]' }}{% else %}{{ '0.0.0.0' }}{% endif %}"
+    win_localhost_address: "{% if splunk.listen_on_ipv6 %}{{ '[::1]' }}{% else %}{{ '127.0.0.1' }}{% endif %}"
+
 - name: Set mgmt port
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
     section: settings
     option: "mgmtHostPort"
-    value: "0.0.0.0:{{ splunk.svc_port }}"
+    value: "{{ localhost_address}}:{{ splunk.svc_port }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   when:
@@ -17,7 +22,7 @@
     dest: "{{ splunk.home }}/etc/system/local/web.conf"
     section: settings
     option: "mgmtHostPort"
-    value: "127.0.0.1:{{ splunk.svc_port }}"
+    value: "{{ win_localhost_address }}:{{ splunk.svc_port }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   when:


### PR DESCRIPTION
Introduce new ansible env variable SPLUNK_LISTEN_ON_IPV6, when set to true, will apply the minimum configuration settings to Splunk to enable endpoints to listen via IPv6.