### PR TITLE
Fix License manager dual server role problem in Monitoring Console

### DIFF
--- a/roles/splunk_monitor/tasks/main.yml
+++ b/roles/splunk_monitor/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: Create search strings
   set_fact:
-    index_string: "{{ distributed_info['json']['entry'] | selectattr('content.server_roles','defined') | selectattr('content.server_roles', 'search', 'indexer') | map(attribute='name') | list | join('&member=') }}"
+    index_string: "{{ distributed_info['json']['entry'] | selectattr('content.server_roles','defined') | selectattr('content.server_roles', 'search', 'indexer') | rejectattr('content.server_roles', 'search', 'license_master') | map(attribute='name') | list | join('&member=') }}"
     search_head_string: "{{ distributed_info['json']['entry'] | selectattr('content.server_roles','defined') | selectattr('content.server_roles', 'regex', '(?:shc_member|search_head|shc_captain)') | map(attribute='name') | list | join('&member=') }}"
     cluster_master_string: "{{ distributed_info['json']['entry'] | selectattr('content.server_roles','defined') | selectattr('content.server_roles', 'search', 'cluster_master') | map(attribute='name') | list | join('&member=') }}"
     deployment_server_string: "{{ distributed_info['json']['entry'] | selectattr('content.server_roles','defined') | selectattr('content.server_roles', 'search', 'deployment_server') | map(attribute='name') | list | join('&member=') }}"


### PR DESCRIPTION
Description:

In C3 deployments, the License Manager incorrectly appears with an indexer role in the Monitoring Console because:

- License Manager has dual server roles: A Splunk License Manager instance reports both license_master and indexer in its server_roles array (it's a standalone Splunk instance by default)
- Insufficient filtering logic: The code in `main.yml` filtered peers by checking if indexer was in their server_roles, but didn't exclude instances that also have the license_master role

Fix Applied:

Modified line 94 in main.yml:
The added `| rejectattr('content.server_roles', 'search', 'license_master')` filter excludes any peer that has license_master in its server roles from being added to the indexer group in the Monitoring Console.

Impact:

This fix ensures that License Managers are correctly categorized only in the dmc_group_license_master group and not incorrectly added to the dmc_group_indexer group in the Monitoring Console configuration.