### PR TITLE
fix(CSPL-4617): preserve custom httpinput configs set via splunk.conf

### DIFF
--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -68,11 +68,11 @@
         | combine(
             {'enableSSL': '1' if splunk.hec.ssl | bool else '0'}
             if ('hec' in splunk and 'ssl' in splunk.hec and splunk.hec.ssl is not none)
-            else ({'enableSSL': '1'} if ('hec_enableSSL' in splunk and splunk.hec_enableSSL | bool) else {})
+            else ({'enableSSL': '1' if splunk.hec_enableSSL | bool else '0'} if ('hec_enableSSL' in splunk) else {})
           )
       }}
   when: >-
-    ('hec' in splunk and ('enable' in splunk.hec or 'ssl' in splunk.hec or 'port' in splunk.hec or 'cert' in splunk.hec))
+    ('hec' in splunk and ('enable' in splunk.hec or 'ssl' in splunk.hec or 'port' in splunk.hec or 'cert' in splunk.hec or 'password' in splunk.hec))
     or ('hec_disabled' in splunk)
     or ('hec_enableSSL' in splunk)
     or ('hec_port' in splunk)

--- a/roles/splunk_common/tasks/set_as_hec_receiver.yml
+++ b/roles/splunk_common/tasks/set_as_hec_receiver.yml
@@ -55,6 +55,28 @@
   when:
     - ('hec' in splunk and 'token' in splunk.hec and splunk.hec.token) or ('hec_token' in splunk and splunk.hec_token)
 
+- name: Build global HEC body
+  set_fact:
+    hec_global_body: >-
+      {{
+        {
+          'disabled': '0' if (('hec' in splunk and 'enable' in splunk.hec and splunk.hec.enable | bool) or ('hec_disabled' in splunk and not splunk.hec_disabled | bool)) else '1',
+          'port': splunk.hec.port if ('hec' in splunk and 'port' in splunk.hec and splunk.hec.port) else (splunk.hec_port if ('hec_port' in splunk and splunk.hec_port) else '8088'),
+          'serverCert': splunk.hec.cert if ('hec' in splunk and 'cert' in splunk.hec and splunk.hec.cert) else '',
+          'sslPassword': splunk.hec.password if ('hec' in splunk and 'password' in splunk.hec and splunk.hec.password) else ''
+        }
+        | combine(
+            {'enableSSL': '1' if splunk.hec.ssl | bool else '0'}
+            if ('hec' in splunk and 'ssl' in splunk.hec and splunk.hec.ssl is not none)
+            else ({'enableSSL': '1'} if ('hec_enableSSL' in splunk and splunk.hec_enableSSL | bool) else {})
+          )
+      }}
+  when: >-
+    ('hec' in splunk and ('enable' in splunk.hec or 'ssl' in splunk.hec or 'port' in splunk.hec or 'cert' in splunk.hec))
+    or ('hec_disabled' in splunk)
+    or ('hec_enableSSL' in splunk)
+    or ('hec_port' in splunk)
+
 - name: Setup global HEC
   splunk_api:
     url: "/services/data/inputs/http/http"
@@ -63,11 +85,7 @@
     username: "{{ splunk.admin_user }}"
     password: "{{ splunk.password }}"
     svc_port: "{{ splunk.svc_port }}"
-    body:
-      disabled: "{% if ('hec' in splunk and 'enable' in splunk.hec and splunk.hec.enable | bool) or ('hec_disabled' in splunk and not splunk.hec_disabled | bool) %}0{% else %}1{% endif %}"
-      enableSSL: "{% if ('hec' in splunk and 'ssl' in splunk.hec and splunk.hec.ssl | bool) or ('hec_enableSSL' in splunk and splunk.hec_enableSSL | bool) %}1{% else %}0{% endif %}"
-      port: "{% if 'hec' in splunk and 'port' in splunk.hec and splunk.hec.port %}{{ splunk.hec.port }}{% elif 'hec_port' in splunk and splunk.hec_port %}{{ splunk.hec_port }}{% else %}8088{% endif %}"
-      serverCert: "{% if 'hec' in splunk and 'cert' in splunk.hec and splunk.hec.cert %}{{ splunk.hec.cert }}{% endif %}"
-      sslPassword: "{% if 'hec' in splunk and 'password' in splunk.hec and splunk.hec.password %}{{ splunk.hec.password }}{% endif %}"
+    body: "{{ hec_global_body }}"
     body_format: "form-urlencoded"
   register: sample
