### PR TITLE
CSPL-5143 Remove conf files to mitigate duplicate stanza issue

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include_tasks: get_facts.yml
 
+- include_tasks: remove_stale_sok_conf.yml
+
 - include_tasks: install_python_requirements.yml
 
 - include_tasks: change_splunk_directory_owner.yml

--- a/roles/splunk_common/tasks/remove_stale_sok_conf.yml
+++ b/roles/splunk_common/tasks/remove_stale_sok_conf.yml
@@ -1,0 +1,15 @@
+---
+# Remove stale local outputs.conf/inputs.conf files that may have been left behind
+# by the Splunk Operator for Kubernetes (SOK) apps, to prevent conflicting configuration
+# from persisting across runs.
+- name: "Remove stale SOK local outputs.conf/inputs.conf files"
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ splunk.home }}/etc/apps/100-sok/local/outputs.conf"
+    - "{{ splunk.home }}/etc/apps/100-sok/local/inputs.conf"
+    - "{{ splunk.home }}/etc/apps/101-sok-secrets/local/inputs.conf"
+    - "{{ splunk.home }}/etc/apps/101-sok-secrets/local/outputs.conf"
+  become: yes
+  become_user: "{{ splunk.user }}"


### PR DESCRIPTION
**Summary**

- Splunk Operator for Kubernetes (SOK) apps (100-sok, 101-sok-secrets) can leave behind stale local/outputs.conf and local/inputs.conf files that persist across runs and combine with newly generated stanzas, causing duplicated queue/forwarding stanzas.
- Adds a new task, remove_stale_sok_conf.yml, which removes these four files (if present) at the very start of the splunk_common role, before any other provisioning happens:
    - {{ splunk.home }}/etc/apps/100-sok/local/outputs.conf
    - {{ splunk.home }}/etc/apps/100-sok/local/inputs.conf
    - {{ splunk.home }}/etc/apps/101-sok-secrets/local/inputs.conf
    - {{ splunk.home }}/etc/apps/101-sok-secrets/local/outputs.conf
- Wired into main.yml immediately after get_facts.yml, so this always runs first on every provisioning run, before any stanzas are (re)generated.

**Jira**

https://splunk.atlassian.net/browse/CSPL-5143