### PR TITLE
support openjdk 21

### DIFF
--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -39,7 +39,7 @@ HERE = os.path.dirname(os.path.normpath(__file__))
 _PLATFORM = platform.platform().lower()
 PLATFORM = "windows" if ("windows" in _PLATFORM or "cygwin" in _PLATFORM) else "linux"
 HOSTNAME = os.uname()[1]
-JAVA_VERSION_WHITELIST = frozenset(("oracle:8", "openjdk:8", "openjdk:9", "openjdk:11"))
+JAVA_VERSION_WHITELIST = frozenset(("oracle:8", "openjdk:8", "openjdk:9", "openjdk:11", "openjdk:21"))
 
 roleNames = [
     'splunk_cluster_master', # (if it exists, set up indexer clustering)
@@ -440,6 +440,12 @@ def getJava(vars_scope):
             raise Exception("Invalid Java download URL format")
     elif java_version == "openjdk:11":
         vars_scope["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz")
+        try:
+            vars_scope["java_update_version"] = re.search(r"openjdk-(\d+\.\d+\.\d+)_linux-x64_bin.tar.gz", vars_scope["java_download_url"]).group(1)
+        except:
+            raise Exception("Invalid Java download URL format")
+    elif java_version == "openjdk:21":
+        vars_scope["java_download_url"] = os.environ.get("JAVA_DOWNLOAD_URL", "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz")
         try:
             vars_scope["java_update_version"] = re.search(r"openjdk-(\d+\.\d+\.\d+)_linux-x64_bin.tar.gz", vars_scope["java_download_url"]).group(1)
         except:

--- a/roles/splunk_common/tasks/install_java.yml
+++ b/roles/splunk_common/tasks/install_java.yml
@@ -22,3 +22,9 @@
   when:
     - java_version == "openjdk:9"
     - ansible_system is match("CYGWIN*|Win32NT")
+
+- name: Install Openjdk21 JDK
+  include_tasks: java_tasks/install_openjdk21_jdk.yml
+  when:
+    - java_version == "openjdk:21"
+    - ansible_system is match("Linux")

--- a/roles/splunk_common/tasks/java_tasks/install_openjdk21_jdk.yml
+++ b/roles/splunk_common/tasks/java_tasks/install_openjdk21_jdk.yml
@@ -1,0 +1,57 @@
+---
+- name: Create a dependency file
+  file:
+    path: /usr/share/man/man1
+    state: directory
+  when:
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat' or ansible_distribution == 'Ubuntu'
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Download the Java distribution
+  unarchive:
+    src: "{{ java_download_url }}"
+    dest: /opt/container_artifact
+    remote_src: yes
+  retries: "{{ retry_num }}"
+  delay: "{{ retry_delay }}"
+  when:
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat' or ansible_distribution == 'Ubuntu'
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Install openjdk for CentOS
+  yum:
+    name: java-21-openjdk
+    state: present
+  when:
+    - ansible_distribution == 'CentOS'
+  become: yes
+  become_user: "{{ privileged_user }}"
+
+- name: Create symlinks for java/javac
+  file:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    state: link
+  with_items:
+    - { "src": "/opt/container_artifact/jdk-{{ java_update_version }}/bin/java", "dest": "/usr/bin/java"}
+    - { "src": "/opt/container_artifact/jdk-{{ java_update_version }}/bin/javac", "dest": "/usr/bin/javac"}
+  become: yes
+  become_user: "{{ privileged_user }}"
+  ignore_errors: true
+  when:
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat' or ansible_distribution == 'Ubuntu'
+
+- name: Set JAVA_HOME in splunk-launch.conf
+  become: yes
+  become_user: "{{ privileged_user }}"
+  lineinfile:
+    path: "{{ splunk.home }}/etc/splunk-launch.conf"
+    regexp: '^JAVA_HOME'
+    line: "JAVA_HOME=/opt/container_artifact/jdk-{{ java_update_version }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+    create: yes
+  when:
+    - ansible_distribution == 'Debian' or ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
Adds support for installing openjdk 21 via environment variables. New code is based off existing install steps for openjdk 11.

Tested with the generic linux (non-CentOS) install step:
```
$ java --version
openjdk 21.0.2 2024-01-16
OpenJDK Runtime Environment (build 21.0.2+13-58)
OpenJDK 64-Bit Server VM (build 21.0.2+13-58, mixed mode, sharing)
$ cat /opt/splunk/etc/splunk-launch.conf
JAVA_HOME=/opt/container_artifact/jdk-21.0.2
```
