### PR TITLE
Add support for site-specific multisite SF and RF

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -94,8 +94,10 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNK_MULTISITE_MASTER_PORT | For multisite topologies, define the Splunk management port of the multisite cluster master | no | no | no |
 | SPLUNK_MULTISITE_REPLICATION_FACTOR_ORIGIN | For multisite topologies, define the origin replication factor | no | no | no |
 | SPLUNK_MULTISITE_REPLICATION_FACTOR_TOTAL | For multisite topologies, define the total replication factor | no | no | no |
+| SPLUNK_MULTISITE_REPLICATION_FACTOR_SITES | For multisite topologies, define site-specific replication terms (for example: `site1:1,site2:1`) | no | no | no |
 | SPLUNK_MULTISITE_SEARCH_FACTOR_ORIGIN | For multisite topologies, define the origin search factor | no | no | no |
 | SPLUNK_MULTISITE_SEARCH_FACTOR_TOTAL | For multisite topologies, define the total search factor | no | no | no |
+| SPLUNK_MULTISITE_SEARCH_FACTOR_SITES | For multisite topologies, define site-specific search terms (for example: `site1:1,site2:1`) | no | no | no |
 | NO_HEALTHCHECK | Disable the Splunk health check script | no | no | yes |
 | STEPDOWN_ANSIBLE_USER | Removes Ansible user from the sudo group when set to true. This means that no other users than root will have root access. | no | no | no |
 | SPLUNK_HOME_OWNERSHIP_ENFORCEMENT | Recursively enforces `${SPLUNK_HOME}` to be owned by the user "splunk". Default: `True` | no | no | no |

--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -482,6 +482,12 @@ splunk:
   * Determine site-level knowledge object replication factor when in a multisite environment
   * Default: 3
 
+  multisite_replication_factor_sites:
+  * Optional site-specific replication terms (without origin/total), appended between origin and total values
+  * Example: `site1:1,site2:1`
+  * Final value rendered as: `origin:<origin>,<sites>,total:<total>`
+  * Default: null
+
   multisite_search_factor_origin:
   * Determine origin-level search replication factor when in a multisite environment
   * Default: 1
@@ -489,6 +495,12 @@ splunk:
   multisite_search_factor_total:
   * Determine site-level search replication factor when in a multisite environment
   * Default: 3
+
+  multisite_search_factor_sites:
+  * Optional site-specific search terms (without origin/total), appended between origin and total values
+  * Example: `site1:1,site2:1`
+  * Final value rendered as: `origin:<origin>,<sites>,total:<total>`
+  * Default: null
 
   site:
   * Define the site of this particular Splunk Enterprise instance when in a multisite environment

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -286,6 +286,79 @@ def getMultisite(vars_scope):
     splunk_vars["multisite_search_factor_origin"] = int(os.environ.get("SPLUNK_MULTISITE_SEARCH_FACTOR_ORIGIN", splunk_vars.get("multisite_search_factor_origin", 1)))
     splunk_vars["multisite_search_factor_total"] = int(os.environ.get("SPLUNK_MULTISITE_SEARCH_FACTOR_TOTAL", splunk_vars.get("multisite_search_factor_total", 1)))
     splunk_vars["multisite_search_factor_total"] = max(splunk_vars["multisite_search_factor_total"], splunk_vars["idxc"]["search_factor"])
