### PR TITLE
CSPL-5085: Fix for LM peer breakage after server.conf replacement

### DIFF
--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -121,6 +121,7 @@
     conf_file: "{{ item.key }}.conf"
     conf_directory: "{{ item.value.directory | default(splunk.home + '/etc/system/local', true) }}"
     conf_stanzas: "{{ item.value.content | default({}) }}"
+    reconcile_config_map_values: true
   with_items: "{% if splunk.conf is mapping %}{{ splunk.conf | dict2items }}{% else %}{{ splunk.conf }}{% endif %}"
   when: "'conf' in splunk and splunk.conf"
   no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/reconcile_config_map_values.yml
+++ b/roles/splunk_common/tasks/reconcile_config_map_values.yml
@@ -1,0 +1,29 @@
+---
+- name: Check for previous ConfigMap-owned values in {{ conf_file }}
+  stat:
+    path: "{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml"
+  register: config_map_managed_values_file
+  become: yes
+  become_user: "{{ splunk.user }}"
+
+- name: Load previous ConfigMap-owned values in {{ conf_file }}
+  include_vars:
+    file: "{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml"
+    name: previous_config_map_stanzas
+  when: config_map_managed_values_file.stat.exists
+  no_log: "{{ hide_password }}"
+
+- name: Initialize previous ConfigMap-owned values in {{ conf_file }}
+  set_fact:
+    previous_config_map_stanzas: {}
+  when: not config_map_managed_values_file.stat.exists
+
+- name: Remove previous ConfigMap-owned values from {{ conf_file }}
+  include_tasks: remove_config_map_stanza.yml
+  vars:
+    config_map_stanza_name: "{{ previous_stanza.key }}"
+    config_map_stanza_settings: "{{ previous_stanza.value | default({}) }}"
+  with_dict: "{{ previous_config_map_stanzas }}"
+  loop_control:
+    loop_var: previous_stanza
+  no_log: "{{ hide_password }}"

--- a/roles/splunk_common/tasks/remove_config_map_stanza.yml
+++ b/roles/splunk_common/tasks/remove_config_map_stanza.yml
@@ -1,0 +1,15 @@
+---
+- name: Remove ConfigMap-owned options in {{ config_map_stanza_name }}
+  ini_file:
+    path: "{{ conf_directory }}/{{ conf_file }}"
+    section: "{{ config_map_stanza_name }}"
+    option: "{{ config_map_stanza_setting.key }}"
+    state: absent
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  become: yes
+  become_user: "{{ splunk.user }}"
+  with_dict: "{{ config_map_stanza_settings }}"
+  loop_control:
+    loop_var: config_map_stanza_setting
+  when: config_map_stanza_name and config_map_stanza_settings

--- a/roles/splunk_common/tasks/set_config_file.yml
+++ b/roles/splunk_common/tasks/set_config_file.yml
@@ -7,15 +7,12 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
-- name: Remove stale {{ conf_file }} before writing config map values
-  file:
-    path: "{{ conf_directory }}/{{ conf_file }}"
-    state: absent
+- name: Remove stale ConfigMap-owned values from {{ conf_file }}
+  include_tasks: reconcile_config_map_values.yml
   when:
-    - conf_directory is defined
+    - reconcile_config_map_values | default(false) | bool
     - conf_stanzas | length > 0
-  become: yes
-  become_user: "{{ splunk.user }}"
+  no_log: "{{ hide_password }}"
 
 - include_tasks: set_config_stanza.yml
   vars:
@@ -24,4 +21,18 @@
   with_dict: "{{ conf_stanzas }}"
   loop_control:
     loop_var: stanza
+  no_log: "{{ hide_password }}"
+
+- name: Record ConfigMap-owned values in {{ conf_file }}
+  copy:
+    content: "{{ conf_stanzas | to_nice_yaml }}"
+    dest: "{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    mode: '0660'
+  when:
+    - reconcile_config_map_values | default(false) | bool
+    - conf_stanzas | length > 0
+  become: yes
+  become_user: "{{ splunk.user }}"
   no_log: "{{ hide_password }}"

