### PR TITLE
SPL-290972: Add ansible support to read the env  KVSERVICE_CONNECTION_STRING and write it to server.conf

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -618,6 +618,7 @@ def overrideEnvironmentVars(vars_scope):
     vars_scope["splunk"]["allow_upgrade"] = os.environ.get('SPLUNK_ALLOW_UPGRADE', vars_scope["splunk"]["allow_upgrade"])
     vars_scope["splunk"]["appserver"]["port"] = os.environ.get('SPLUNK_APPSERVER_PORT', vars_scope["splunk"]["appserver"]["port"])
     vars_scope["splunk"]["kvstore"]["port"] = os.environ.get('SPLUNK_KVSTORE_PORT', vars_scope["splunk"]["kvstore"]["port"])
+    vars_scope["splunk"]["kvstore"]["kvservice_connection_string"] = os.environ.get('KVSERVICE_CONNECTION_STRING', vars_scope["splunk"]["kvstore"].get("kvservice_connection_string"))
     vars_scope["splunk"]["connection_timeout"] = int(os.environ.get('SPLUNK_CONNECTION_TIMEOUT', vars_scope["splunk"]["connection_timeout"]))
 
     if vars_scope["splunk"]["splunk_http_enabled"] == "false" and "forwarder" not in vars_scope["splunk"]["role"].lower():

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -70,6 +70,7 @@ splunk:
         port: 8065
     kvstore:
         port: 8191
+        kvservice_connection_string:
     http_port: 8000
     http_enableSSL: 0
     http_enableSSL_cert:

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -94,6 +94,12 @@
     - "'kvstore' in splunk and 'port' in splunk.kvstore"
     - splunk.kvstore.port | int != 8191
 
+- include_tasks: set_kvservice_connection_string.yml
+  when:
+    - "'kvstore' in splunk and 'kvservice_connection_string' in splunk.kvstore"
+    - splunk.kvstore.kvservice_connection_string is not none
+    - splunk.kvstore.kvservice_connection_string | length > 0
+
 - include_tasks: enable_splunkweb_ssl.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"

--- a/roles/splunk_common/tasks/set_kvservice_connection_string.yml
+++ b/roles/splunk_common/tasks/set_kvservice_connection_string.yml
@@ -1,0 +1,9 @@
+---
+- name: Set externalManagedKVStoreConnectionString
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: kvstore
+    option: "externalManagedKVStoreConnectionString"
+    value: "{{ splunk.kvstore.kvservice_connection_string }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"

--- a/roles/splunk_common/tasks/set_kvservice_connection_string.yml
+++ b/roles/splunk_common/tasks/set_kvservice_connection_string.yml
@@ -1,9 +1,9 @@
 ---
-- name: Set externalManagedKVStoreConnectionString
+- name: Set kvserviceConnectionString
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: kvstore
-    option: "externalManagedKVStoreConnectionString"
+    option: "kvserviceConnectionString"
     value: "{{ splunk.kvstore.kvservice_connection_string }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -891,6 +891,10 @@ def test_getSplunkAppsLocal(default_yml, os_env, apps_count):
                 # Check splunk.kvstore.port
                 ({"splunk": {"kvstore" :{"port": "9165"}}}, {}, "splunk.kvstore.port", "9165"),
                 ({}, {"SPLUNK_KVSTORE_PORT": "9265"}, "splunk.kvstore.port", "9265"),
+                # Check splunk.kvstore.kvservice_connection_string
+                ({"splunk": {"kvstore": {"kvservice_connection_string": "splunk-kvservice.my-namespace.svc.cluster.local:443"}}}, {}, "splunk.kvstore.kvservice_connection_string", "splunk-kvservice.my-namespace.svc.cluster.local:443"),
+                ({}, {"KVSERVICE_CONNECTION_STRING": "splunk-kvservice.my-namespace.svc.cluster.local:443"}, "splunk.kvstore.kvservice_connection_string", "splunk-kvservice.my-namespace.svc.cluster.local:443"),
+                ({"splunk": {"kvstore": {"kvservice_connection_string": "old-value.svc.cluster.local:443"}}}, {"KVSERVICE_CONNECTION_STRING": "new-value.svc.cluster.local:443"}, "splunk.kvstore.kvservice_connection_string", "new-value.svc.cluster.local:443"),
                 # Check splunk.connection_timeout
                 ({"splunk": {"connection_timeout": 60}}, {}, "splunk.connection_timeout", 60),
                 ({}, {"SPLUNK_CONNECTION_TIMEOUT": 200}, "splunk.connection_timeout", 200),
@@ -909,7 +913,7 @@ def test_overrideEnvironmentVars(default_yml, os_env, key, value):
                                 "svc_port": 8089,
                                 "s2s": {"port": 9997},
                                 "appserver": {"port": 8065},
-                                "kvstore": {"port": 8191},
+                                "kvstore": {"port": 8191, "kvservice_connection_string": None},
                                 "hec_token": "abcd1234",
                                 "enable_service": False,
                                 "service_name": "Splunkd",


### PR DESCRIPTION
```
tests/small/test_environ.py::test_overrideEnvironmentVars[default_yml26-os_env26-splunk.kvstore.kvservice_connection_string-splunk-kvservice.my-namespace.svc.cluster.local:443] PASSED [ 33%]
tests/small/test_environ.py::test_overrideEnvironmentVars[default_yml27-os_env27-splunk.kvstore.kvservice_connection_string-splunk-kvservice.my-namespace.svc.cluster.local:443] PASSED [ 66%]
tests/small/test_environ.py::test_overrideEnvironmentVars[default_yml28-os_env28-splunk.kvstore.kvservice_connection_string-new-value.svc.cluster.local:443] PASSED [100%]
```