### PR TITLE
Disable Postgres by default

### DIFF
--- a/roles/splunk_common/tasks/disable_postgres.yml
+++ b/roles/splunk_common/tasks/disable_postgres.yml
@@ -4,7 +4,7 @@
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: postgres
     option: disabled
-    value: "true"
+    value: "{{ splunk_postgres_disabled | default(true) | bool | ternary('true', 'false') }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   become: yes

--- a/roles/splunk_common/tasks/disable_postgres.yml
+++ b/roles/splunk_common/tasks/disable_postgres.yml
@@ -1,0 +1,11 @@
+---
+- name: Disable Postgres by default
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: postgres
+    option: disabled
+    value: "true"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -116,6 +116,10 @@
     - "'connection_timeout' in splunk and splunk.connection_timeout"
     - splunk.connection_timeout | int > 0
 
+- include_tasks: disable_postgres.yml
+  when:
+    - splunk.role != "splunk_universal_forwarder"
+
 - include_tasks: set_config_file.yml
   vars:
     conf_file: "{{ item.key }}.conf"

--- a/roles/splunk_standalone/molecule/default/tests/test_default.py
+++ b/roles/splunk_standalone/molecule/default/tests/test_default.py
@@ -94,6 +94,14 @@ def test_inputs_conf(host):
     assert f.contains("[splunktcp://9997]")
     assert f.contains("disabled = 0")
 
+def test_postgres_disabled(host):
+    f = host.file("{}/etc/system/local/server.conf".format(SPLUNK_HOME))
+    assert f.exists
+    assert f.user == SPLUNK_USER
+    assert f.group == SPLUNK_GROUP
+    assert f.contains("[postgres]")
+    assert f.contains("disabled = true")
+
 def test_splunk_ports(host):
     output = host.run("netstat -tuln")
     assert "0.0.0.0:8000" in output.stdout


### PR DESCRIPTION
Postgres via Sidecars should be disabled in the CMP-K environment as Postgres will be managed in a more K8s native fashion in upcoming SOK release

Testing evidence for this PR

I tested this change locally by building a temporary Splunk image from the same Splunk Enterprise container base, replacing the bundled /opt/ansible with this PR branch, and running a standalone container.

Test setup:
- PR branch commit tested: 4cbe9fa
- Runtime role: SPLUNK_ROLE=splunk_standalone
- Validation image: base Splunk image + this branch copied to /opt/ansible
- Used SPLUNK_HOME_OWNERSHIP_ENFORCEMENT=false only to avoid a slow recursive chown under local amd64 emulation on Apple Silicon. This does not affect the server.conf Postgres setting or sidecar behavior being tested.

Validation after this PR:

```
TASK [splunk_common : include_tasks]
included: /opt/ansible/roles/splunk_common/tasks/disable_postgres.yml

TASK [splunk_common : Disable Postgres by default]
changed: [localhost]

```
Effective config after this PR:

```
/opt/splunk/etc/system/local/server.conf [postgres]
/opt/splunk/etc/system/local/server.conf disabled = true
```

server.conf content after this PR:

```
[postgres]
disabled = true
```

Process check after this PR:
- No active postgres, pgbouncer, traefik, or splunk-postgres processes were running.

I also compared against the unmodified base image.

Effective config in the unmodified baseline image:

```
/opt/splunk/etc/system/default/server.conf [postgres]
/opt/splunk/etc/system/default/server.conf disabled = false
```

Postgres-related processes in the unmodified baseline image were running, including:
```
- splunk-postgres
- /opt/splunk/bin/postgres
- /opt/splunk/bin/pgbouncer
- /opt/splunk/bin/traefik
```

Supervisor behavior note:

This PR prevents Postgres from staying up, but with current supervisor behavior, supervisor still attempts to start the Postgres sidecar periodically. The sidecar reads `[postgres] disabled = true `and exits cleanly.

Observed in the PR test container:
```
- supervisor.log showed repeated "Starting a sidecar" events for postgres.
- sup-pkg-postgres-stdout.log showed repeated "Postgres is disabled via server.conf, exiting." events.
- At the time of testing, I observed 14 supervisor start attempts and 14 clean disabled exits.
- Recent observed attempts were at 06:49:09, 06:49:45, 06:50:38, 06:51:57, and 06:54:15 UTC.
```

Summary:
- Before this change: Postgres is enabled by default and Postgres-related processes run.
- After this change: Postgres is disabled by default and no Postgres-related processes remain running.
- Current limitation: supervisor may still periodically launch the disabled Postgres sidecar, which immediately exits after reading the config.
- Given the current supervisor behavior, this PR still moves the container to the desired runtime state: Postgres is not running by default.