### PR TITLE
CSPL-4186: Retrieve splunk.secret from /mnt/splunk-secrets

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -487,6 +487,10 @@ def getSecrets(vars_scope):
         vars_scope["splunk"]["declarative_admin_password"] = bool(vars_scope["splunk"].get("declarative_admin_password"))
     vars_scope["splunk"]["pass4SymmKey"] = os.environ.get('SPLUNK_PASS4SYMMKEY', vars_scope["splunk"].get("pass4SymmKey"))
     vars_scope["splunk"]["secret"] = os.environ.get('SPLUNK_SECRET', vars_scope["splunk"].get("secret"))
+    vars_scope["splunk"]["splunk_secret"] = os.environ.get('SPLUNK_SPLUNK_SECRET', vars_scope["splunk"].get("splunk_secret"))
+    if vars_scope["splunk"]["splunk_secret"] and os.path.isfile(vars_scope["splunk"]["splunk_secret"]):
+        with open(vars_scope["splunk"]["splunk_secret"], "r") as f:
+            vars_scope["splunk"]["splunk_secret"] = f.read().strip()
 
 def getLaunchConf(vars_scope):
     """

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -42,6 +42,7 @@ splunk:
     password:
     declarative_admin_password: False
     secret:
+    splunk_secret:
     pass4SymmKey:
     svc_port: 8089
     ssl:

--- a/roles/splunk_common/tasks/set_splunk_secret.yml
+++ b/roles/splunk_common/tasks/set_splunk_secret.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set the Splunk secret
+- name: Set the Splunk secret from splunk.secret
   copy:
     dest: "{{ splunk.home }}/etc/auth/splunk.secret"
     owner: "{{ splunk.user }}"
@@ -11,3 +11,17 @@
     - splunk.secret
   become: yes
   become_user: "{{ splunk.user }}"
+
+- name: Set the Splunk secret from splunk.splunk_secret
+  copy:
+    dest: "{{ splunk.home }}/etc/auth/splunk.secret"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: 0400
+    content: "{{ splunk.splunk_secret }}"
+  when:
+    - splunk.splunk_secret is defined
+    - splunk.splunk_secret
+  become: yes
+  become_user: "{{ splunk.user }}"
+


### PR DESCRIPTION
Cloudworks must provide secrets to SOK-managed Splunk workloads. The SOK8S API delivers a Kubernetes Secret with plaintext admin password and splunk.secret. SOK does the following:
- mounts this Secret into pods at /mnt/splunk-secrets. 
- generates /mnt/splunk-secrets/default.yml

This PR applies the following change:
-  Retrieve splunk_secret from /mnt/splunk-secrets/default.yml
- Copy the value of splunk_secret to /opt/splunk/etc/auth/splunk.secret. 
- Ensure that this change is backward compatible:
If the new splunk_secret is not provided, Ansible will set splunk.secret using the existing mechanism.
If the new splunk_secret is provided, Ansible will set splunk.secret from the splunk_secret value.
