### PR TITLE
Wait for cluster manager to be ready

### DIFF
--- a/roles/splunk_common/tasks/peer_cluster_master.yml
+++ b/roles/splunk_common/tasks/peer_cluster_master.yml
@@ -3,6 +3,15 @@
   vars:
     splunk_instance_address: "{{ splunk.cluster_master_url }}"
 
+# wait_for_splunk_instance.yml above only confirms the cluster manager's
+# management port answers HTTP; it can return 200 while the manager is
+# still mid-restart from its own `edit cluster-config -mode manager` call
+# and not yet accepting peer/searchhead registrations. Wait for the
+# cluster-specific endpoint to be ready too, so the join below isn't
+# attempted against a manager that can't yet service it.
+- include_tasks: ../../../roles/splunk_common/tasks/wait_for_cluster_manager_ready.yml
+  when: not uds_enabled | bool
+
 # http://docs.splunk.com/Documentation/Splunk/latest/DistSearch/SHCandindexercluster#Integrate_with_a_single-site_indexer_cluster
 - name: Peer cluster master TCP
   command: "{{ splunk.exec }} edit cluster-config -mode searchhead -master_uri {{ cert_prefix }}://{{ splunk.cluster_master_url }}:{{ splunk.svc_port }} -replication_port {{ splunk.idxc.replication_port }} -secret '{{ splunk.idxc.pass4SymmKey }}' -auth '{{ splunk.admin_user }}:{{ splunk.password }}'"

--- a/roles/splunk_common/tasks/wait_for_cluster_manager_ready.yml
+++ b/roles/splunk_common/tasks/wait_for_cluster_manager_ready.yml
@@ -1,0 +1,24 @@
+---
+# Confirms the cluster manager has actually finished initializing as a
+# manager (not just that its management port is reachable) before this
+# search head attempts to join it. wait_for_splunk_instance.yml only
+# checks that some HTTP response comes back, which succeeds even while
+# the splunk_cluster_master role's own mode-switch restart is still in
+# progress. This polls the same /services/cluster/master/info endpoint
+# that `edit cluster-config` itself depends on internally, so the join
+# is only attempted once it can actually succeed.
+- name: Wait for cluster manager to be ready
+  uri:
+    url: "{{ cert_prefix }}://{{ splunk.cluster_master_url }}:{{ splunk.svc_port }}/services/cluster/master/info?output_mode=json"
+    method: GET
+    user: "{{ splunk.admin_user }}"
+    password: "{{ splunk.password }}"
+    force_basic_auth: yes
+    validate_certs: false
+    use_proxy: no
+    status_code: [200]
+  register: cluster_manager_ready
+  until: cluster_manager_ready.status == 200
+  retries: "{{ wait_for_splunk_retry_num }}"
+  delay: "{{ retry_delay }}"
+  no_log: "{{ hide_password }}"


### PR DESCRIPTION
Add logic to confirm the cluster manager has actually finished initializing as a manager before search head attempts to join it