### PR TITLE
Add SPLUNK_KVSTORE_DISABLED to opt out of the KV Store

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -87,6 +87,7 @@ Splunk-Ansible ships with an inventory script in `inventory/environ.py`. The scr
 | SPLUNKD_SSL_PASSWORD | Custom SSL password used with Splunkd when HTTPS is enabled | no | no | no |
 | SPLUNK_KVSTORE_PORT | Port to run Splunk KVStore. Default: `8191` | no | no | no |
 | SPLUNK_KVSTORE_DEFAULT_TYPE | Configures `[kvstore] defaultKVStoreType` in `server.conf` when explicitly set. Allowed values are `cohosted` and `local`; Ansible writes the setting only for Splunk Enterprise 10.6.0 or later. When set to `cohosted`, Ansible also writes `[kvstore] postgresMigrateOnStartup=true`; when set to `local`, it writes `[kvstore] postgresMigrateOnStartup=false`. Older Splunk versions skip the default KV Store type configuration. SOK injects `local` for supported CMP-K deployments. | no | no | no |
+| SPLUNK_KVSTORE_DISABLED | Configures `[kvstore] disabled` in `server.conf` when explicitly set to `true` or `false`. Indexers and forwarders are documented as safe to run without the KV Store; use this to disable it on deployments that have no local apps or lookups depending on it. Unset by default, leaving Splunk's own default (enabled) in place. | no | no | no |
 | SPLUNK_APPSERVER_PORT | Port to run Splunk appserver. Default: `8065` | no | no | no |
 | SPLUNK_SET_SEARCH_PEERS | Boolean to configure whether search heads should connect to search peers. Default: `True`. Not recommended to change | no | no | no |
 | SPLUNK_SITE | For multisite topologies, define the site of this particular Splunk Enterprise instance | no | no | no |

--- a/docs/advanced/default.yml.spec.md
+++ b/docs/advanced/default.yml.spec.md
@@ -418,6 +418,11 @@ splunk:
     * Determine the port used for Splunk Key-Value store
     * Default: 8191
 
