### PR TITLE
CSPL-4878: Add operator-driven TLS certificate configuration for server and input (S2S) certs

### DIFF
--- a/roles/splunk_common/tasks/configure_input_cert.yml
+++ b/roles/splunk_common/tasks/configure_input_cert.yml
@@ -1,0 +1,120 @@
+---
+# Configure Splunk input (S2S) certificate from operator-mounted TLS secret.
+# Input: /mnt/tls/splunk-input-tls-cert/{tls.crt, tls.key, ca.crt}
+# Output: bundled PEM at /opt/splunk/etc/auth/input-bundle.pem
+#         CA at /opt/splunk/etc/auth/splunk-input-ca.pem
+#         inputs.conf [SSL] configured
+
+- name: Generate ephemeral SSL passphrase for input cert
+  command: >
+    python3 -c
+    "import secrets, base64; print(base64.b64encode(secrets.token_bytes(40)).decode())"
+  register: input_ssl_passphrase
+  changed_when: false
+  no_log: true
+
+- name: Ensure Splunk auth directory exists
+  file:
+    path: "{{ splunk.home }}/etc/auth"
+    state: directory
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0700'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Write input cert bundle script
+  copy:
+    dest: /tmp/splunk_bundle_input_cert.py
+    content: |
+      from cryptography.hazmat.primitives.serialization import (
+          load_pem_private_key, Encoding, PrivateFormat, BestAvailableEncryption
+      )
+      import sys
+
+      passphrase = sys.argv[1].encode()
+      key_path   = '/mnt/tls/splunk-input-tls-cert/tls.key'
+      cert_path  = '/mnt/tls/splunk-input-tls-cert/tls.crt'
+      out_path   = sys.argv[2] + '/etc/auth/input-bundle.pem'
+
+      with open(key_path, 'rb') as f:
+          key = load_pem_private_key(f.read(), password=None)
+
+      enc_key_pem = key.private_bytes(
+          Encoding.PEM,
+          PrivateFormat.PKCS8,
+          BestAvailableEncryption(passphrase)
+      )
+
+      with open(cert_path, 'rb') as f:
+          cert_pem = f.read()
+
+      with open(out_path, 'wb') as f:
+          f.write(cert_pem)
+          if not cert_pem.endswith(b'\n'):
+              f.write(b'\n')
+          f.write(enc_key_pem)
+    mode: '0700'
+
+- name: Encrypt private key and build input cert bundle
+  command: >
+    python3 /tmp/splunk_bundle_input_cert.py
+    {{ input_ssl_passphrase.stdout }} {{ splunk.home }}
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: true
+
+- name: Set input bundle permissions
+  file:
+    path: "{{ splunk.home }}/etc/auth/input-bundle.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0600'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Copy input CA certificate
+  copy:
+    src: /mnt/tls/splunk-input-tls-cert/ca.crt
+    dest: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
+    remote_src: yes
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0644'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Configure serverCert in inputs.conf [SSL]
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
+    section: SSL
+    option: serverCert
+    value: "{{ splunk.home }}/etc/auth/input-bundle.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Configure sslPassword in inputs.conf [SSL]
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
+    section: SSL
+    option: sslPassword
+    value: "{{ input_ssl_passphrase.stdout }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: true
+  changed_when: false
+
+- name: Configure sslRootCAPath in inputs.conf [SSL]
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
+    section: SSL
+    option: sslRootCAPath
+    value: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/configure_server_cert.yml
+++ b/roles/splunk_common/tasks/configure_server_cert.yml
@@ -1,8 +1,8 @@
 ---
 # Configure Splunk server certificate from operator-mounted TLS secret.
 # Input: /mnt/tls/splunk-server-tls-cert/{tls.crt, tls.key, ca.crt}
-# Output: bundled PEM at /opt/splunk/etc/auth/server-bundle.pem
-#         CA at /opt/splunk/etc/auth/splunk-ca.pem
+# Output: bundled PEM at /opt/splunk/etc/auth/splunk-server-bundle.pem
+#         CA at /opt/splunk/etc/auth/splunk-server-ca.pem
 #         server.conf [sslConfig] configured
 
 - name: Generate ephemeral SSL passphrase
@@ -35,7 +35,7 @@
       passphrase = sys.argv[1].encode()
       key_path   = '/mnt/tls/splunk-server-tls-cert/tls.key'
       cert_path  = '/mnt/tls/splunk-server-tls-cert/tls.crt'