+  when: hec_global_body is defined

--- a/roles/splunk_common/tasks/set_config_file.yml
+++ b/roles/splunk_common/tasks/set_config_file.yml
@@ -7,6 +7,16 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
+- name: Remove stale {{ conf_file }} before writing config map values
+  file:
+    path: "{{ conf_directory }}/{{ conf_file }}"
+    state: absent
+  when:
+    - conf_directory is defined
+    - conf_stanzas | length > 0
+  become: yes
+  become_user: "{{ splunk.user }}"
+
 - include_tasks: set_config_stanza.yml
   vars:
     stanza_name: "{{ stanza.key }}"

--- a/tests/small/test_hec_receiver.py
+++ b/tests/small/test_hec_receiver.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python
+'''
+Unit tests for roles/splunk_common/tasks/set_as_hec_receiver.yml logic.
+
+These tests mirror the Jinja2 expressions in the task file in pure Python so
+that the guard conditions and hec_global_body construction can be validated
+without running a live Ansible playbook.  Any change to the task's `when`
+clause or the `set_fact` expression should be reflected here.
+'''
+from __future__ import absolute_import
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Python equivalents of the Ansible Jinja2 expressions
+# ---------------------------------------------------------------------------
+
+def _bool(v):
+    '''Mimic Ansible's | bool filter: truthy strings and booleans -> True.'''
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in ('1', 'true', 'yes', 'on')
+    return bool(v)
+
+
+def should_build_hec_body(splunk):
+    '''
+    Mirror the `when` guard on "Build global HEC body".
+
+    Returns True when the task should run (i.e. hec_global_body is defined).
+    Must stay in sync with set_as_hec_receiver.yml.
+    '''
+    hec = splunk.get('hec', {})
+    if 'hec' in splunk and (
+        'enable' in hec or 'ssl' in hec or 'port' in hec
+        or 'cert' in hec or 'password' in hec
+    ):
+        return True
+    if 'hec_disabled' in splunk:
+        return True
+    if 'hec_enableSSL' in splunk:
+        return True
+    if 'hec_port' in splunk:
+        return True
+    return False
+
+
+def build_hec_global_body(splunk):
+    '''
+    Mirror the `set_fact: hec_global_body` Jinja2 expression.
+
+    Returns the dict that would be POSTed to the Splunk REST API, or None
+    when the guard does not fire.  Must stay in sync with
+    set_as_hec_receiver.yml.
+    '''
+    if not should_build_hec_body(splunk):
+        return None
+
+    hec = splunk.get('hec', {})
+
+    # disabled
+    if ('hec' in splunk and 'enable' in hec and _bool(hec['enable'])) or \
+       ('hec_disabled' in splunk and not _bool(splunk['hec_disabled'])):
+        disabled = '0'
+    else:
+        disabled = '1'
+
+    # port
+    if 'hec' in splunk and 'port' in hec and hec['port']:
+        port = hec['port']
+    elif 'hec_port' in splunk and splunk['hec_port']:
+        port = splunk['hec_port']
+    else:
+        port = '8088'
+
+    # serverCert
+    server_cert = hec['cert'] if ('hec' in splunk and 'cert' in hec and hec['cert']) else ''
+
+    # sslPassword
+    ssl_password = hec['password'] if ('hec' in splunk and 'password' in hec and hec['password']) else ''
+
+    body = {
+        'disabled': disabled,
+        'port': port,
+        'serverCert': server_cert,
+        'sslPassword': ssl_password,
+    }
+
+    # enableSSL — splunk.hec.ssl takes precedence over deprecated hec_enableSSL
+    if 'hec' in splunk and 'ssl' in hec and hec['ssl'] is not None:
+        body['enableSSL'] = '1' if _bool(hec['ssl']) else '0'
+    elif 'hec_enableSSL' in splunk:
+        body['enableSSL'] = '1' if _bool(splunk['hec_enableSSL']) else '0'
+
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Guard / `when` condition tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(('splunk', 'expected'), [
+    # Guard must NOT fire — no HEC fields at all (custom httpinput preserved)
+    ({}, False),
+    ({'hec': {}}, False),
+    ({'hec': {'token': 'abc'}}, False),   # token-only, no global fields
+
+    # Guard MUST fire — splunk.hec.* fields
+    ({'hec': {'enable': True}}, True),
+    ({'hec': {'ssl': True}}, True),
+    ({'hec': {'ssl': False}}, True),
+    ({'hec': {'port': 9088}}, True),
+    ({'hec': {'cert': '/path/cert.pem'}}, True),
+    # Password-only: guard must fire (this was the bug being fixed)
+    ({'hec': {'password': 's3cr3t'}}, True),
+
+    # Guard MUST fire — deprecated hec_* top-level vars
+    ({'hec_disabled': True}, True),
+    ({'hec_disabled': False}, True),
+    ({'hec_enableSSL': True}, True),
+    ({'hec_enableSSL': False}, True),   # explicit false must fire too
+    ({'hec_port': 8888}, True),
+])
+def test_should_build_hec_body(splunk, expected):
+    assert should_build_hec_body(splunk) == expected
+
+
+# ---------------------------------------------------------------------------
+# hec_global_body construction tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(('splunk', 'expected_body'), [
+    # Guard does not fire — body is None (custom httpinput preserved)
+    ({}, None),
+    ({'hec': {}}, None),
+    ({'hec': {'token': 'only-token'}}, None),
+
+    # --- enableSSL via splunk.hec.ssl ---
+    (
+        {'hec': {'ssl': True}},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': '', 'enableSSL': '1'},
+    ),
+    (
+        {'hec': {'ssl': False}},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': '', 'enableSSL': '0'},
+    ),
+
+    # --- enableSSL via deprecated hec_enableSSL ---
+    # True produces '1'
+    (
+        {'hec_enableSSL': True},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': '', 'enableSSL': '1'},
+    ),
+    # False must produce '0', NOT be silently dropped (regression guard)
+    (
+        {'hec_enableSSL': False},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': '', 'enableSSL': '0'},
+    ),
+
+    # splunk.hec.ssl takes precedence over hec_enableSSL
+    (
+        {'hec': {'ssl': False}, 'hec_enableSSL': True},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': '', 'enableSSL': '0'},
+    ),
+
+    # --- password-only guard fix ---
+    (
+        {'hec': {'password': 'mypassword'}},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': 'mypassword'},
+    ),
+
+    # --- cert + password together ---
+    (
+        {'hec': {'cert': '/mnt/cert.pem', 'password': 'p@ssw0rd', 'ssl': True}},
+        {'disabled': '1', 'port': '8088', 'serverCert': '/mnt/cert.pem', 'sslPassword': 'p@ssw0rd', 'enableSSL': '1'},
+    ),
+
+    # --- port override ---
+    (
+        {'hec': {'port': 9088, 'ssl': True}},
+        {'disabled': '1', 'port': 9088, 'serverCert': '', 'sslPassword': '', 'enableSSL': '1'},
+    ),
+    (
+        {'hec_port': 7777},
+        {'disabled': '1', 'port': 7777, 'serverCert': '', 'sslPassword': ''},
+    ),
+
+    # --- enable / disabled ---
+    (
+        {'hec': {'enable': True}},
+        {'disabled': '0', 'port': '8088', 'serverCert': '', 'sslPassword': ''},
+    ),
+    (
+        {'hec_disabled': False},
+        {'disabled': '0', 'port': '8088', 'serverCert': '', 'sslPassword': ''},
+    ),
+    (
+        {'hec_disabled': True},
+        {'disabled': '1', 'port': '8088', 'serverCert': '', 'sslPassword': ''},
+    ),
+])
+def test_build_hec_global_body(splunk, expected_body):
+    result = build_hec_global_body(splunk)
+    assert result == expected_body
+
+
+# ---------------------------------------------------------------------------
+# Stale config-file removal guard
+# ---------------------------------------------------------------------------
+
+def should_remove_conf_file(conf_directory, conf_stanzas):
+    '''
+    Mirror the `when` guard on "Remove stale <conf_file> before writing
+    config map values" in set_config_file.yml.
+
+    The task removes the file only when conf_directory is defined AND
+    conf_stanzas is non-empty.
+    '''
+    return conf_directory is not None and len(conf_stanzas) > 0
+
+
+@pytest.mark.parametrize(('conf_directory', 'conf_stanzas', 'expected'), [
+    # conf_directory undefined — never remove
+    (None, {}, False),
+    (None, {'stanza1': {'key': 'val'}}, False),
+
+    # conf_directory defined but no stanzas — skip removal (nothing to write)
+    ('/opt/splunk/etc/system/local', {}, False),
+
+    # conf_directory defined and stanzas present — remove stale file
+    ('/opt/splunk/etc/system/local', {'stanza1': {'key': 'val'}}, True),
+    ('/opt/splunk/etc/system/local', {'a': {}, 'b': {}}, True),
+])
+def test_should_remove_conf_file(conf_directory, conf_stanzas, expected):
+    assert should_remove_conf_file(conf_directory, conf_stanzas) == expected


