### PR TITLE
SPL-295139 Configure default KV Store type via env

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -86,6 +86,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNKD_SSL_CA | Path to custom CA certificate used for Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNKD_SSL_PASSWORD | Custom SSL password used with Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNK_KVSTORE_PORT | Port to run Splunk KVStore. Default: `8191` | no | no | no |
+| SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; when set to `local`, Ansible also writes `[kvstore] postgresMigrateOnStartup=false`. SOK injects `local` for supported CMP-K deployments. | no | no | no |
 | SPLUNK_APPSERVER_PORT | Port to run Splunk appserver. Default: `8065` | no | no | no |
 | SPLUNK_SET_SEARCH_PEERS | Boolean to configure whether search heads should connect to search peers. Default: `True`. Not recommended to change | no | no | no |
 | SPLUNK_SITE | For multisite topologies, define the site of this particular Splunk Enterprise instance | no | no | no |

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -86,7 +86,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNKD_SSL_CA | Path to custom CA certificate used for Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNKD_SSL_PASSWORD | Custom SSL password used with Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNK_KVSTORE_PORT | Port to run Splunk KVStore. Default: `8191` | no | no | no |
-| SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; when set to `local`, Ansible also writes `[kvstore] postgresMigrateOnStartup=false`. SOK injects `local` for supported CMP-K deployments. | no | no | no |
+| SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; when set to `local`, Ansible writes the setting only for Splunk Enterprise 10.6.0 or later and also writes `[kvstore] postgresMigrateOnStartup=false`. Older Splunk versions skip the local KV Store configuration. SOK injects `local` for supported CMP-K deployments. | no | no | no |
 | SPLUNK_APPSERVER_PORT | Port to run Splunk appserver. Default: `8065` | no | no | no |
 | SPLUNK_SET_SEARCH_PEERS | Boolean to configure whether search heads should connect to search peers. Default: `True`. Not recommended to change | no | no | no |
 | SPLUNK_SITE | For multisite topologies, define the site of this particular Splunk Enterprise instance | no | no | no |

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -86,7 +86,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNKD_SSL_CA | Path to custom CA certificate used for Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNKD_SSL_PASSWORD | Custom SSL password used with Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNK_KVSTORE_PORT | Port to run Splunk KVStore. Default: `8191` | no | no | no |
-| SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; when set to `local`, Ansible writes the setting only for Splunk Enterprise 10.6.0 or later and also writes `[kvstore] postgresMigrateOnStartup=false`. Older Splunk versions skip the local KV Store configuration. SOK injects `local` for supported CMP-K deployments. | no | no | no |
+| SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; Ansible writes the setting only for Splunk Enterprise 10.6.0 or later. When set to `cohosted`, Ansible also writes `[kvstore] postgresMigrateOnStartup=true`; when set to `local`, it writes `[kvstore] postgresMigrateOnStartup=false`. Older Splunk versions skip the default KV Store type configuration. SOK injects `local` for supported CMP-K deployments. | no | no | no |
 | SPLUNK_APPSERVER_PORT | Port to run Splunk appserver. Default: `8065` | no | no | no |
 | SPLUNK_SET_SEARCH_PEERS | Boolean to configure whether search heads should connect to search peers. Default: `True`. Not recommended to change | no | no | no |
 | SPLUNK_SITE | For multisite topologies, define the site of this particular Splunk Enterprise instance | no | no | no |

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -176,6 +176,7 @@ def getDefaultVars():
     getESSplunkVariables(defaultVars)
     getDSP(defaultVars)
     getIPv6(defaultVars)
+    getDefaultKVStoreType(defaultVars)
     getNodeSidecarPostgres(defaultVars)
     return defaultVars
 
@@ -742,6 +743,20 @@ def getIPv6(vars_scope):
     Set specific environment variables to apply IPv6 configurations
     """
     vars_scope["splunk"]["listen_on_ipv6"] = os.environ.get("SPLUNK_LISTEN_ON_IPV6", "").lower() == "true"
+
+def getDefaultKVStoreType(vars_scope):
+    """
+    Honor SPLUNK_KVSTORE_DEFAULT_TYPE to configure server.conf
+    [kvstore] defaultKVStoreType when explicitly provided.
+    """
+    kvstore = vars_scope["splunk"].get("kvstore", {})
+    val = os.environ.get("SPLUNK_KVSTORE_DEFAULT_TYPE", kvstore.get("default_kvstore_type"))
+    if val is None or val == "":
+        return
+
+    default_kvstore_type = val.lower()
+    vars_scope["splunk"].setdefault("kvstore", {})
+    vars_scope["splunk"]["kvstore"]["default_kvstore_type"] = default_kvstore_type
 
 def getNodeSidecarPostgres(vars_scope):
     """

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -103,6 +103,13 @@
     - splunk.kvstore.kvservice_connection_string is not none
     - splunk.kvstore.kvservice_connection_string | length > 0
 
