### PR TITLE
Fix SPLUNK_LISTEN_ON_IPV6="false" being treated as truthy

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -739,7 +739,7 @@ def getIPv6(vars_scope):
     """
     Set specific environment variables to apply IPv6 configurations
     """
-    vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", False)
+    vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", "").lower() == "true"
 
 
 def getRandomString():


### PR DESCRIPTION
## Summary
- `SPLUNK_LISTEN_ON_IPV6="false"` passed via `--env` is a non-empty string, which is truthy in Python — causing `mgmtHostPort` in `web.conf` to be set to `[::1]:8089` (IPv6) even when the user intended to disable IPv6.
- Fixed by normalizing with `.lower() == "true"`, consistent with how other boolean env vars are handled in `environ.py` (e.g. `SPLUNK_SKIP_CLUSTER_BUNDLE_PUSH`).
- Bug introduced in commit `1c45c9d` (Oct 7, 2024).

## Root cause
In `inventory/environ.py`, `getIPv6()` stored the raw string from `os.environ.get()`:
```python
# Before (buggy): "false" is a non-empty string → truthy
vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", False)

# After (fixed): explicit boolean parse
vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", "").lower() == "true"
```

## Test plan
- [ ] Deploy with `--env SPLUNK_LISTEN_ON_IPV6="false"` on Splunk 10.2+ and verify `mgmtHostPort` is `0.0.0.0:8089`
- [ ] Deploy with `--env SPLUNK_LISTEN_ON_IPV6="true"` and verify `mgmtHostPort` is `[::1]:8089`
- [ ] Deploy without the env var and verify `mgmtHostPort` is `0.0.0.0:8089`
