### PR TITLE
CSPL-4777: Fall back to system CA bundle when ca.crt is absent from TLS

### DIFF
--- a/roles/splunk_common/tasks/configure_input_cert.yml
+++ b/roles/splunk_common/tasks/configure_input_cert.yml
@@ -1,6 +1,6 @@
 ---
 # Configure Splunk input (S2S) certificate from operator-mounted TLS secret.
-# Input: /mnt/tls/splunk-input-tls-cert/{tls.crt, tls.key, ca.crt}
+# Input: /mnt/tls/splunk-input-tls-cert/{tls.crt, tls.key[, ca.crt]}
 # Output: bundled PEM at /opt/splunk/etc/auth/input-bundle.pem
 #         CA at /opt/splunk/etc/auth/splunk-input-ca.pem
 #         inputs.conf [SSL] configured
@@ -73,7 +73,12 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
-- name: Copy input CA certificate
+- name: Check if ca.crt is present in input cert mount
+  stat:
+    path: /mnt/tls/splunk-input-tls-cert/ca.crt
+  register: input_ca_file
+
+- name: Copy input CA certificate from secret
   copy:
     src: /mnt/tls/splunk-input-tls-cert/ca.crt
     dest: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
@@ -83,6 +88,17 @@
     mode: '0644'
   become: yes
   become_user: "{{ splunk.user }}"
+  when: input_ca_file.stat.exists
+
+- name: Set sslRootCAPath to system bundle when ca.crt is absent
+  set_fact:
+    input_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  when: not input_ca_file.stat.exists
+
+- name: Set sslRootCAPath to secret-provided CA
+  set_fact:
+    input_ca_path: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
+  when: input_ca_file.stat.exists
 
 - name: Configure serverCert in inputs.conf [SSL]
   ini_file:
@@ -113,7 +129,7 @@
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: SSL
     option: sslRootCAPath
-    value: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
+    value: "{{ input_ca_path }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   become: yes

--- a/roles/splunk_common/tasks/configure_server_cert.yml
+++ b/roles/splunk_common/tasks/configure_server_cert.yml
@@ -1,6 +1,6 @@
 ---
 # Configure Splunk server certificate from operator-mounted TLS secret.
-# Input: /mnt/tls/splunk-server-tls-cert/{tls.crt, tls.key, ca.crt}
+# Input: /mnt/tls/splunk-server-tls-cert/{tls.crt, tls.key[, ca.crt]}
 # Output: bundled PEM at /opt/splunk/etc/auth/splunk-server-bundle.pem
 #         CA at /opt/splunk/etc/auth/splunk-server-ca.pem
 #         server.conf [sslConfig] configured
@@ -73,7 +73,12 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
-- name: Copy CA certificate
+- name: Check if ca.crt is present in server cert mount
+  stat:
+    path: /mnt/tls/splunk-server-tls-cert/ca.crt
+  register: server_ca_file
+
+- name: Copy CA certificate from secret
   copy:
     src: /mnt/tls/splunk-server-tls-cert/ca.crt
     dest: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
@@ -83,6 +88,17 @@
     mode: '0644'
   become: yes
   become_user: "{{ splunk.user }}"
+  when: server_ca_file.stat.exists
+
+- name: Set sslRootCAPath to system bundle when ca.crt is absent
+  set_fact:
+    server_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  when: not server_ca_file.stat.exists
+
+- name: Set sslRootCAPath to secret-provided CA
+  set_fact:
+    server_ca_path: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
+  when: server_ca_file.stat.exists
 
 - name: Configure serverCert in server.conf
   ini_file:
@@ -113,7 +129,7 @@
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: sslConfig
     option: sslRootCAPath
-    value: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
+    value: "{{ server_ca_path }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   become: yes


### PR DESCRIPTION
## Summary

CloudWorks-issued DigiCert certs do not include a `ca.crt` in the Kubernetes
TLS secret — the leaf + intermediates are in `tls.crt`, and the DigiCert root
is already in the OS trust store on RHEL/UBI images. The previous Ansible tasks
unconditionally copied `ca.crt` from the mount, which would fail or produce an
invalid CA file for CloudWorks certs.

When `ca.crt` is absent from the secret mount, both `configure_server_cert.yml`
and `configure_input_cert.yml` now fall back to the system CA bundle at
`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, which includes the DigiCert
roots on UBI 8 images.

When `ca.crt` is present (self-signed or cert-manager certs), it is still copied
and used as before — no behavior change for existing users.

## Key Changes

- `configure_server_cert.yml` — `stat` the mount for `ca.crt`; copy + use it when
  present, fall back to system bundle when absent; `sslRootCAPath` in `server.conf`
  set via `server_ca_path` fact
- `configure_input_cert.yml` — same pattern; `sslRootCAPath` in `inputs.conf` set
  via `input_ca_path` fact

## Testing

Tested on EKS (`mqiu-eks`) with a TLS secret containing only `tls.crt` and `tls.key`
(no `ca.crt`):

=== server.conf [sslConfig] ===
serverCert    = /opt/splunk/etc/auth/splunk-server-bundle.pem
sslRootCAPath = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

=== inputs.conf [SSL] ===
serverCert    = /opt/splunk/etc/auth/input-bundle.pem
sslRootCAPath = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem



Both paths correctly fall back to the system bundle.

## Jira

- related: CSPL-4777 