-      out_path   = sys.argv[2] + '/etc/auth/server-bundle.pem'
+      out_path   = sys.argv[2] + '/etc/auth/splunk-server-bundle.pem'
 
       with open(key_path, 'rb') as f:
           key = load_pem_private_key(f.read(), password=None)
@@ -66,7 +66,7 @@
 
 - name: Set bundle permissions
   file:
-    path: "{{ splunk.home }}/etc/auth/server-bundle.pem"
+    path: "{{ splunk.home }}/etc/auth/splunk-server-bundle.pem"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     mode: '0600'
@@ -76,7 +76,7 @@
 - name: Copy CA certificate
   copy:
     src: /mnt/tls/splunk-server-tls-cert/ca.crt
-    dest: "{{ splunk.home }}/etc/auth/splunk-ca.pem"
+    dest: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
     remote_src: yes
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
@@ -89,7 +89,7 @@
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: sslConfig
     option: serverCert
-    value: "{{ splunk.home }}/etc/auth/server-bundle.pem"
+    value: "{{ splunk.home }}/etc/auth/splunk-server-bundle.pem"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   become: yes
@@ -113,7 +113,7 @@
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: sslConfig
     option: sslRootCAPath
-    value: "{{ splunk.home }}/etc/auth/splunk-ca.pem"
+    value: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   become: yes

--- a/roles/splunk_common/tasks/configure_server_cert.yml
+++ b/roles/splunk_common/tasks/configure_server_cert.yml
@@ -1,0 +1,120 @@
+---
+# Configure Splunk server certificate from operator-mounted TLS secret.
+# Input: /mnt/tls/splunk-server-tls-cert/{tls.crt, tls.key, ca.crt}
+# Output: bundled PEM at /opt/splunk/etc/auth/server-bundle.pem
+#         CA at /opt/splunk/etc/auth/splunk-ca.pem
+#         server.conf [sslConfig] configured
+
+- name: Generate ephemeral SSL passphrase
+  command: >
+    python3 -c
+    "import secrets, base64; print(base64.b64encode(secrets.token_bytes(40)).decode())"
+  register: ssl_passphrase
+  changed_when: false
+  no_log: true
+
+- name: Ensure Splunk auth directory exists
+  file:
+    path: "{{ splunk.home }}/etc/auth"
+    state: directory
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0700'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Write cert bundle script
+  copy:
+    dest: /tmp/splunk_bundle_cert.py
+    content: |
+      from cryptography.hazmat.primitives.serialization import (
+          load_pem_private_key, Encoding, PrivateFormat, BestAvailableEncryption
+      )
+      import sys
+
+      passphrase = sys.argv[1].encode()
+      key_path   = '/mnt/tls/splunk-server-tls-cert/tls.key'
+      cert_path  = '/mnt/tls/splunk-server-tls-cert/tls.crt'
+      out_path   = sys.argv[2] + '/etc/auth/server-bundle.pem'
+
+      with open(key_path, 'rb') as f:
+          key = load_pem_private_key(f.read(), password=None)
+
+      enc_key_pem = key.private_bytes(
+          Encoding.PEM,
+          PrivateFormat.PKCS8,
+          BestAvailableEncryption(passphrase)
+      )
+
+      with open(cert_path, 'rb') as f:
+          cert_pem = f.read()
+
+      with open(out_path, 'wb') as f:
+          f.write(cert_pem)
+          if not cert_pem.endswith(b'\n'):
+              f.write(b'\n')
+          f.write(enc_key_pem)
+    mode: '0700'
+
+- name: Encrypt private key and build server cert bundle
+  command: >
+    python3 /tmp/splunk_bundle_cert.py
+    {{ ssl_passphrase.stdout }} {{ splunk.home }}
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: true
+
+- name: Set bundle permissions
+  file:
+    path: "{{ splunk.home }}/etc/auth/server-bundle.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0600'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Copy CA certificate
+  copy:
+    src: /mnt/tls/splunk-server-tls-cert/ca.crt
+    dest: "{{ splunk.home }}/etc/auth/splunk-ca.pem"
+    remote_src: yes
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0644'
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Configure serverCert in server.conf
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: sslConfig
+    option: serverCert
+    value: "{{ splunk.home }}/etc/auth/server-bundle.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Configure sslPassword in server.conf
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: sslConfig
+    option: sslPassword
+    value: "{{ ssl_passphrase.stdout }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  no_log: true
+  changed_when: false
+
+- name: Configure sslRootCAPath in server.conf
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: sslConfig
+    option: sslRootCAPath
+    value: "{{ splunk.home }}/etc/auth/splunk-ca.pem"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/configure_splunk_certs.yml
+++ b/roles/splunk_common/tasks/configure_splunk_certs.yml
@@ -10,3 +10,12 @@
 - name: Configure Splunk server certificate
   include_tasks: configure_server_cert.yml
   when: server_cert_dir.stat.exists and server_cert_dir.stat.isdir