+    disabled: <bool>
+    * When explicitly set, writes [kvstore] disabled in server.conf. Splunk indexers and
+      forwarders can run without the KV Store; this lets a deployment opt out of it.
+    * Default: null (not written; Splunk's own default of enabled stands)
+
   launch: null
   * key::value pairs for environment variables that get written to ${SPLUNK_HOME}/etc/splunk-launch.conf
   * Default: null

--- a/inventory/environ.py
+++ b/inventory/environ.py
@@ -177,6 +177,7 @@ def getDefaultVars():
     getDSP(defaultVars)
     getIPv6(defaultVars)
     getDefaultKVStoreType(defaultVars)
+    getKVStoreDisabled(defaultVars)
     getNodeSidecarPostgres(defaultVars)
     return defaultVars
 
@@ -763,6 +764,19 @@ def getDefaultKVStoreType(vars_scope):
     default_kvstore_type = val.lower()
     vars_scope["splunk"].setdefault("kvstore", {})
     vars_scope["splunk"]["kvstore"]["default_kvstore_type"] = default_kvstore_type
+
+def getKVStoreDisabled(vars_scope):
+    """
+    Honor SPLUNK_KVSTORE_DISABLED to configure server.conf
+    [kvstore] disabled when explicitly provided.
+    """
+    kvstore = vars_scope["splunk"].get("kvstore", {})
+    val = os.environ.get("SPLUNK_KVSTORE_DISABLED", kvstore.get("disabled"))
+    if val is None or val == "":
+        return
+
+    vars_scope["splunk"].setdefault("kvstore", {})
+    vars_scope["splunk"]["kvstore"]["disabled"] = str(val).lower() == "true"
 
 def getNodeSidecarPostgres(vars_scope):
     """

--- a/roles/splunk_common/tasks/main.yml
+++ b/roles/splunk_common/tasks/main.yml
@@ -112,6 +112,11 @@
     - splunk.kvstore.default_kvstore_type | length > 0
     - splunk.role != "splunk_universal_forwarder"
 
+- include_tasks: set_kvstore_disabled.yml
+  when:
+    - "'kvstore' in splunk and 'disabled' in splunk.kvstore"
+    - splunk.kvstore.disabled is not none
+
 - include_tasks: enable_splunkweb_ssl.yml
   when:
     - "'http_enableSSL' in splunk and splunk.http_enableSSL is not none"

--- a/roles/splunk_common/tasks/set_kvstore_disabled.yml
+++ b/roles/splunk_common/tasks/set_kvstore_disabled.yml
@@ -1,0 +1,12 @@
+---
+- ini_file:
+    dest: "{{ splunk.home }}/etc/system/local/server.conf"
+    section: kvstore
+    option: "disabled"
+    value: "{{ splunk.kvstore.disabled | bool | lower }}"
+    owner: "{{ splunk.user }}"
+    group: "{{ splunk.group }}"
+  register: set_kvstore_disabled
+
+- include_tasks: ../handlers/restart_splunk.yml
+  when: set_kvstore_disabled is changed

--- a/roles/splunk_common/tasks/set_kvstore_disabled.yml
+++ b/roles/splunk_common/tasks/set_kvstore_disabled.yml
@@ -7,6 +7,8 @@
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
   register: set_kvstore_disabled
+  become: yes
+  become_user: "{{ splunk.user }}"
 
 - include_tasks: ../handlers/restart_splunk.yml
   when: set_kvstore_disabled is changed

--- a/tests/small/test_environ.py
+++ b/tests/small/test_environ.py
@@ -671,6 +671,25 @@ def test_getDefaultKVStoreType(default_yml, os_env, result):
             environ.getDefaultKVStoreType(vars_scope)
     assert vars_scope["splunk"]["kvstore"] == result
 
+@pytest.mark.parametrize(("default_yml", "os_env", "result"),
+            [
+                ({}, {}, {}),
+                ({"disabled": True}, {}, {"disabled": True}),
+                ({"disabled": False}, {}, {"disabled": False}),
+                ({}, {"SPLUNK_KVSTORE_DISABLED": ""}, {}),
+                ({}, {"SPLUNK_KVSTORE_DISABLED": "true"}, {"disabled": True}),
+                ({}, {"SPLUNK_KVSTORE_DISABLED": "TRUE"}, {"disabled": True}),
+                ({}, {"SPLUNK_KVSTORE_DISABLED": "false"}, {"disabled": False}),
+            ]
+        )
+def test_getKVStoreDisabled(default_yml, os_env, result):
+    vars_scope = {"splunk": {"kvstore": {}}}
+    vars_scope["splunk"]["kvstore"].update(default_yml)
+    with patch("environ.inventory") as mock_inven:
+        with patch("os.environ", new=os_env):
+            environ.getKVStoreDisabled(vars_scope)
+    assert vars_scope["splunk"]["kvstore"] == result
+
 @pytest.mark.parametrize(("es_enablement", "os_env", "result"),
             [
                 (None, {}, ""),


### PR DESCRIPTION
## Why

Splunk indexers and forwarders are documented as safe to run without the App Key Value Store ([About the app key value store](https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/9.2/administer-the-app-key-value-store/about-the-app-key-value-store)), but the collection has no way to express that. The only existing route is the generic `splunk.conf` escape hatch, and the one branch that tried this directly (`CSPL-4011-disable-kvstore`) is ingestor-scoped, unmerged, and puts `kvstore:` directly under `value:` — omitting the required `content:` level, so it never actually writes anything.

## What

Mirrors the newest kvstore task's presence-gated pattern (`set_default_kvstore_type.yml`):

- `roles/splunk_common/tasks/set_kvstore_disabled.yml` (new) — single `ini_file` task writing `[kvstore] disabled` to `server.conf`, following the register-and-restart pattern used elsewhere in this role (`set_server_name.yml`, `set_postgres_sidecar.yml`).
- Wired into `roles/splunk_common/tasks/main.yml` right after `set_default_kvstore_type.yml`, gated on **presence** (`'disabled' in splunk.kvstore`) rather than a `false` default — same reasoning upstream already applied to `default_kvstore_type`, and it means `roles/splunk_indexer/molecule/default/tests/test_default.py`'s `mongod.lock` assertion is untouched (this is opt-in, not a default-behavior change).
- `SPLUNK_KVSTORE_DISABLED` env override in `inventory/environ.py`, mirroring `getDefaultKVStoreType`'s shape.
- Docs in `docs/ADVANCED.md` and `docs/advanced/default.yml.spec.md`.
- Unit test in `tests/small/test_environ.py`.

## Testing

- `tests/small/` (pytest): all new cases pass, no regressions.
- Functional dry-run: ran the actual `main.yml` gate condition and `set_kvstore_disabled.yml` task via `ansible-playbook` against a scratch `splunk.home`, confirmed the gate only fires when `kvstore.disabled` is explicitly set, the first write is `changed`, a repeat is idempotent, and the resulting `server.conf` reads exactly `[kvstore]\ndisabled = <bool>`.
- **Not yet run**: this hasn't been exercised on a live Splunk instance. We're building it as the KV-store-disable pilot for a new production indexer joining our cluster and expect to run it there within the next few days — will report back with the result.
