### PR TITLE
check for uds file as splunk.user

### DIFF
--- a/roles/splunk_common/tasks/check_uds_file.yml
+++ b/roles/splunk_common/tasks/check_uds_file.yml
@@ -3,6 +3,8 @@
   stat:
     path: "{{ splunk.home }}/var/run/splunk/cli.socket"
   register: socket_file
+  become: yes
+  become_user: "{{ splunk.user }}"
 
 - name: Set UDS enabled/disabled
   set_fact:


### PR DESCRIPTION
If ansible is running as a non-root user, it won't have permissions to read the cli.socket file. Running the check for the socket file as the splunk user ensures the permissions are correct for it to be read.