### PR TITLE
Point to python binary in custom module

### DIFF
--- a/ansible_commands/shc_ready.py
+++ b/ansible_commands/shc_ready.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from __future__ import absolute_import
 '''
 Ansible module


### PR DESCRIPTION
Starting in ansible-core 2.15, we are explicitly told not to use `#!/usr/bin/env <python/python3>` as a header for custom modules: https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding

We have also observed issues with this method in Ubuntu environments with only python3 installed. The command itself (`/usr/bin/env python`) runs fine on its own, but it produces an error when used inside of ansible-playbook invocations.
```
MSG:

The module failed to execute correctly, you probably need to set the interpreter.
See stdout/stderr for the exact error


MODULE_STDERR:

/bin/sh: 1: /usr/bin/env python: not found
```

Note that this change may require some additional setup to ensure that the python binary (or a symlink) exists at the `/usr/bin/python` path.