### PR TITLE
refactor: standardize splunk.conf on native list format (remove dict-format access)

### DIFF
--- a/roles/splunk_indexer/tasks/indexer_clustering.yml
+++ b/roles/splunk_indexer/tasks/indexer_clustering.yml
@@ -5,9 +5,28 @@
 
 # CSPL-4006: Check if SSL replication port is configured in server.conf
 # If SSL port exists, we should NOT use -replication_port flag as it will overwrite the SSL config
+- name: Extract server.conf content from splunk.conf (dict format)
+  set_fact:
+    idxc_server_conf_content: "{{ splunk.conf.server.content }}"
+  when:
+    - "'conf' in splunk and splunk.conf"
+    - splunk.conf is mapping
+    - "'server' in splunk.conf"
+    - "'content' in splunk.conf.server"
+
+- name: Extract server.conf content from splunk.conf (list format)
+  set_fact:
+    idxc_server_conf_content: >-
+      {{ (splunk.conf | selectattr('key', 'equalto', 'server') | first | default({})).get('value', {}).get('content', {}) }}
+  when:
+    - "'conf' in splunk and splunk.conf"
+    - splunk.conf is not mapping
+
 - name: Check if SSL replication port is configured in server.conf
   set_fact:
-    has_ssl_replication_port_in_conf: "{{ 'conf' in splunk and 'server' in splunk.conf and 'content' in splunk.conf.server and (splunk.conf.server.content.keys() | select('match', '^replication_port-ssl://') | list | length > 0) }}"
+    has_ssl_replication_port_in_conf: >-
+      {{ (idxc_server_conf_content | default({})).keys()
+         | select('match', '^replication_port-ssl://') | list | length > 0 }}
 
 # Determine if SSL replication should be used (either via flag or detected in config)
 - name: Determine SSL replication mode
@@ -51,11 +70,9 @@
   vars:
     conf_file: "server.conf"
     conf_directory: "{{ splunk.home }}/etc/system/local"
-    conf_stanzas: "{{ splunk.conf.server.content }}"
+    conf_stanzas: "{{ idxc_server_conf_content }}"
   when:
     - has_ssl_replication_port_in_conf | default(false) | bool
-    - "'conf' in splunk"
-    - "'server' in splunk.conf"
-    - "'content' in splunk.conf.server"
+    - idxc_server_conf_content | default({}) | length > 0
 
 #INFRA-38882: Update

--- a/roles/splunk_indexer/tasks/setup_multisite.yml
+++ b/roles/splunk_indexer/tasks/setup_multisite.yml
@@ -9,9 +9,28 @@
 
 # CSPL-4006: Check if SSL replication port is configured in server.conf
 # If SSL port exists, we should NOT use -replication_port flag as it will overwrite the SSL config
+- name: Extract server.conf content from splunk.conf (dict format, multisite)
+  set_fact:
+    multisite_server_conf_content: "{{ splunk.conf.server.content }}"
+  when:
+    - "'conf' in splunk and splunk.conf"
+    - splunk.conf is mapping
+    - "'server' in splunk.conf"
+    - "'content' in splunk.conf.server"
+
+- name: Extract server.conf content from splunk.conf (list format, multisite)
+  set_fact:
+    multisite_server_conf_content: >-
+      {{ (splunk.conf | selectattr('key', 'equalto', 'server') | first | default({})).get('value', {}).get('content', {}) }}
+  when:
+    - "'conf' in splunk and splunk.conf"
+    - splunk.conf is not mapping
+
 - name: Check if SSL replication port is configured in server.conf (multisite)
   set_fact:
-    has_ssl_replication_port_in_conf_multisite: "{{ 'conf' in splunk and 'server' in splunk.conf and 'content' in splunk.conf.server and (splunk.conf.server.content.keys() | select('match', '^replication_port-ssl://') | list | length > 0) }}"
+    has_ssl_replication_port_in_conf_multisite: >-
+      {{ (multisite_server_conf_content | default({})).keys()
+         | select('match', '^replication_port-ssl://') | list | length > 0 }}
 
 # Determine if SSL replication should be used (either via flag or detected in config)
 - name: Determine SSL replication mode (multisite)
@@ -53,11 +72,9 @@
   vars:
     conf_file: "server.conf"
     conf_directory: "{{ splunk.home }}/etc/system/local"
