### PR TITLE
Skip cgroup v1-only ExecStartPost chown in Splunkd.service under cgroup v2

### DIFF
--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -52,14 +52,14 @@
     replace:
       path: "/etc/systemd/system/{{ splunk_service_name }}"
       regexp: '^ExecStartPost=.*/sys/fs/cgroup/cpu.*$'
-      replace: 'ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"'
+      replace: 'ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"'
     when: installed_splunk_version[0] is version("8.0.0", "<")
 
   - name: Update memory cgroup
     replace:
       path: "/etc/systemd/system/{{ splunk_service_name }}"
       regexp: '^ExecStartPost=.*/sys/fs/cgroup/memory.*$'
-      replace: 'ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"'
+      replace: 'ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"'
     when: installed_splunk_version[0] is version("8.0.0", "<")
 
   - name: Disable cgroup per Splunk version

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -52,14 +52,14 @@
     replace:
       path: "/etc/systemd/system/{{ splunk_service_name }}"
       regexp: '^ExecStartPost=.*/sys/fs/cgroup/cpu.*$'
-      replace: 'ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"'
+      replace: 'ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"'
     when: installed_splunk_version[0] is version("8.0.0", "<")
 
   - name: Update memory cgroup
     replace:
       path: "/etc/systemd/system/{{ splunk_service_name }}"
       regexp: '^ExecStartPost=.*/sys/fs/cgroup/memory.*$'
-      replace: 'ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"'
+      replace: 'ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"'
     when: installed_splunk_version[0] is version("8.0.0", "<")
 
   - name: Disable cgroup per Splunk version
@@ -76,6 +76,26 @@
       path: "/etc/systemd/system/{{ splunk_service_name }}"
       regexp: '^(ExecStartPost=.*?)\/init.scope\/(.*)'
       replace: '\1/\2'
+
+- name: Detect cgroup v2
+  stat:
+    path: /sys/fs/cgroup/cgroup.controllers
+  register: cgroup_v2
+  when:
+    - ansible_system is match("Linux")
+    - splunk_systemd
+
+- name: Disable cgroup ExecStartPost under cgroup v2
+  replace:
+    path: "/etc/systemd/system/{{ splunk_service_name }}"
+    regexp: '^ExecStartPost=(.*?/sys/fs/cgroup/.*)$'
+    replace: '#ExecStartPost=\1'
+  become: yes
+  become_user: "{{ privileged_user }}"
+  when:
+    - ansible_system is match("Linux")
+    - splunk_systemd
+    - cgroup_v2.stat.exists | default(false)
 
 - name: "Reload daemons via systemctl - Linux (systemd)"
   become: yes

--- a/roles/splunk_common/tasks/enable_service.yml
+++ b/roles/splunk_common/tasks/enable_service.yml
@@ -71,31 +71,11 @@
       - installed_splunk_version[0] is version("8.0.0", ">=")
       - installed_splunk_version[0] is version("8.1.0", "<")
 
-  - name: Remove init.scope pathing
+  - name: Normalize cgroup pathing and skip cgroup v1 chown under cgroup v2
     replace:
       path: "/etc/systemd/system/{{ splunk_service_name }}"
-      regexp: '^(ExecStartPost=.*?)\/init.scope\/(.*)'
-      replace: '\1/\2'
-
-- name: Detect cgroup v2
-  stat:
-    path: /sys/fs/cgroup/cgroup.controllers
-  register: cgroup_v2
-  when:
-    - ansible_system is match("Linux")
-    - splunk_systemd
-
-- name: Disable cgroup ExecStartPost under cgroup v2
-  replace:
-    path: "/etc/systemd/system/{{ splunk_service_name }}"
-    regexp: '^ExecStartPost=(.*?/sys/fs/cgroup/.*)$'
-    replace: '#ExecStartPost=\1'
-  become: yes
-  become_user: "{{ privileged_user }}"
-  when:
-    - ansible_system is match("Linux")
-    - splunk_systemd
-    - cgroup_v2.stat.exists | default(false)
+      regexp: '^(ExecStartPost=.*?\/bin\/bash -c ")(?!\[ -f \/sys\/fs\/cgroup\/cgroup.controllers \] \|\| )(.*?\/sys\/fs\/cgroup(?:(?!\/init\.scope\/).)*)(?:\/init\.scope)?(\/(?:(?!\/init\.scope\/).)*)$'
+      replace: '\1[ -f /sys/fs/cgroup/cgroup.controllers ] || \2\3'
 
 - name: "Reload daemons via systemctl - Linux (systemd)"
   become: yes

--- a/roles/splunk_common/templates/Splunkd.service.j2
+++ b/roles/splunk_common/templates/Splunkd.service.j2
@@ -15,8 +15,8 @@ Delegate=true
 MemoryLimit=100G
 CPUShares=1024
 PermissionsStartOnly=true
-ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"
-ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"
+ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"
+ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/splunk_common/templates/Splunkd.service.j2
+++ b/roles/splunk_common/templates/Splunkd.service.j2
@@ -15,8 +15,8 @@ Delegate=true
 MemoryLimit=100G
 CPUShares=1024
 PermissionsStartOnly=true
-ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"
-ExecStartPost=/bin/bash -c "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"
+ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/cpu/system.slice/%n"
+ExecStartPost=/bin/bash -c "chown -R {{ splunk.user }}:{{ splunk.group }} /sys/fs/cgroup/memory/system.slice/%n"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
@@ -134,5 +134,5 @@ def test_splunkd_systemd_file(host):
     assert f.is_file
     assert f.user == "root"
     assert f.group == "root"
-    assert f.contains('ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/cpu/.*"$')
-    assert f.contains('^ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/memory/.*"$')
+    assert f.contains('^ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup\\.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/cpu/.*"$')
+    assert f.contains('^ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup\\.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/memory/.*"$')

--- a/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
@@ -134,5 +134,5 @@ def test_splunkd_systemd_file(host):
     assert f.is_file
     assert f.user == "root"
     assert f.group == "root"
-    assert f.contains('ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/cpu/.*"$')
-    assert f.contains('^ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/memory/.*"$')
+    assert f.contains('ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/cpu/.*"$')
+    assert f.contains('^ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/memory/.*"$')

--- a/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_standalone/molecule/systemd/tests/test_systemd.py
@@ -134,5 +134,5 @@ def test_splunkd_systemd_file(host):
     assert f.is_file
     assert f.user == "root"
     assert f.group == "root"
-    assert f.contains('^ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup\\.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/cpu/.*"$')
-    assert f.contains('^ExecStartPost=/bin/bash -c "\\[ -f /sys/fs/cgroup/cgroup\\.controllers \\] \\|\\| chown -R .* /sys/fs/cgroup/memory/.*"$')
+    assert f.contains('ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/cpu/.*"$')
+    assert f.contains('^ExecStartPost=/bin/bash -c "chown -R .* /sys/fs/cgroup/memory/.*"$')

--- a/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
@@ -122,7 +122,6 @@ def test_splunkforwarder_systemd_file(host):
     hostname = host.check_output("hostname -s")
     if "splunk-uf-732-systemd-centos8" in hostname:
         assert "ExecStartPost" in f.content_string
-        assert "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R" in f.content_string
     else:
         assert "ExecStartPost" not in f.content_string
 

--- a/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
+++ b/roles/splunk_universal_forwarder/molecule/systemd/tests/test_systemd.py
@@ -122,6 +122,7 @@ def test_splunkforwarder_systemd_file(host):
     hostname = host.check_output("hostname -s")
     if "splunk-uf-732-systemd-centos8" in hostname:
         assert "ExecStartPost" in f.content_string
+        assert "[ -f /sys/fs/cgroup/cgroup.controllers ] || chown -R" in f.content_string
     else:
         assert "ExecStartPost" not in f.content_string
 


### PR DESCRIPTION
## Summary
- Guard cgroup-path `ExecStartPost` commands with `/sys/fs/cgroup/cgroup.controllers`, so the legacy cgroup v1 `chown` is skipped on cgroup v2.
- Reuse the existing systemd-unit normalization task for Splunk 7.2.2 and newer; it still removes obsolete `/init.scope` pathing while adding the guard.
- Add the same guard directly to the legacy unit template used before Splunk 7.2.2.
- Apply to Splunk Enterprise and Universal Forwarder units, including units generated by Splunk 8.1 and newer.

## Performance
- Adds no Ansible tasks compared with `develop`.
- Replaces the PR's earlier extra `stat` and `replace` tasks by extending an existing `replace` task, keeping Ansible execution time effectively unchanged.
- On cgroup v2, service startup avoids the known failing recursive `chown`; on cgroup v1, behavior is unchanged apart from one inexpensive file-existence check at service start.

## Compatibility
- cgroup v1: `cgroup.controllers` is absent, so the existing ownership adjustment still runs.
- cgroup v2: `cgroup.controllers` is present, so the obsolete cgroup v1 ownership adjustment is skipped successfully.
- Existing Splunk 8.0.x behavior, where the directives are disabled, remains unchanged.
- The normalization is idempotent and preserves optional `ExecStartPost=-...` failure-prefix syntax.

## Validation
- [x] YAML parsing and `git diff --check`
- [x] `ansible-playbook site.yml --syntax-check`
- [x] Python syntax validation for the modified Molecule test
- [x] Regex cases: observed Splunk 9.0.7 unit, cgroup v1 controller path, legacy `/init.scope`, already-guarded line, and commented line
- [x] Prior Orca A/B test on cgroup v2 established that skipping this `chown` removes the `ExecStartPost` failure without changing Splunk service availability or delegated cgroup ownership
- [x] Downstream image rebuild and cgroup v2 runtime verification with this optimized guard
- [x] cgroup v1 runtime spot-check

Local `ansible-lint` could not start because the installed ansible-compat version failed while loading this repository's role metadata; the PR pipeline remains the lint authority.

## Downstream validation chain
- https://cd.splunkdev.com/core-ee/docker-splunk-internal/-/merge_requests/86
- https://cd.splunkdev.com/orca/orca-internal-base-images/-/merge_requests/442

> This pull request was updated with assistance from OpenAI Codex.
