### PR TITLE
SOK serverName

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -130,6 +130,11 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNK_ANSIBLE_ENV | Pass in a comma-separated list of "key=value" pairs that will be mapped to environment variables used during `site.yml` execution. These variables are also available in ansible pre/post playbooks and can be referenced as `hostvars['localhost'].ansible_environment['key']` | no | no | no |
 | SPLUNK_CONNECTION_TIMEOUT | Configures splunkdConnectionTimeout in `web.conf` with passed integer value (in seconds) | no | no | no |
 | SPLUNK_ES_SSL_ENABLEMENT | Set the ssl-enablement flag in ES.  Valid values are 'auto', 'strict', and 'ignore'. Defaults to auto when present. | no | no | no |
+| SPLUNK_SERVICE_NAME | Used alongside `POD_NAMESPACE` and `CLUSTER_DOMAIN` to construct a k8s-supported `issuer_uri` value for oauth2 configurations | no | no | no |
+| SPLUNK_HEADLESS_SERVICE_NAME | Used alongside `POD_NAME`, `POD_NAMESPACE`, and `CLUSTER_DOMAIN` to construct a k8s-supported `serverName` value. This is also used for the `search_head_uri` and `register_replication_address` settings when clustering is enabled. | no | no | no |
+| POD_NAME | Defines the current pod name in a k8s environment | no | no | no |
+| POD_NAMESPACE | Defines the namespace of the current pod in a k8s environment | no | no | no |
+| CLUSTER_DOMAIN | Defines the domain name for DNS resolution in a k8s cluster (default: cluster.local) | no | no | no |
 
 \* Password must be set either in `default.yml` or as the environment variable `SPLUNK_PASSWORD`
 

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -139,8 +139,9 @@ def getDefaultVars():
     defaultVars["splunk"]["preferred_captaincy"] = True
     if os.environ.get("SPLUNK_PREFERRED_CAPTAINCY", "").lower() == "false":
         defaultVars["splunk"]["preferred_captaincy"] = False
-    defaultVars["splunk"]["hostname"] = os.environ.get('SPLUNK_HOSTNAME', socket.getfqdn())
+    defaultVars["splunk"]["hostname"] = os.environ.get('SPLUNK_HOSTNAME', socket.getfqdn())    
 
+    getServiceName(defaultVars)
     getJava(defaultVars)
     getSplunkBuild(defaultVars)
     getSplunkbaseToken(defaultVars)
@@ -154,6 +155,20 @@ def getDefaultVars():
     getDSP(defaultVars)
     getIPv6(defaultVars)
     return defaultVars
+
+def getServiceName(vars_scope):
+    """
+    Use k8s related env vars to construct a custom serverName value
+    """
+    podName = os.environ.get("POD_NAME", socket.getfqdn())
+    clusterDomain = os.environ.get("CLUSTER_DOMAIN", "cluster.local")
+    serviceName = os.environ.get("SPLUNK_SERVICE_NAME", "")
+    headlessServiceName = os.environ.get("SPLUNK_HEADLESS_SERVICE_NAME", "")
+    namespace = os.environ.get("POD_NAMESPACE", "")
+    if serviceName != "" and namespace != "":
+        vars_scope["splunk"]["issuer_uri"] = "{}.{}.svc.{}".format(serviceName, namespace, clusterDomain)
+    if headlessServiceName != "" and namespace != "":
+        vars_scope["splunk"]["server_name"] = "{}.{}.{}.svc.{}".format(podName, headlessServiceName, namespace, clusterDomain)
 
 def getSplunkPaths(vars_scope):
     """

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -141,3 +141,6 @@
 
 - include_tasks: check_mgmt_mode_status.yml
   when: splunk.role == "splunk_universal_forwarder"
+
+- include_tasks: set_server_name.yml
+  when: "'server_name' in splunk and splunk.server_name is not none"

--- a/roles/splunk_common/tasks/set_server_name.yml
+++ b/roles/splunk_common/tasks/set_server_name.yml
@@ -33,7 +33,7 @@
   when:
     - splunk.role == "splunk_search_head"
     - splunk_search_head_cluster | bool
-  register: set_shcclustering_sername_name
+  register: set_shcclustering_server_name
 
 - include_tasks: ../handlers/restart_splunk.yml
   when: set_server_name is changed or set_clustering_server_name is changed or set_shcclustering_server_name is changed

--- a/roles/splunk_common/tasks/set_server_name.yml
+++ b/roles/splunk_common/tasks/set_server_name.yml
@@ -1,0 +1,39 @@
+---
+- ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: general
+    option: "serverName"
+    value: "{{ splunk.server_name }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  register: set_server_name
+
+- ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: clustering
+    option: "register_replication_address"
+    value: "{{ splunk.server_name }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when:
+    - splunk.role == "splunk_indexer"
+    - splunk_indexer_cluster | bool
+  register: set_clustering_server_name
+
+- ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: shcclustering
+    option: "{{ item }}"
+    value: "{{ splunk.server_name }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  with_items:
+    - register_replication_address
+    - search_head_uri
+  when:
+    - splunk.role == "splunk_search_head"
+    - splunk_search_head_cluster | bool
+  register: set_shcclustering_sername_name
+
+- include_tasks: ../handlers/restart_splunk.yml
+  when: set_server_name is changed or set_clustering_server_name is changed or set_shcclustering_server_name is changed


### PR DESCRIPTION
Adds the ability to set a custom `serverName`, `register_replication_address`, and `search_head_uri` value in server.conf. This is required for Splunk Operator for Kubernetes (SOK) applications.