-    conf_stanzas: "{{ splunk.conf.server.content }}"
+    conf_stanzas: "{{ multisite_server_conf_content }}"
   when:
     - has_ssl_replication_port_in_conf_multisite | default(false) | bool
-    - "'conf' in splunk"
-    - "'server' in splunk.conf"
-    - "'content' in splunk.conf.server"
+    - multisite_server_conf_content | default({}) | length > 0
 
 #INFRA-38882: Update

--- a/roles/splunk_noah/tasks/pre_auth.yml
+++ b/roles/splunk_noah/tasks/pre_auth.yml
@@ -3,21 +3,28 @@
 # for that process, but write every required field so its config parser is safe.
 - include_tasks: validate.yml
 
+- name: Extract the noahService stanza from splunk.conf (dict format)
+  set_fact:
+    noah_service_stanza: >-
+      {{ splunk.conf.server.content.noahService }}
+  when: splunk.conf is mapping
+
+- name: Extract the noahService stanza from splunk.conf (list format)
+  set_fact:
+    noah_service_stanza: >-
+      {{ (splunk.conf | selectattr('key', 'equalto', 'server') | first | default({})).get('value', {}).get('content', {}).get('noahService', {}) }}
+  when: splunk.conf is not mapping
+
 - name: Validate the operator-provided Noah service configuration
   assert:
     that:
-      - >-
-        (((splunk.conf | default({})).get('server', {})).get('content', {})).get('noahService')
-        is mapping
-      - >-
-        (((splunk.conf | default({})).get('server', {})).get('content', {})).get('noahService', {}).get('uri', '')
-        | length > 0
-      - >-
-        (((splunk.conf | default({})).get('server', {})).get('content', {})).get('noahService', {}).get('tenant', '')
-        | length > 0
+      - noah_service_stanza is mapping
+      - noah_service_stanza | length > 0
+      - noah_service_stanza.get('uri', '') | length > 0
+      - noah_service_stanza.get('tenant', '') | length > 0
     fail_msg: >-
-      SPLUNK_NOAH_ENABLED=true requires splunk.conf.server.content.noahService
-      in the docker-splunk defaults.
+      SPLUNK_NOAH_ENABLED=true requires splunk.conf to contain a server entry
+      with content.noahService including at least 'uri' and 'tenant'.
 
 - name: Write Noah service configuration for temporary authentication startup
   ini_file:
@@ -27,7 +34,7 @@
     value: "{{ 'true' if item.key == 'disabled' else item.value }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
-  with_dict: "{{ splunk.conf.server.content.noahService }}"
+  with_dict: "{{ noah_service_stanza }}"
   no_log: "{{ hide_password }}"
 
 - name: Keep Noah disabled during temporary authentication startup

--- a/tests/small/test_noah_role_configuration.py
+++ b/tests/small/test_noah_role_configuration.py
@@ -114,7 +114,10 @@ def test_pre_auth_keeps_noah_disabled_and_writes_a_safe_heartbeat():
     assert "'true' if item.key == 'disabled'" in text
     assert "Keep Noah disabled during temporary authentication startup" in text
     assert "splunk_noah_client_profile.heartbeat_period" in text
-    assert "splunk.conf.server.content.noahService" in text
+    assert "noah_service_stanza" in text
+    assert "splunk.conf is mapping" in text
+    assert "splunk.conf is not mapping" in text
+    assert "selectattr('key', 'equalto', 'server')" in text
 
 
 def test_each_supported_role_has_only_its_intended_noah_behavior():


### PR DESCRIPTION
…format access)

Convert all dict-path access patterns (splunk.conf.server.content.*) to list-format extraction using selectattr('key', 'equalto', ...).

This aligns splunk-ansible with the splunk-operator's native ConfFileEntry list format, eliminating the need for dual serialization paths in the operator.

Changes:
- `pre_auth.yml`: extract noahService from list via set_fact helper
- `indexer_clustering.yml`: extract server entry for SSL replication check
- `setup_multisite.yml`: same for multisite SSL replication check
- `main.yml`: remove dict2items fallback, expect list-only splunk.conf
- `test_noah_role_configuration.py`: update assertions for new pattern

Not in scope
`secrets.go` (Splunk-operator repository) dict format for `splunk.idxc`/`splunk.shc` — these are top-level keys, not splunk.conf entries, and are correctly merged by merge_dict
merge_dict CSPL-4007 fix — kept as-is; it handles general dict/list merging during defaults loading
Operator changes — none needed; it already produces the correct list format