### PR TITLE
Assemble full chain into sslRootCAPath and fix legacy rootCA collision

### DIFF
--- a/roles/splunk_common/tasks/configure_input_cert.yml
+++ b/roles/splunk_common/tasks/configure_input_cert.yml
@@ -78,11 +78,76 @@
     path: /mnt/tls/splunk-input-tls-cert/ca.crt
   register: input_ca_file
 
-- name: Copy input CA certificate from secret
+- name: Set sslRootCAPath to system bundle when ca.crt is absent
+  set_fact:
+    input_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  when: not input_ca_file.stat.exists
+
+- name: Write CA trust bundle script
   copy:
-    src: /mnt/tls/splunk-input-tls-cert/ca.crt
-    dest: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
-    remote_src: yes
+    dest: /tmp/splunk_build_input_ca_bundle.py
+    content: |
+      # tls.crt from the operator-mounted secret may contain intermediate
+      # certs that are not repeated in ca.crt (e.g. Vault PKI issuers put
+      # only the root in ca.crt). Splunk requires the full chain to be
+      # present locally in sslRootCAPath -- it does not complete the chain
+      # using intermediates presented by the peer during the handshake.
+      # Assemble tls.crt's non-leaf certs + ca.crt into one deduplicated
+      # trust bundle.
+      import sys
+
+      tls_crt_path = '/mnt/tls/splunk-input-tls-cert/tls.crt'
+      ca_crt_path = '/mnt/tls/splunk-input-tls-cert/ca.crt'
+      out_path = sys.argv[1] + '/etc/auth/splunk-input-ca.pem'
+
+      def split_pem_certs(data):
+          certs = []
+          current = []
+          for line in data.splitlines(keepends=True):
+              if line.strip() == b'-----BEGIN CERTIFICATE-----':
+                  current = [line]
+              elif line.strip() == b'-----END CERTIFICATE-----':
+                  current.append(line)
+                  certs.append(b''.join(current))
+                  current = []
+              elif current:
+                  current.append(line)
+          return certs
+
+      with open(tls_crt_path, 'rb') as f:
+          tls_certs = split_pem_certs(f.read())
+      chain_certs = tls_certs[1:]  # drop the leaf; keep any presented intermediates/root
+
+      with open(ca_crt_path, 'rb') as f:
+          ca_certs = split_pem_certs(f.read())
+
+      seen = set()
+      ordered = []
+      for cert in chain_certs + ca_certs:
+          if cert not in seen:
+              seen.add(cert)
+              ordered.append(cert)
+
+      with open(out_path, 'wb') as f:
+          for cert in ordered:
+              f.write(cert)
+              if not cert.endswith(b'\n'):
+                  f.write(b'\n')
+    mode: '0700'
+  when: input_ca_file.stat.exists
+
+- name: Build input CA trust bundle
+  command: >
+    python3 /tmp/splunk_build_input_ca_bundle.py
+    {{ splunk.home }}
+  become: yes
+  become_user: "{{ splunk.user }}"
+  changed_when: true
+  when: input_ca_file.stat.exists
+
+- name: Set CA trust bundle permissions
+  file:
+    path: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     mode: '0644'
@@ -90,12 +155,7 @@
   become_user: "{{ splunk.user }}"
   when: input_ca_file.stat.exists
 
-- name: Set sslRootCAPath to system bundle when ca.crt is absent
-  set_fact:
-    input_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-  when: not input_ca_file.stat.exists
-
-- name: Set sslRootCAPath to secret-provided CA
+- name: Set sslRootCAPath to the assembled CA trust bundle
   set_fact:
     input_ca_path: "{{ splunk.home }}/etc/auth/splunk-input-ca.pem"
   when: input_ca_file.stat.exists
@@ -129,6 +189,21 @@
     dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
     section: SSL
     option: sslRootCAPath
+    value: "{{ input_ca_path }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+# enable_s2s.yml (legacy S2S flow) may have already written the deprecated
+# rootCA key to this same [SSL] stanza, pointing at $SPLUNK_HOME/etc/auth/cacert.pem
+# regardless of the operator-mounted cert. Overwrite it here so the two SSL
+# trust settings in inputs.conf agree.
+- name: Configure rootCA in inputs.conf [SSL] to match sslRootCAPath
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/inputs.conf"
+    section: SSL
+    option: rootCA
     value: "{{ input_ca_path }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"

--- a/roles/splunk_common/tasks/configure_server_cert.yml
+++ b/roles/splunk_common/tasks/configure_server_cert.yml
@@ -78,11 +78,76 @@
     path: /mnt/tls/splunk-server-tls-cert/ca.crt
   register: server_ca_file
 