--- a/tests/small/test_hec_receiver.py
+++ b/tests/small/test_hec_receiver.py
@@ -207,31 +207,49 @@ def test_build_hec_global_body(splunk, expected_body):
 
 
 # ---------------------------------------------------------------------------
-# Stale config-file removal guard
+# ConfigMap-owned config reconciliation
 # ---------------------------------------------------------------------------
 
-def should_remove_conf_file(conf_directory, conf_stanzas):
+def config_map_options_to_remove(previous_stanzas):
     '''
-    Mirror the `when` guard on "Remove stale <conf_file> before writing
-    config map values" in set_config_file.yml.
+    Mirror the stale-value removal input in reconcile_config_map_values.yml.
 
-    The task removes the file only when conf_directory is defined AND
-    conf_stanzas is non-empty.
+    All values from the previous ConfigMap ownership manifest are removed
+    before the current ConfigMap values are applied. This removes stale keys
+    without deleting settings that were never ConfigMap-owned.
     '''
-    return conf_directory is not None and len(conf_stanzas) > 0
+    return {
+        (stanza_name, option_name)
+        for stanza_name, options in previous_stanzas.items()
+        for option_name in options
+    }
 
 
-@pytest.mark.parametrize(('conf_directory', 'conf_stanzas', 'expected'), [
-    # conf_directory undefined — never remove
-    (None, {}, False),
-    (None, {'stanza1': {'key': 'val'}}, False),
+def test_config_map_reconciliation_preserves_unowned_general_key():
+    previous_config_map_stanzas = {
+        'kvstore': {'disabled': True},
+    }
 
-    # conf_directory defined but no stanzas — skip removal (nothing to write)
-    ('/opt/splunk/etc/system/local', {}, False),
+    options_to_remove = config_map_options_to_remove(previous_config_map_stanzas)
 
-    # conf_directory defined and stanzas present — remove stale file
-    ('/opt/splunk/etc/system/local', {'stanza1': {'key': 'val'}}, True),
-    ('/opt/splunk/etc/system/local', {'a': {}, 'b': {}}, True),
-])
-def test_should_remove_conf_file(conf_directory, conf_stanzas, expected):
-    assert should_remove_conf_file(conf_directory, conf_stanzas) == expected
+    assert ('kvstore', 'disabled') in options_to_remove
+    assert ('general', 'pass4SymmKey') not in options_to_remove
+
+
+def test_config_map_reconciliation_removes_stale_option_before_applying_current_value():
+    previous_config_map_stanzas = {
+        'kvstore': {'disabled': True, 'port': 8191},
+    }
+    current_config_map_stanzas = {
+        'kvstore': {'disabled': False},
+    }
+
+    options_to_remove = config_map_options_to_remove(previous_config_map_stanzas)
+
+    assert ('kvstore', 'disabled') in options_to_remove
+    assert ('kvstore', 'port') in options_to_remove
+    assert current_config_map_stanzas['kvstore']['disabled'] is False
+
+
+def test_config_map_reconciliation_has_no_stale_values_on_first_run():
+    assert config_map_options_to_remove({}) == set()


### PR DESCRIPTION
### Summary
Fixes [CSPL-5085](https://splunk.atlassian.net/browse/CSPL-5085), where ConfigMap-provided `server.conf` settings deleted the entire `system/local/server.conf` file. The previous reconciliation removed operator-managed settings, including `[general] pass4SymmKey`, causing License Manager signature mismatches and preventing new indexers from becoming Ready.

This change tracks ConfigMap-owned options and removes only those values during reconciliation. Other Ansible-managed settings in the same file are preserved.

### Testing

- Reproduced the failure with Splunk Enterprise 9.4.13 using an IndexerCluster with three replicas, a ClusterManager, and a License Manager.
- Verified the original ConfigMap targeting system/local/server.conf caused License Manager signature mismatches before the fix.
- Built 9.4.13 and 10.4.2 images with this branch and verified all three indexers reach `Ready` with the same configuration.
- Verified the app-local `server.conf` workaround also remains healthy.
- Verified stale ConfigMap-owned settings are removed while `[general] pass4SymmKey` remains present after restart.