### PR TITLE
Fix Splunk startup failure on Windows FIPS: restore POSIX ACL mask on splunk-launch.conf

### DIFF
--- a/roles/splunk_common/tasks/set_launch_conf.yml
+++ b/roles/splunk_common/tasks/set_launch_conf.yml
@@ -8,3 +8,9 @@
   become: yes
   become_user: "{{ splunk.user }}"
   with_dict: "{{ splunk.launch }}"
+
+- name: Fix splunk-launch.conf POSIX ACL mask (Windows)
+  command: setfacl -m mask::rwx "{{ splunk.home }}/etc/splunk-launch.conf"
+  become: yes
+  become_user: "{{ privileged_user }}"
+  when: ansible_system is match("CYGWIN*|Win32NT")


### PR DESCRIPTION
## Summary

On Windows/Cygwin, Ansible's \`lineinfile\` with \`create: yes\` creates new files with \`mask::---\` in the POSIX ACL layer, zeroing out all effective permissions regardless of named-user/group entries. This causes \`splunk.exe\` (running as SYSTEM) to get \"Access is denied\" when reading \`splunk-launch.conf\` at startup.

**Why only the FIPS image is affected:** The FIPS image bakes \`SPLUNK_LAUNCH_CONF=SPLUNK_FIPS=1\` into the container (via \`inject_envs.sh\`). This makes \`splunk.launch\` non-empty, so \`set_launch_conf.yml\` runs and \`lineinfile\` recreates the file with a broken ACL. The non-FIPS image has no \`SPLUNK_LAUNCH_CONF\` set, so \`splunk.launch\` is an empty dict, the task is skipped by its \`when\` guard, and the MSI-installed file (with correct ACLs) is left untouched.

## Change

`roles/splunk_common/tasks/set_launch_conf.yml` — run `setfacl -m mask::rwx` after `lineinfile` on Windows/Cygwin to restore effective permissions on the newly created file.

## Test plan

- [x] Reproduced original failure on live `x64_windows_2022_fips` container: `splunk.exe start` → \"Access is denied\" on `splunk-launch.conf` (POSIX ACL `mask::---` confirmed via `getfacl`)
- [x] Verified fix manually on same container: `setfacl` sets `mask::rwx`, `getfacl` confirms effective permissions restored, Splunk starts successfully (`Splunkd: Starting (pid 12968)`)
- [x] `orca --k8s-cluster keet.orca.west.splunkeng.com create --platform x64_windows_2022_fips --fips 140-2 --env SPLUNK_LAUNCH_CONF="SPLUNK_FIPS=1,SPLUNK_FIPS_VERSION=140-2" --splunk-ansible .` → `success:: Yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)