+- include_tasks: set_default_kvstore_type.yml
+  when:
+    - "'kvstore' in splunk and 'default_kvstore_type' in splunk.kvstore"
+    - splunk.kvstore.default_kvstore_type is not none
+    - splunk.kvstore.default_kvstore_type | length > 0
+    - splunk.role != "splunk_universal_forwarder"
+
 - include_tasks: enable_splunkweb_ssl.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"

--- a/roles/splunk_common/tasks/set_default_kvstore_type.yml
+++ b/roles/splunk_common/tasks/set_default_kvstore_type.yml
@@ -5,6 +5,32 @@
       - splunk.kvstore.default_kvstore_type in ["cohosted", "local"]
     fail_msg: "splunk.kvstore.default_kvstore_type must be either 'cohosted' or 'local'"
 
+- name: Retrieve installed Splunk version for local KV Store
+  command: "{{ splunk.exec }} version --accept-license --answer-yes --no-prompt"
+  register: kvstore_installed_splunk_version_cmd
+  become: yes
+  become_user: "{{ splunk.user }}"
+  changed_when: false
+  when: splunk.kvstore.default_kvstore_type == "local"
+
+- name: Set installed Splunk version fact for local KV Store
+  set_fact:
+    kvstore_installed_splunk_version: "{{ kvstore_installed_splunk_version_cmd.stdout | regex_search(regexp, '\\1') | default(['0'], true) }}"
+  vars:
+    regexp: 'Splunk(?:\sUniversal\sForwarder)?\s((\d+)\.(\d+)\.(\d+)(?:\.\d+)?).*'
+  when: splunk.kvstore.default_kvstore_type == "local"
+
+- name: Set local KV Store support fact
+  set_fact:
+    kvstore_local_supported: "{{ kvstore_installed_splunk_version[0] is version('10.6.0', '>=') }}"
+  when: splunk.kvstore.default_kvstore_type == "local"
+
+- name: Skip local KV Store type for unsupported Splunk version
+  debug:
+    msg: "Skipping splunk.kvstore.default_kvstore_type=local because it requires Splunk Enterprise 10.6.0 or later. Installed version is {{ kvstore_installed_splunk_version[0] | default('unknown') }}."
+  when: splunk.kvstore.default_kvstore_type == "local"
+    and not kvstore_local_supported | default(false) | bool
+
 - name: Set default KV Store type
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
@@ -13,6 +39,8 @@
     value: "{{ splunk.kvstore.default_kvstore_type }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
+  when: splunk.kvstore.default_kvstore_type != "local"
+    or kvstore_local_supported | default(false) | bool
 
 - name: Disable Postgres migrate on startup for local KV Store
   ini_file:
@@ -22,4 +50,6 @@
     value: "false"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-  when: splunk.kvstore.default_kvstore_type == "local"
+  when:
+    - splunk.kvstore.default_kvstore_type == "local"
+    - kvstore_local_supported | default(false) | bool

--- a/roles/splunk_common/tasks/set_default_kvstore_type.yml
+++ b/roles/splunk_common/tasks/set_default_kvstore_type.yml
@@ -5,31 +5,27 @@
       - splunk.kvstore.default_kvstore_type in ["cohosted", "local"]
     fail_msg: "splunk.kvstore.default_kvstore_type must be either 'cohosted' or 'local'"
 
-- name: Retrieve installed Splunk version for local KV Store
+- name: Retrieve installed Splunk version for default KV Store type
   command: "{{ splunk.exec }} version --accept-license --answer-yes --no-prompt"
   register: kvstore_installed_splunk_version_cmd
   become: yes
   become_user: "{{ splunk.user }}"
   changed_when: false
-  when: splunk.kvstore.default_kvstore_type == "local"
 
-- name: Set installed Splunk version fact for local KV Store
+- name: Set installed Splunk version fact for default KV Store type
   set_fact:
     kvstore_installed_splunk_version: "{{ kvstore_installed_splunk_version_cmd.stdout | regex_search(regexp, '\\1') | default(['0'], true) }}"
   vars:
     regexp: 'Splunk(?:\sUniversal\sForwarder)?\s((\d+)\.(\d+)\.(\d+)(?:\.\d+)?).*'
-  when: splunk.kvstore.default_kvstore_type == "local"
 
-- name: Set local KV Store support fact
+- name: Set default KV Store type support fact
   set_fact:
-    kvstore_local_supported: "{{ kvstore_installed_splunk_version[0] is version('10.6.0', '>=') }}"
-  when: splunk.kvstore.default_kvstore_type == "local"
+    kvstore_default_type_supported: "{{ kvstore_installed_splunk_version[0] is version('10.6.0', '>=') }}"
 
