### PR TITLE
feat: add become statements to allow non-root ansible execution

### DIFF
--- a/roles/splunk_common/tasks/enable_forwarding.yml
+++ b/roles/splunk_common/tasks/enable_forwarding.yml
@@ -2,6 +2,8 @@
 # Configure forwarding to indexer cluster master
 # See: https://docs.splunk.com/Documentation/Splunk/latest/Indexer/indexerdiscovery
 - name: Setup indexer discovery for index-clustering
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/outputs.conf"
     section: "indexer_discovery:splunk-indexer"
@@ -21,6 +23,8 @@
     label: "{{ item.key }}"
 
 - name: Setup tcpout group for index-clustering
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/outputs.conf"
     section: "tcpout:group1"
@@ -40,6 +44,8 @@
   register: tcpout_group
 
 - name: Setup default tcpout group for index-clustering
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/outputs.conf"
     section: "tcpout"
@@ -57,6 +63,8 @@
 
 # NOTE: If this task is called or used, it will disable all local indexing!
 - name: Disable indexing on the current node
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     path: "{{ splunk.home }}/etc/system/local/outputs.conf"
     section: "indexAndForward"

--- a/roles/splunk_common/tasks/enable_splunkweb_ssl.yml
+++ b/roles/splunk_common/tasks/enable_splunkweb_ssl.yml
@@ -8,6 +8,8 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     mode: 0660
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - name: Set Web certificate path
   ini_file:
@@ -21,6 +23,8 @@
   when:
     - splunk.http_enableSSL_cert is defined
     - splunk.http_enableSSL_cert
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - name: Set Web private key path
   ini_file:
@@ -34,6 +38,8 @@
   when:
     - splunk.http_enableSSL_privKey is defined
     - splunk.http_enableSSL_privKey
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - name: Set Web private key password
   ini_file:
@@ -47,3 +53,5 @@
   when:
     - splunk.http_enableSSL_privKey_password is defined
     - splunk.http_enableSSL_privKey_password
+  become: true
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/s2s/configure_splunktcp.yml
+++ b/roles/splunk_common/tasks/s2s/configure_splunktcp.yml
@@ -1,5 +1,7 @@
 ---
 - name: Enable splunktcp input
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: "splunktcp://{{ splunk.s2s_port if splunk.s2s_port is defined else splunk.s2s.port }}"
@@ -10,6 +12,8 @@
   register: splunktcp_enabled
 
 - name: Remove splunktcp-ssl input
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: "splunktcp-ssl:{{ splunk.s2s_port if splunk.s2s_port is defined else splunk.s2s.port }}"
@@ -19,6 +23,8 @@
   register: splunktcp_ssl_disabled
 
 - name: Remove input SSL settings
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: SSL
@@ -28,6 +34,8 @@
   register: splunktcp_ssl_reset
 
 - name: Reset root CA
+  become: yes
+  become_user: "{{ splunk.user }}"
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: sslConfig

--- a/roles/splunk_common/tasks/set_general_symmkey_password.yml
+++ b/roles/splunk_common/tasks/set_general_symmkey_password.yml
@@ -8,6 +8,8 @@
     group: "{{ splunk.group }}"
   register: set_symmkey
   no_log: "{{ hide_password }}"
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - include_tasks: trigger_restart.yml
   when: set_symmkey is changed

--- a/roles/splunk_common/tasks/set_http_port.yml
+++ b/roles/splunk_common/tasks/set_http_port.yml
@@ -8,6 +8,8 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   when: splunk.http_port == 0
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - name: Set HTTP Port
   ini_file:
@@ -18,3 +20,5 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   when: splunk.http_port != 0
+  become: true
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/set_mgmt_port.yml
+++ b/roles/splunk_common/tasks/set_mgmt_port.yml
@@ -16,6 +16,8 @@
     - "'svc_port' in splunk"
     - ansible_system is not match("CYGWIN*|Win32NT")
   register: set_mgmt_port
+  become: true
+  become_user: "{{ splunk.user }}"
 
 - name: Set mgmt port (Windows)
   ini_file:
@@ -30,6 +32,8 @@
     - ansible_system is match("CYGWIN*|Win32NT")
     - splunk.svc_port | int != 8089
   register: set_mgmt_port
+  become: true
+  become_user: "{{ splunk.user }}"
 
 # Restart only when Splunk is running and when any of the above have changed
 - include_tasks: ../handlers/restart_splunk.yml


### PR DESCRIPTION
This pull request just adds more become and become_user specifications so that people who run ansible as a non-root user can do so. This also helps to make sure that files that are created are owned by the splunk.user.