+
+- name: Check for input cert mount
+  stat:
+    path: /mnt/tls/splunk-input-tls-cert
+  register: input_cert_dir
+
+- name: Configure Splunk input certificate
+  include_tasks: configure_input_cert.yml
+  when: input_cert_dir.stat.exists and input_cert_dir.stat.isdir

--- a/roles/splunk_common/tasks/configure_splunk_certs.yml
+++ b/roles/splunk_common/tasks/configure_splunk_certs.yml
@@ -1,0 +1,12 @@
+---
+# Dispatcher for operator-driven cert configuration.
+# Each cert type is handled only when its mount directory exists.
+
+- name: Check for server cert mount
+  stat:
+    path: /mnt/tls/splunk-server-tls-cert
+  register: server_cert_dir
+
+- name: Configure Splunk server certificate
+  include_tasks: configure_server_cert.yml
+  when: server_cert_dir.stat.exists and server_cert_dir.stat.isdir

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -105,6 +105,9 @@
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"
     - splunk.http_enableSSL | bool
 
+- include_tasks: configure_splunk_certs.yml
+  when: ansible_system is match("Linux")
+
 - include_tasks: enable_splunkd_ssl.yml
   when: "'ssl' in splunk and splunk.ssl"
 


### PR DESCRIPTION
## Summary

Introduces Ansible support for mounting and configuring TLS certificates delivered by the Splunk Operator (SOK) as Kubernetes Secrets. This is the format-adaptor layer of the SOK Certificate Management design (Phase 1).

- Adds `configure_splunk_certs.yml` — dispatcher that checks for operator-mounted cert directories under `/mnt/tls/` and conditionally includes per-cert-type tasks. If a cert directory is absent, Ansible skips it entirely with no error.
- Adds `configure_server_cert.yml` — reads `tls.crt`, `tls.key`, `ca.crt` from `/mnt/tls/splunk-server-tls-cert/`, generates an ephemeral passphrase, encrypts the private key, bundles cert+key into `splunk-server-bundle.pem`, and configures `server.conf [sslConfig]` (`serverCert`, `sslPassword`, `sslRootCAPath`).
- Adds `configure_input_cert.yml` — same flow for S2S input cert, reads from `/mnt/tls/splunk-input-tls-cert/`, configures `inputs.conf [SSL]`, outputs `splunk-input-bundle.pem` and `splunk-input-ca.pem`.
- Wires `configure_splunk_certs.yml` into `main.yml` before the existing `enable_splunkd_ssl.yml` step, gated on Linux only.

## Design Notes

- **Non-breaking:** cert processing is fully conditional on directory existence. Existing deployments without operator-mounted certs are unaffected.
- **Extensible:** adding a new cert type (e.g. `web`) requires only a new `stat` + `include_tasks` entry in the dispatcher and a corresponding task file.
- **Ephemeral passphrase:** a new random passphrase is generated at each pod startup to meet Splunk's bundled cert format requirement. The passphrase is not persisted.
- **Output file naming:** consistent `splunk-<role>-bundle.pem` / `splunk-<role>-ca.pem` pattern across all cert types.

## Test Plan

- [ ] Deploy SOK with these Ansible changes baked into the Splunk image
- [ ] Deploy Standalone with no cert secret — verify Ansible skips cert configuration cleanly
- [ ] Create `splunk-server-tls-cert` secret with `tls.crt`, `tls.key`, `ca.crt` — verify `splunk-server-bundle.pem` created and `server.conf [sslConfig]` configured correctly
- [ ] Create `splunk-input-tls-cert` secret — verify `splunk-input-bundle.pem` created and `inputs.conf [SSL]` configured correctly
- [ ] Verify Splunk REST endpoint (port 8089) and S2S port (9997) accept TLS connections using the configured certs