### PR DESCRIPTION
## Summary

- **Bug 1 — HEC REST overwrites splunk.conf values:** The \`Setup global HEC\` task in \`set_as_hec_receiver.yml\` ran unconditionally and always POSTed to \`/services/data/inputs/http/http\`, silently overwriting \`enableSSL\` and other global HEC settings (e.g. \`httpEventCollectorWithAckEnabled\`) even when the caller only set HEC config via \`splunk.conf\`. Fixed by guarding the REST call behind a \`set_fact\` that only fires when \`splunk.hec.*\` or deprecated \`hec_*\` vars are explicitly supplied. \`enableSSL\` is now only included in the body when \`splunk.hec.ssl\` is explicitly set.

- **Bug 2 — Stale conf file keys persist across pod restarts:** When a config map is updated and pods are rolled, keys removed from the config map were not removed from the on-disk \`.conf\` file because \`ini_file\` with \`state: present\` only adds/updates — it never deletes stanzas or keys. Fixed by deleting the target conf file before writing, so each pod start applies a clean state matching the current config map exactly.

## Additional fixes (post-review)

- **`splunk.hec.password` guard:** The \`when\` guard on \`Build global HEC body\` was missing \`'password' in splunk.hec\`. When \`sslPassword\` was the only explicit HEC field (no \`ssl\`/\`cert\`/\`port\`/\`enable\`), the body was never built and \`sslPassword\` was silently dropped from the REST POST. Added \`'password' in splunk.hec\` to the guard.

- **Preserve \`hec_enableSSL: false\`:** The deprecated-var fallback \`{'enableSSL': '1'} if hec_enableSSL | bool else {}\` silently dropped \`enableSSL\` when the value was \`false\`, so users relying on the deprecated variable to force REST-managed HEC SSL off had their setting ignored. Changed to \`{'enableSSL': '1'|'0'} if 'hec_enableSSL' in splunk else {}\` so an explicit \`false\` sends \`enableSSL=0\`.

## Files changed

- \`roles/splunk_common/tasks/set_as_hec_receiver.yml\` — conditional \`set_fact\` for HEC body; REST POST guarded by \`when: hec_global_body is defined\`; password added to guard; \`hec_enableSSL: false\` preserved
- \`roles/splunk_common/tasks/set_config_file.yml\` — delete conf file before writing stanzas to ensure config map is the source of truth
- \`tests/small/test_hec_receiver.py\` (new) — 34 parametrized unit tests

## Test plan

- [x] Custom \`splunk.conf\` \`enableSSL\` and \`httpEventCollectorWithAckEnabled\` values are preserved when no \`splunk.hec.*\` vars are set (Setup global HEC task is skipped)
- [x] \`splunk.hec.ssl: true\` → \`enableSSL=1\` sent to REST endpoint
- [x] \`splunk.hec.ssl: false\` → \`enableSSL=0\` sent to REST endpoint
- [x] \`hec_enableSSL: false\` → \`enableSSL=0\` sent (regression: was silently dropped)
- [x] \`splunk.hec.password\`-only field fires the guard and sets \`sslPassword\`
- [x] \`splunk.hec.cert\` + \`splunk.hec.password\` + \`splunk.hec.ssl\` together produce correct body
- [x] Stale conf stanzas removed from disk after config map update and pod restart
- [x] 34 unit tests in \`tests/small/test_hec_receiver.py\` pass

Fixes: CSPL-4617

🤖 Generated with [Claude Code](https://claude.com/claude-code)