### PR TITLE
make multisite vars a dictionary

### DIFF
--- a/multisite.yml
+++ b/multisite.yml
@@ -13,6 +13,6 @@
         when:
           - splunk.role is defined
         vars:
-          - splunk_install: false
-          - splunk_upgrade: false
-          - first_run: false
+          splunk_install: false
+          splunk_upgrade: false
+          first_run: false


### PR DESCRIPTION
A new error was found when provisioning multisite deployments with ansible 11.x:
```
ERROR! Vars in a IncludeRole must be specified as a dictionary.

The error appears to be in '/opt/ansible/multisite.yml': line 16, column 11, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

        vars:
          - splunk_install: false
          ^ here
```

From the ansible 11.x [porting guide](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_11.html#id98):
```
Removed support for setting the vars keyword to lists of dictionaries. It is now required to be a single dictionary.
```