-- name: Skip local KV Store type for unsupported Splunk version
+- name: Skip default KV Store type for unsupported Splunk version
   debug:
-    msg: "Skipping splunk.kvstore.default_kvstore_type=local because it requires Splunk Enterprise 10.6.0 or later. Installed version is {{ kvstore_installed_splunk_version[0] | default('unknown') }}."
-  when: splunk.kvstore.default_kvstore_type == "local"
-    and not kvstore_local_supported | default(false) | bool
+    msg: "Skipping splunk.kvstore.default_kvstore_type={{ splunk.kvstore.default_kvstore_type }} because it requires Splunk Enterprise 10.6.0 or later. Installed version is {{ kvstore_installed_splunk_version[0] | default('unknown') }}."
+  when: not (kvstore_default_type_supported | default(false) | bool)
 
 - name: Set default KV Store type
   ini_file:
@@ -39,17 +35,14 @@
     value: "{{ splunk.kvstore.default_kvstore_type }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-  when: splunk.kvstore.default_kvstore_type != "local"
-    or kvstore_local_supported | default(false) | bool
+  when: kvstore_default_type_supported | default(false) | bool
 
-- name: Disable Postgres migrate on startup for local KV Store
+- name: Set Postgres migrate on startup for default KV Store type
   ini_file:
     dest: "{{ splunk.home }}/etc/system/local/server.conf"
     section: kvstore
     option: "postgresMigrateOnStartup"
-    value: "false"
+    value: "{{ 'false' if splunk.kvstore.default_kvstore_type == 'local' else 'true' }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-  when:
-    - splunk.kvstore.default_kvstore_type == "local"
-    - kvstore_local_supported | default(false) | bool
+  when: kvstore_default_type_supported | default(false) | bool

--- a/roles/splunk_common/tasks/set_default_kvstore_type.yml
+++ b/roles/splunk_common/tasks/set_default_kvstore_type.yml
@@ -1,0 +1,25 @@
+---
+- name: Validate default KV Store type
+  assert:
+    that:
+      - splunk.kvstore.default_kvstore_type in ["cohosted", "local"]
+    fail_msg: "splunk.kvstore.default_kvstore_type must be either 'cohosted' or 'local'"
+
+- name: Set default KV Store type
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: kvstore
+    option: "defaultKVStoreType"
+    value: "{{ splunk.kvstore.default_kvstore_type }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+
+- name: Disable Postgres migrate on startup for local KV Store
+  ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: kvstore
+    option: "postgresMigrateOnStartup"
+    value: "false"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  when: splunk.kvstore.default_kvstore_type == "local"

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -653,6 +653,24 @@ def test_getNodeSidecarPostgres(os_env, result):
             environ.getNodeSidecarPostgres(vars_scope)
     assert vars_scope["splunk"] == result
 
