### PR TITLE
CSPL-4925: disable Postgres node sidecar by default on CMP-K/SOK

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -122,6 +122,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPARK_MASTER_WEBUI_PORT | Identifies the port for the Spark master web UI. | no | no | no |
 | DMC_FORWARDER_MONITORING | Enables forwarder monitoring on all standalone and search head instances. Default: `False` | no | no | no |
 | DMC_ASSET_INTERVAL | Cron schedule that determines how often forwarder assets are re-built. Default: `"3,18,33,48 * * * *"` = every 15 minutes) | no | no | no |
+| SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED | Toggles the co-hosted Postgres node sidecar by writing `[postgres] disabled` to `server.conf`. Set to `true` to disable the sidecar (injected by default on SOK/CMP-K deployments), or `false` to re-enable it. When unset, the stanza is not written. **Deprecation notice:** this override may be removed in a future SOK release. | no | no | no |
 | SPLUNK_ENABLE_ASAN | Internally used trigger to handle special provisioning of debug builds of Splunk Enterprise | no | no | no |
 | SPLUNK_DEFAULTS_URL | URL to a remote `default.yml` file - when fetched, this will get merged into a consolidated mapping of variables | no | no | no |
 | SPLUNK_DEFAULTS_HTTP_MAX_TIMEOUT | When fetching a remote `default.yml`, specify the timeout of the request | no | no | no |

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -176,6 +176,7 @@ def getDefaultVars():
     getESSplunkVariables(defaultVars)
     getDSP(defaultVars)
     getIPv6(defaultVars)
+    getNodeSidecarPostgres(defaultVars)
     return defaultVars
 
 def getServiceName(vars_scope):
@@ -741,6 +742,17 @@ def getIPv6(vars_scope):
     Set specific environment variables to apply IPv6 configurations
     """
     vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", "").lower() == "true"
+
+def getNodeSidecarPostgres(vars_scope):
+    """
+    Honor SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED to toggle the co-hosted
+    Postgres node sidecar via the server.conf [postgres] disabled setting.
+    The stanza is only injected when the env var is explicitly set, so
+    deployments that do not set it are left untouched.
+    """
+    val = os.environ.get("SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED")
+    if val is not None and val != "":
+        vars_scope["splunk"]["node_sidecar_postgres_disabled"] = val.lower() == "true"
 
 
 def getRandomString():

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -37,6 +37,9 @@
 - include_tasks: enable_ipv6.yml
   when: splunk.listen_on_ipv6 | bool
 
+- include_tasks: set_postgres_sidecar.yml
+  when: "'node_sidecar_postgres_disabled' in splunk"
+
 - include_tasks: enable_asan.yml
   when:
     - "'asan' in splunk and splunk.asan | bool"

--- a/roles/splunk_common/tasks/set_postgres_sidecar.yml
+++ b/roles/splunk_common/tasks/set_postgres_sidecar.yml
@@ -1,0 +1,14 @@
+---
+# Toggle the co-hosted Postgres node sidecar via server.conf.
+# Driven by SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED; SOK injects this by
+# default on CMP-K deployments and users may override it via spec.extraEnv.
+- name: Configure Postgres node sidecar
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: postgres
+    option: disabled
+    value: "{{ splunk.node_sidecar_postgres_disabled | bool | lower }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -634,6 +634,25 @@ def test_getDSP(default_yml, os_env, result):
             environ.getDSP(vars_scope)
     assert vars_scope["splunk"]["dsp"] == result
 
+@pytest.mark.parametrize(("os_env", "result"),
+            [
+                # Unset or empty -> key is not injected at all
+                ({}, {}),
+                ({"SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED": ""}, {}),
+                # Explicit values -> boolean stored
+                ({"SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED": "true"}, {"node_sidecar_postgres_disabled": True}),
+                ({"SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED": "TRUE"}, {"node_sidecar_postgres_disabled": True}),
+                ({"SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED": "false"}, {"node_sidecar_postgres_disabled": False}),
+                ({"SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED": "yes"}, {"node_sidecar_postgres_disabled": False}),
+            ]
+        )
+def test_getNodeSidecarPostgres(os_env, result):
+    vars_scope = {"splunk": {}}
+    with patch("environ.inventory") as mock_inven:
+        with patch("os.environ", new=os_env):
+            environ.getNodeSidecarPostgres(vars_scope)
+    assert vars_scope["splunk"] == result
+
 @pytest.mark.parametrize(("es_enablement", "os_env", "result"),
             [
                 (None, {}, ""),


### PR DESCRIPTION
## Summary

The Postgres node sidecar starts by default on CMP-K/SOK deployments — an
unintentional behaviour with no supported use case. On older releases it
self-disables then gets restarted in a loop; on 10.4+ it silently accumulates
data in an unsupported configuration.

This PR wires splunk-ansible to honour `SPLUNK_NODE_SIDECAR_POSTGRES_DISABLED`
and write `[postgres] disabled = <true|false>` to `server.conf`. The stanza is
only written when the env var is explicitly set, so plain docker-splunk
deployments are unaffected. SOK will inject the default (`true`) via pod spec;
users can override via `spec.extraEnv`.

Upstream node platform task: SPL-295437.

## Key Changes

- **`inventory/environ.py`** — new `getNodeSidecarPostgres()` getter (mirrors
  `getIPv6`/`getDSP` pattern); called from `getDefaultVars()`. Sets
  `splunk.node_sidecar_postgres_disabled` only when the env var is present and
  non-empty.
- **`roles/splunk_common/tasks/set_postgres_sidecar.yml`** (new) — writes
  `[postgres] disabled` to `server.conf` via `ini_file`.
- **`roles/splunk_common/tasks/main.yml`** — gated `include_tasks` next to
  `enable_ipv6.yml`; guard: `'node_sidecar_postgres_disabled' in splunk`.
  Runs for all roles via `splunk_common`.
- **`docs/ADVANCED.md`** — new env-var table row with deprecation notice.

## Testing

- `tests/small/test_environ.py` — added `test_getNodeSidecarPostgres` with 6
  parametrized cases covering: unset, empty string, `true`, `TRUE`, `false`,
  `yes` (only strict `true`/`True` → disabled). All pass.
- Verified yamllint (repo `.yamllint` config) is clean on all changed files.
- Confirmed the 13 pre-existing `test_getSecrets` failures reproduce on the
  clean baseline (environment artifact, not introduced by this change).

## Jira

- ticket: [CSPL-4925](https://splunk.atlassian.net/browse/CSPL-4925)