### PR TITLE
add task for instanceType=cloud

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -449,6 +449,7 @@ def getSplunkBuild(vars_scope):
     """
     vars_scope["splunk"]["build_url_bearer_token"] = os.environ.get("SPLUNK_BUILD_URL_BEARER_TOKEN", vars_scope["splunk"].get("build_url_bearer_token"))
     vars_scope["splunk"]["build_location"] = os.environ.get("SPLUNK_BUILD_URL", vars_scope["splunk"].get("build_location"))
+    vars_scope["splunk"]["cloud_build"] = os.environ.get("SPLUNK_CLOUD_BUILD", vars_scope["splunk"].get("cloud_build"))
 
 def getSplunkbaseToken(vars_scope):
     """

--- a/inventory/splunk_defaults_linux.yml
+++ b/inventory/splunk_defaults_linux.yml
@@ -132,6 +132,6 @@ splunk:
         idxc: !!python/object/apply:os.path.join [*home, "etc", "master-apps"]
         deployment: !!python/object/apply:os.path.join [*home, "etc", "deployment-apps"]
         httpinput: !!python/object/apply:os.path.join [*home, "etc", "apps", "splunk_httpinput"]
-
     es:
       ssl_enablement: "auto"
+    cloud_build: False

--- a/inventory/splunk_defaults_windows.yml
+++ b/inventory/splunk_defaults_windows.yml
@@ -120,6 +120,6 @@ splunk:
         idxc: !!python/object/apply:os.path.join [*home, "etc", "master-apps"]
         deployment: !!python/object/apply:os.path.join [*home, "etc", "deployment-apps"]
         httpinput: !!python/object/apply:os.path.join [*home, "etc", "apps", "splunk_httpinput"]
-
     es:
       ssl_enablement: "auto"
+    cloud_build: False

--- a/inventory/splunkforwarder_defaults_linux.yml
+++ b/inventory/splunkforwarder_defaults_linux.yml
@@ -121,3 +121,4 @@ splunk:
         httpinput: !!python/object/apply:os.path.join [*home, "etc", "apps", "splunk_httpinput"]
     es:
       ssl_enablement: "auto"
+    cloud_build: False

--- a/inventory/splunkforwarder_defaults_windows.yml
+++ b/inventory/splunkforwarder_defaults_windows.yml
@@ -119,6 +119,6 @@ splunk:
         idxc: !!python/object/apply:os.path.join [*home, "etc", "master-apps"]
         deployment: !!python/object/apply:os.path.join [*home, "etc", "deployment-apps"]
         httpinput: !!python/object/apply:os.path.join [*home, "etc", "apps", "splunk_httpinput"]
-
     es:
       ssl_enablement: "auto"
+    cloud_build: False

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -133,6 +133,11 @@
 - include_tasks: enable_dsp.yml
   when: "'dsp' in splunk and 'enable' in splunk.dsp and splunk.dsp.enable"
 
+- include_tasks: set_cloud_instance.yml
+  when:
+    - splunk.role != "splunk_universal_forwarder"
+    - splunk.cloud_build
+
 - include_tasks: start_splunk.yml
 
 - include_tasks: set_certificate_prefix.yml

--- a/roles/splunk_common/tasks/set_cloud_instance.yml
+++ b/roles/splunk_common/tasks/set_cloud_instance.yml
@@ -1,0 +1,12 @@
+---
+- name: Set instanceType as cloud
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: general
+    option: "instanceType"
+    value: "cloud"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: true
+  become_user: "{{ splunk.user }}"
+  


### PR DESCRIPTION
This feature has been tested and used by the Splunk Operator for Kubernetes (SOK) team. It allows images with Splunk Cloud builds to be recognized as such instead of the Splunk Enterprise product.