+@pytest.mark.parametrize(("default_yml", "os_env", "result"),
+            [
+                ({}, {}, {}),
+                ({"default_kvstore_type": "cohosted"}, {}, {"default_kvstore_type": "cohosted"}),
+                ({"default_kvstore_type": "local"}, {}, {"default_kvstore_type": "local"}),
+                ({}, {"SPLUNK_KVSTORE_DEFAULT_TYPE": ""}, {}),
+                ({}, {"SPLUNK_KVSTORE_DEFAULT_TYPE": "local"}, {"default_kvstore_type": "local"}),
+                ({}, {"SPLUNK_KVSTORE_DEFAULT_TYPE": "LOCAL"}, {"default_kvstore_type": "local"}),
+            ]
+        )
+def test_getDefaultKVStoreType(default_yml, os_env, result):
+    vars_scope = {"splunk": {"kvstore": {}}}
+    vars_scope["splunk"]["kvstore"].update(default_yml)
+    with patch("environ.inventory") as mock_inven:
+        with patch("os.environ", new=os_env):
+            environ.getDefaultKVStoreType(vars_scope)
+    assert vars_scope["splunk"]["kvstore"] == result
+
 @pytest.mark.parametrize(("es_enablement", "os_env", "result"),
             [
                 (None, {}, ""),


### PR DESCRIPTION
## Summary

- Add `SPLUNK_KVSTORE_DEFAULT_TYPE` handling so Splunk Ansible can explicitly configure `[kvstore] defaultKVStoreType`.
- Keep Ansible unset behavior as a no-op: no default `defaultKVStoreType` value is introduced by this change.
- When the effective KV Store type is explicitly set to `local`, also write `[kvstore] postgresMigrateOnStartup=false`.
- Wire the new task into `splunk_common` for non-Universal Forwarder roles and document the new environment variable.

## Why

SOK needs to configure supported CMP-K Splunk pods for local KV Store without relying on a bundled app to write `server.conf`. This adds the Ansible-side hook while preserving existing behavior unless the value is explicitly supplied.

## Validation

- `python3 -c "path='/Users/sgontla/git/Ansible/splunk-ansible/inventory/environ.py'; compile(open(path).read(), path, 'exec'); print('syntax ok')"`
- Direct parser checks for unset, empty, explicit `LOCAL`, and explicit `cohosted`
- `git diff --check`

Full `make test` was not run locally because the current Python environment is missing dependencies from `tests/requirements.txt` such as `mock`, `ansible-lint`, `molecule`, and related tooling.




### Manually validated on 10.4 and 10.6:
```
On 10.4, mounted my ansible branch, and ran the playbook to set cohosted. As expected, it didn't change the config to cohosted, and still points to local:

docker run -d   --name splunk-kvtype-local   --platform linux/amd64   --user root   --entrypoint /bin/bash   -e SPLUNK_START_ARGS=--accept-license   -e SPLUNK_PASSWORD='Password123!'   -e SPLUNK_KVSTORE_DEFAULT_TYPE=cohosted   -v "$PWD":/tmp/splunk-ansible   splunk/splunk:latest   -lc 'sleep infinity'

sgontla@sgk8s:~/git/Ansible/splunk-ansible$ docker exec -u root splunk-kvtype-local bash -lc '
  /opt/splunk/bin/splunk version --accept-license --answer-yes --no-prompt
'
Splunk 10.4.2 (build 33c3bf42cd73)


sgontla@sgk8s:~/git/Ansible/splunk-ansible$ docker exec -u splunk splunk-kvtype-local bash -lc '
  /opt/splunk/bin/splunk btool server list kvstore --debug \
    | egrep "defaultKVStoreType|postgresMigrateOnStartup"
'
ERROR - Failed opening "/opt/splunk/var/log/splunk/btool.log": Permission denied
/opt/splunk/etc/system/default/server.conf defaultKVStoreType = local
/opt/splunk/etc/system/default/server.conf postgresMigrateOnStartup = false





Now, run the docker image with 10.6:

docker rm -f splunk-kvtype-local 2>/dev/null || true

docker run -d \
  --name splunk-kvtype-local \
  --platform linux/arm64 \
  --user root \
  --entrypoint /bin/bash \
  -e SPLUNK_START_ARGS=--accept-license \
  -e SPLUNK_PASSWORD='Password123!' \
  -e SPLUNK_KVSTORE_DEFAULT_TYPE=local \
  -v /Users/sgontla/git/Ansible/splunk-ansible:/tmp/splunk-ansible \
  docker.repo.splunkdev.net/eng-effectiveness/docker-splunk/splunk/splunk-redhat-9-arm64:10.6.0-b5422d3eeb03 \
  -lc 'sleep infinity'

docker exec -u root -it splunk-kvtype-local bash -lc '
  cd /tmp/splunk-ansible &&
  ansible-playbook -i inventory/environ.py --limit localhost site.yml
'



sgontla@ [~/git/Ansible/splunk-ansible]$docker exec -u root splunk-kvtype-local bash -lc '
>   /opt/splunk/bin/splunk version --accept-license --answer-yes --no-prompt
>   echo "--- system/local/server.conf ---"
>   grep -nE "defaultKVStoreType|postgresMigrateOnStartup" /opt/splunk/etc/system/local/server.conf
> '
Splunk 10.6.0 (build b5422d3eeb03)
--- system/local/server.conf ---
6:defaultKVStoreType = local
7:postgresMigrateOnStartup = false



After moving to cohosted:

docker rm -f splunk-kvtype-cohosted 2>/dev/null || true

docker run -d \
  --name splunk-kvtype-cohosted \
  --platform linux/arm64 \
  --user root \
  --entrypoint /bin/bash \
  -e SPLUNK_START_ARGS=--accept-license \
  -e SPLUNK_PASSWORD='Password123!' \
  -e SPLUNK_KVSTORE_DEFAULT_TYPE=cohosted \
  -v /Users/sgontla/git/Ansible/splunk-ansible:/tmp/splunk-ansible \
  docker.repo.splunkdev.net/eng-effectiveness/docker-splunk/splunk/splunk-redhat-9-arm64:10.6.0-b5422d3eeb03 \
  -lc 'sleep infinity'

docker exec -u root -it splunk-kvtype-cohosted bash -lc '
  cd /tmp/splunk-ansible &&
  ansible-playbook -i inventory/environ.py --limit localhost site.yml
'


sgontla@ [~/git/Ansible/splunk-ansible]$docker exec -u root splunk-kvtype-cohosted bash -lc '
>   grep -nE "defaultKVStoreType|postgresMigrateOnStartup" /opt/splunk/etc/system/local/server.conf
> '
6:defaultKVStoreType = cohosted
7:postgresMigrateOnStartup = true

```