+    replication_sites = os.environ.get(
+        "SPLUNK_MULTISITE_REPLICATION_FACTOR_SITES",
+        splunk_vars.get("multisite_replication_factor_sites")
+    )
+    normalized_replication_sites = ""
+    if replication_sites:
+        normalized_replication_sites = normalizeMultisiteFactorSites(replication_sites)
+        splunk_vars["multisite_replication_factor_sites"] = normalized_replication_sites
+    splunk_vars["multisite_replication_factor"] = buildMultisiteFactor(
+        splunk_vars["multisite_replication_factor_origin"],
+        splunk_vars["multisite_replication_factor_total"],
+        normalized_replication_sites
+    )
+
+    search_sites = os.environ.get(
+        "SPLUNK_MULTISITE_SEARCH_FACTOR_SITES",
+        splunk_vars.get("multisite_search_factor_sites")
+    )
+    normalized_search_sites = ""
+    if search_sites:
+        normalized_search_sites = normalizeMultisiteFactorSites(search_sites)
+        splunk_vars["multisite_search_factor_sites"] = normalized_search_sites
+    splunk_vars["multisite_search_factor"] = buildMultisiteFactor(
+        splunk_vars["multisite_search_factor_origin"],
+        splunk_vars["multisite_search_factor_total"],
+        normalized_search_sites
+    )
+
+def normalizeMultisiteFactorSites(sites):
+    """
+    Normalize site-only multisite factors, where each term is site:value.
+    Example input: site1:1,site2:1
+    """
+    try:
+        string_types = (basestring,)
+    except NameError:
+        string_types = (str,)
+
+    if not isinstance(sites, string_types):
+        raise Exception("Invalid multisite factor sites format: expected a string")
+
+    parsed_factors = []
+    for term in sites.split(","):
+        site_factor = term.strip()
+        if not site_factor:
+            continue
+        parts = site_factor.split(":", 1)
+        if len(parts) != 2:
+            raise Exception("Invalid multisite factor term '{}'".format(site_factor))
+        site = parts[0].strip()
+        if not site:
+            raise Exception("Invalid multisite factor term '{}'".format(site_factor))
+        if site in ("origin", "total"):
+            raise Exception("Invalid multisite factor site '{}': use origin/total base variables".format(site))
+        try:
+            value = int(parts[1].strip())
+        except ValueError:
+            raise Exception("Invalid multisite factor term '{}'".format(site_factor))
+
+        parsed_factors.append((site, value))
+
+    if not parsed_factors:
+        raise Exception("Invalid multisite factor sites format: no values supplied")
+
+    return ",".join(["{}:{}".format(site, value) for site, value in parsed_factors])
+
+def buildMultisiteFactor(origin, total, sites):
+    """
+    Build full multisite factor string from base origin/total values plus site-only terms.
+    """
+    if not sites:
+        return "origin:{},total:{}".format(origin, total)
+    return "origin:{},{},total:{}".format(origin, sites, total)
 
 def getSplunkWebSSL(vars_scope):
     """

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -109,8 +109,10 @@ splunk:
         spark_master_webui_port: 8080
     multisite_replication_factor_origin: 2
     multisite_replication_factor_total: 3
+    multisite_replication_factor_sites:
     multisite_search_factor_origin: 1
     multisite_search_factor_total: 2
+    multisite_search_factor_sites:
     license_master_url:
     cluster_master_url:
     auxiliary_cluster_masters: []

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -98,8 +98,10 @@ splunk:
         replication_ssl: False
     multisite_replication_factor_origin: 2
     multisite_replication_factor_total: 3
+    multisite_replication_factor_sites:
     multisite_search_factor_origin: 1
     multisite_search_factor_total: 2
+    multisite_search_factor_sites:
     license_master_url:
     cluster_master_url:
     auxiliary_cluster_masters: []

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -97,8 +97,10 @@ splunk:
         replication_port: 9887
     multisite_replication_factor_origin: 2
     multisite_replication_factor_total: 3
+    multisite_replication_factor_sites:
     multisite_search_factor_origin: 1
     multisite_search_factor_total: 2
+    multisite_search_factor_sites:
     license_master_url:
     cluster_master_url:
     auxiliary_cluster_masters: []

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -97,8 +97,10 @@ splunk:
         replication_port: 9887
     multisite_replication_factor_origin: 2
     multisite_replication_factor_total: 3
+    multisite_replication_factor_sites:
     multisite_search_factor_origin: 1
     multisite_search_factor_total: 2
+    multisite_search_factor_sites:
     license_master_url:
     cluster_master_url:
     auxiliary_cluster_masters: []

--- a/roles/splunk_cluster_master/tasks/setup_multisite.yml
+++ b/roles/splunk_cluster_master/tasks/setup_multisite.yml
@@ -9,7 +9,7 @@
       multisite_master_uri: "{{ cert_prefix }}://{{ splunk.multisite_master }}:{{ splunk.svc_port }}"
 
 - name: Set the multisite master
-  command: "{{ splunk.exec }} edit cluster-config -mode master -multisite true -available_sites {{ splunk.all_sites }} -site {{ splunk.site }} -site_replication_factor origin:{{ splunk.multisite_replication_factor_origin }},total:{{ splunk.multisite_replication_factor_total }} -site_search_factor origin:{{ splunk.multisite_search_factor_origin }},total:{{ splunk.multisite_search_factor_total }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
+  command: "{{ splunk.exec }} edit cluster-config -mode master -multisite true -available_sites {{ splunk.all_sites }} -site {{ splunk.site }} -site_replication_factor {{ splunk.multisite_replication_factor }} -site_search_factor {{ splunk.multisite_search_factor }} -auth {{ splunk.admin_user }}:{{ splunk.password }} -secret {{ splunk.idxc.pass4SymmKey }}"
   become: yes
   become_user: "{{ splunk.user }}"
   register: set_multisite_master

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -164,9 +164,106 @@ def test_getSearchHeadClustering(default_yml, os_env, output):
     assert type(vars_scope["splunk"]["shc"]) == dict
     assert vars_scope["splunk"]["shc"] == output
 
-@pytest.mark.skip(reason="TODO")
-def test_getMultisite():
-    pass
+@pytest.mark.parametrize(("sites", "result"),
+            [
+                ("site1:1,site2:1", "site1:1,site2:1"),
+                (" site1:1, site2:1 ", "site1:1,site2:1"),
+            ]
+        )
+def test_normalizeMultisiteFactorSites(sites, result):
+    assert environ.normalizeMultisiteFactorSites(sites) == result
+
+@pytest.mark.parametrize(("sites",),
+            [
+                ("",),
+                ("site1",),
+                ("site1:abc",),
+                ("origin:1",),
+                ("total:2",),
+            ]
+        )
+def test_normalizeMultisiteFactorSites_exception(sites):
+    with pytest.raises(Exception):
+        environ.normalizeMultisiteFactorSites(sites)
+
+@pytest.mark.parametrize(("origin", "total", "sites", "result"),
+            [
+                (1, 2, "site1:1,site2:1", "origin:1,site1:1,site2:1,total:2"),
+                (1, 2, "", "origin:1,total:2"),
+            ]
+        )
+def test_buildMultisiteFactor(origin, total, sites, result):
+    assert environ.buildMultisiteFactor(origin, total, sites) == result
+
+@pytest.mark.parametrize(("default_yml", "os_env", "output"),
+            [
+                # Existing origin/total behavior remains unchanged
+                (
+                    {"site": "site1", "idxc": {"replication_factor": 2, "search_factor": 2}},
+                    {},
+                    {
+                        "site": "site1",
+                        "idxc": {"replication_factor": 2, "search_factor": 2},
+                        "multisite_master_port": 8089,
+                        "multisite_replication_factor_origin": 1,
+                        "multisite_replication_factor_total": 2,
+                        "multisite_replication_factor": "origin:1,total:2",
+                        "multisite_search_factor_origin": 1,
+                        "multisite_search_factor_total": 2,
+                        "multisite_search_factor": "origin:1,total:2"
+                    }
+                ),
+                # Site-specific terms are merged with generated origin/total values
+                (
+                    {"site": "site1", "idxc": {"replication_factor": 2, "search_factor": 2}},
+                    {
+                        "SPLUNK_MULTISITE_REPLICATION_FACTOR_SITES": "site1:1,site2:1",
+                        "SPLUNK_MULTISITE_SEARCH_FACTOR_SITES": "site1:1,site2:1"
+                    },
+                    {
+                        "site": "site1",
+                        "idxc": {"replication_factor": 2, "search_factor": 2},
+                        "multisite_master_port": 8089,
+                        "multisite_replication_factor_origin": 1,
+                        "multisite_replication_factor_total": 2,
+                        "multisite_replication_factor_sites": "site1:1,site2:1",
+                        "multisite_replication_factor": "origin:1,site1:1,site2:1,total:2",
+                        "multisite_search_factor_origin": 1,
+                        "multisite_search_factor_total": 2,
+                        "multisite_search_factor_sites": "site1:1,site2:1",
+                        "multisite_search_factor": "origin:1,site1:1,site2:1,total:2"
+                    }
+                ),
+                # YAML site-specific terms are merged when env vars are not provided
+                (
+                    {
+                        "site": "site1",
+                        "idxc": {"replication_factor": 2, "search_factor": 2},
+                        "multisite_replication_factor_sites": "site1:1,site2:1",
+                        "multisite_search_factor_sites": "site1:1,site2:1"
+                    },
+                    {},
+                    {
+                        "site": "site1",
+                        "idxc": {"replication_factor": 2, "search_factor": 2},
+                        "multisite_master_port": 8089,
+                        "multisite_replication_factor_origin": 1,
+                        "multisite_replication_factor_total": 2,
+                        "multisite_replication_factor_sites": "site1:1,site2:1",
+                        "multisite_replication_factor": "origin:1,site1:1,site2:1,total:2",
+                        "multisite_search_factor_origin": 1,
+                        "multisite_search_factor_total": 2,
+                        "multisite_search_factor_sites": "site1:1,site2:1",
+                        "multisite_search_factor": "origin:1,site1:1,site2:1,total:2"
+                    }
+                ),
+            ]
+        )
+def test_getMultisite(default_yml, os_env, output):
+    vars_scope = {"splunk": default_yml}
+    with patch("os.environ", new=os_env):
+        environ.getMultisite(vars_scope)
+    assert vars_scope["splunk"] == output
 
 @pytest.mark.skip(reason="TODO")
 def test_getSplunkWebSSL():


### PR DESCRIPTION
This PR adds support for site-specific multisite factors for both replication and search, while keeping current behaviour fully compatible.

Users can now provide optional site-specific terms like - `site1:1,site2:1` and the code will build the final values as - `origin:<origin>,<sites>,total:<total>`

So users can keep using existing `origin`/`total` settings and only add per-site terms when needed.

Changes:

- Added new optional inputs:
  - `SPLUNK_MULTISITE_REPLICATION_FACTOR_SITES`
  - `SPLUNK_MULTISITE_SEARCH_FACTOR_SITES`
  - YAML equivalents:
    - `multisite_replication_factor_sites`
    - `multisite_search_factor_sites`
- Moved final factor string construction into `inventory/environ.py` (single place of truth).
- Updated cluster manager setup to consume the computed final strings directly.
- Updated defaults and docs.
- Added tests for:
  - valid/invalid site-term parsing
  - final string building
  - legacy behaviour (origin/total only)
  - env and YAML site-specific inputs

Design options considered 

- High complexity: full free-form string input (`origin:...,site1:...,total:...`)
  - Flexible, but more duplication and easier to misconfigure.
- Medium complexity: map-based input in YAML
  - Structured, but more code and not ideal for current env-driven usage.
- Chosen (lowest complexity / clearest): keep existing `origin` + `total`, add optional `*_SITES` only
  - Least disruptive, easiest to understand, and backward compatible.

Backward compatibility

No breaking change.

If users only set existing origin/total variables, behaviour stays the same.

Validation done

- Ran targeted tests:
  - `python3 -m pytest tests/small/test_environ.py -k multisite -q`
  - Result: `12 passed`
- Lint checks on changed files: no linter errors.