-- name: Copy CA certificate from secret
+- name: Set sslRootCAPath to system bundle when ca.crt is absent
+  set_fact:
+    server_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  when: not server_ca_file.stat.exists
+
+- name: Write CA trust bundle script
   copy:
-    src: /mnt/tls/splunk-server-tls-cert/ca.crt
-    dest: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
-    remote_src: yes
+    dest: /tmp/splunk_build_server_ca_bundle.py
+    content: |
+      # tls.crt from the operator-mounted secret may contain intermediate
+      # certs that are not repeated in ca.crt (e.g. Vault PKI issuers put
+      # only the root in ca.crt). Splunk requires the full chain to be
+      # present locally in sslRootCAPath -- it does not complete the chain
+      # using intermediates presented by the peer during the handshake.
+      # Assemble tls.crt's non-leaf certs + ca.crt into one deduplicated
+      # trust bundle.
+      import sys
+
+      tls_crt_path = '/mnt/tls/splunk-server-tls-cert/tls.crt'
+      ca_crt_path = '/mnt/tls/splunk-server-tls-cert/ca.crt'
+      out_path = sys.argv[1] + '/etc/auth/splunk-server-ca.pem'
+
+      def split_pem_certs(data):
+          certs = []
+          current = []
+          for line in data.splitlines(keepends=True):
+              if line.strip() == b'-----BEGIN CERTIFICATE-----':
+                  current = [line]
+              elif line.strip() == b'-----END CERTIFICATE-----':
+                  current.append(line)
+                  certs.append(b''.join(current))
+                  current = []
+              elif current:
+                  current.append(line)
+          return certs
+
+      with open(tls_crt_path, 'rb') as f:
+          tls_certs = split_pem_certs(f.read())
+      chain_certs = tls_certs[1:]  # drop the leaf; keep any presented intermediates/root
+
+      with open(ca_crt_path, 'rb') as f:
+          ca_certs = split_pem_certs(f.read())
+
+      seen = set()
+      ordered = []
+      for cert in chain_certs + ca_certs:
+          if cert not in seen:
+              seen.add(cert)
+              ordered.append(cert)
+
+      with open(out_path, 'wb') as f:
+          for cert in ordered:
+              f.write(cert)
+              if not cert.endswith(b'\n'):
+                  f.write(b'\n')
+    mode: '0700'
+  when: server_ca_file.stat.exists
+
+- name: Build server CA trust bundle
+  command: >
+    python3 /tmp/splunk_build_server_ca_bundle.py
+    {{ splunk.home }}
+  become: yes
+  become_user: "{{ splunk.user }}"
+  changed_when: true
+  when: server_ca_file.stat.exists
+
+- name: Set CA trust bundle permissions
+  file:
+    path: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
     mode: '0644'
@@ -90,12 +155,7 @@
   become_user: "{{ splunk.user }}"
   when: server_ca_file.stat.exists
 
-- name: Set sslRootCAPath to system bundle when ca.crt is absent
-  set_fact:
-    server_ca_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-  when: not server_ca_file.stat.exists
-
-- name: Set sslRootCAPath to secret-provided CA
+- name: Set sslRootCAPath to the assembled CA trust bundle
   set_fact:
     server_ca_path: "{{ splunk.home }}/etc/auth/splunk-server-ca.pem"
   when: server_ca_file.stat.exists


### PR DESCRIPTION
## Summary
- Assemble a full, deduplicated trust chain into `sslRootCAPath` (server.conf and inputs.conf) by combining `ca.crt` with any non-leaf certs found in `tls.crt`. Fixes mTLS failures on port 9997/8089 when a PKI issuer (e.g. Vault/CO2 convention) places only the root in `ca.crt` and the intermediate only in `tls.crt` — Splunk does not complete a peer's chain from certs presented on the wire, so the intermediate must be present locally.
- Reassert the deprecated `rootCA` key in `inputs.conf [SSL]` to match `sslRootCAPath` after the legacy S2S SSL flow (`enable_s2s.yml`) runs, since it unconditionally overwrites `rootCA` in the same stanza and can otherwise cause `sslRootCAPath` and `rootCA` to disagree.

## Test plan
Verified manually end-to-end on an EKS cluster with the Splunk Operator:
- [x] Port 9997 (input cert): client cert fails mTLS against an pod without the fix (chain incomplete) and succeeds against a pod with the fix
- [x] Port 8089 (server cert): client cert fails mTLS against an pod without the fix (chain incomplete) and succeeds against a pod with the fix
- [x] Legacy S2S SSL flow enabled via `spec.defaults`: confirmed `rootCA` and `sslRootCAPath` agree after patch (previously collided)
- [x] Regression: `ca.crt` absent from the TLS secret still falls back to the system CA bundle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
