### PR TITLE
INFRA-43719: Add retry to reduce transient issues

### DIFF
--- a/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
+++ b/roles/splunk_cluster_master/tasks/apply_cluster_bundle.yml
@@ -14,36 +14,30 @@
   retries: "{{ retry_num }}"
   delay: "{{ retry_delay }}"
 
-# Fails if a cluster bundle did not already exist and yet we did not apply a new bundle.
-# The failed condition is basically eventHasError && bundleNotAlreadyExists.
-# The changed condition is basically !eventHasError && bundleNotAlreadyExists.
-#
 # Stderr/Stdout cases are:
 # 1) The cluster bundle already exists on the indexers. Then stderr will contain the message
-# "...bundle already exists" and we should *not* mark the play as either failed or changed.
+# "...bundle already exists".
 #
 # 2) The cluster bundle does not exist on the indexers but an error occurred during bundle
 # application. Then stderr will NOT contain the word "already" and stdout will contain an error
 # message such as "Error occurred when applying cluster bundle", "sh: invalid operation, exit code 1"
 # or no message at all.
 #
-# 3) The cluster bundle does not exist and we successfully applied the cluster bundle. Then stdout
-# will contain something to the effect of "Applying new bundle. Restarting indexers..". Thus, we
+# 3) The cluster bundle does not exist, and we successfully applied the cluster bundle. Then stdout
+# will contain something to the effect of "Applying new bundle. Restarting indexers..".
+#
+# To accommodate transient issues (such as the replication peers are restarting), we retry until either:
+#   - The command outputs the expected success message, or the bundle already exists.
 - name: Apply cluster bundle
   command: "{{ splunk.exec }} apply cluster-bundle -auth {{ splunk.admin_user }}:{{ splunk.password }} --skip-validation --answer-yes"
   become: yes
   become_user: "{{ splunk.user }}"
   register: splunk_cluster_bundle_result
-  failed_when: >
-    ((splunk_cluster_bundle_result.stdout is not search("[Aa]pply"))
-      or ("bundle" not in splunk_cluster_bundle_result.stdout)
-      or (splunk_cluster_bundle_result.stdout is search("[Ee]rror")))
-    and ("already" not in splunk_cluster_bundle_result.stderr)
-  changed_when: >
+  until: >
     ((splunk_cluster_bundle_result.stdout is search("[Aa]pply"))
       and ("bundle" in splunk_cluster_bundle_result.stdout)
       and (splunk_cluster_bundle_result.stdout is not search("[Ee]rror")))
-    and ("already" not in splunk_cluster_bundle_result.stderr)
+    or ("already" in splunk_cluster_bundle_result.stderr)
   no_log: "{{ hide_password }}"
   retries: "{{ retry_num }}" # We will sometimes see this if the number of peers dictacted by the replication factor aren't up
   delay: "{{ retry_delay }}"

--- a/roles/splunk_common/tasks/change_splunk_directory_owner.yml
+++ b/roles/splunk_common/tasks/change_splunk_directory_owner.yml
@@ -7,3 +7,7 @@
     recurse: yes
   become: yes
   become_user: "{{ privileged_user }}"
+  register: cmd_result
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  until: not cmd_result.failed


### PR DESCRIPTION
Multisite deployment has a small chance of getting some race conditions when modifying directory ownership on site A, and site B is pushing some files to site A. Also adding retry to apply cluster bundle step, so it can handle the case when peers are restarting.