### PR TITLE
allow overriding rpm gpg key location

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -151,6 +151,10 @@ splunk:
   * Splunk build location, either on the filesystem or a remote URL
   * Default: null
 
+  build_location_rpm_key: <str>
+  * GPG key to install for rpm installation, either on the filesystem or a remote URL
+  * Default: null
+
   build_url_bearer_token: <str>
   * Bearer token used to provide authorization when fetching a Splunk build from a remote URL. 
   * Default: null

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -27,6 +27,7 @@ config:
 splunk:
     enable_tcp_mode: False
     build_location:
+    build_location_rpm_key:
     allow_upgrade: True
     tar_dir: "splunk"
     opt: &opt "/opt"

--- a/roles/splunk_common/tasks/install_splunk_yum.yml
+++ b/roles/splunk_common/tasks/install_splunk_yum.yml
@@ -2,7 +2,7 @@
 # https://github.com/ansible/ansible/issues/18979
 - name: Import Splunk key
   rpm_key:
-    key: https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub
+    key: "{{ splunk.build_location_rpm_key | default('https://docs.splunk.com/images/6/6b/SplunkPGPKey.pub') }}"
     state: present
 
 - name: Install Splunk (yum)


### PR DESCRIPTION
We are getting 403 errors when attempting to retrieve the splunk rpm key. This patch allows us to keep our own copy and would allow installation on a machine that does not have access to splunk.com.