### PR TITLE
monitor role uri retries

### DIFF
--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -41,7 +41,7 @@
   when: splunk_indexer_cluster or splunk.multisite_master is defined
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
-  until: clusterMaster_peers_info.status_code == 200
+  until: clusterMaster_peers_info.status == 200
 
 - name: Create list of clusterMaster peers
   set_fact:

--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -41,6 +41,7 @@
   when: splunk_indexer_cluster or splunk.multisite_master is defined
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
+  until: clusterMaster_peers_info.status_code == 200
 
 - name: Create list of clusterMaster peers
   set_fact:


### PR DESCRIPTION
A splunk monitor task that uses the `uri` module is not able to retry when hitting a failure. This seems to be because there is no `until` condition.

This adds an until condition which checks the HTTP request response code to make sure it's 200. Otherwise, it can trigger the specified number of retries.