### PR TITLE
feat: allow a manual list of servers for a monitoring console to monitor

### DIFF
--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -176,7 +176,29 @@ splunk:
   *     pass4SymmKey: thisisasecret
   *   - url: https://master.us-east.corp.net:8089
   *     pass4SymmKey: thisisanothersecret
+
+  manual_monitor_list: <list>
+  * List of other splunk instances that a monitoring console should monitor in addition to automatically added servers from other groups.
+  * Default: []
+  * Example:
+  *   manual_monitor_list:
+  *   - extra-server-1.example.org
+  *   - extra-server-2.example.org
+  *   - different-auth-server-1.example.org
+  *   - different-auth-server-2.example.org
   
+  remote-credentials: <dict>
+  * List of credentials for splunk servers that don't match the defaults
+  * Default: {}
+  * Example:
+  *   remote-credentials:
+  *     different-auth-server-1.example.org:
+  *       admin_user: my-adm-user
+  *       admin_password: my-adm-password
+  *     different-auth-server-2.example.org:
+  *       admin_user: my-adm-user
+  *       admin_password: my-adm-password
+
   deployer_url: null
   * Hostname of Splunk Enterprise deployer instance. May be overridden using SPLUNK_DEPLOYER_URL environment variable.
   * Default: null

--- a/roles/splunk_monitor/tasks/adding_peers.yml
+++ b/roles/splunk_monitor/tasks/adding_peers.yml
@@ -29,7 +29,7 @@
 
 - name: Create list of peers
   set_fact:
-    group_list: "{{ (groups['splunk_indexer'] | default([])) + (groups['splunk_search_head'] | default([])) + (groups['splunk_search_head_captain'] | default([])) + (groups['splunk_cluster_master'] | default([])) + (groups['splunk_deployment_server']| default([])) + (groups['splunk_license_master'] | default([])) + (groups['splunk_standalone'] | default([])) }}"
+    group_list: "{{ (groups['splunk_indexer'] | default([])) + (groups['splunk_search_head'] | default([])) + (groups['splunk_search_head_captain'] | default([])) + (groups['splunk_cluster_master'] | default([])) + (groups['splunk_deployment_server']| default([])) + (groups['splunk_license_master'] | default([])) + (groups['splunk_standalone'] | default([])) + (splunk['manual_monitor_list'] | default([])) }}"
 
 - name: Fetch existing peers
   splunk_api:
@@ -88,7 +88,7 @@
   with_items: "{{ group_list }}"
 
 - name: Set search peers
-  command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk.admin_user }} -remotePassword {{ splunk.password }}"
+  command: "{{ splunk.exec }} add search-server {{ cert_prefix }}://{{ item }}:{{ splunk.svc_port }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -remoteUsername {{ splunk['remote-credentials'][item]['admin_user'] | default(splunk.admin_user) }} -remotePassword {{ splunk['remote-credentials'][item]['admin_password'] | default(splunk.password) }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_as_peer


### PR DESCRIPTION
These changes allow the addition of other splunk servers to be monitored by a monitoring console. The don't need to be a part of the splunk-ansible inventory.