### PR TITLE
Fix reconcile_config_map_values.yml: read ConfigMap state from the managed host, not the control node

### DIFF
--- a/roles/splunk_common/tasks/reconcile_config_map_values.yml
+++ b/roles/splunk_common/tasks/reconcile_config_map_values.yml
@@ -6,10 +6,18 @@
   become: yes
   become_user: "{{ splunk.user }}"
 
+- name: Read previous ConfigMap-owned values in {{ conf_file }}
+  slurp:
+    src: "{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml"
+  register: config_map_managed_values_content
+  become: yes
+  become_user: "{{ splunk.user }}"
+  when: config_map_managed_values_file.stat.exists
+  no_log: "{{ hide_password }}"
+
 - name: Load previous ConfigMap-owned values in {{ conf_file }}
-  include_vars:
-    file: "{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml"
-    name: previous_config_map_stanzas
+  set_fact:
+    previous_config_map_stanzas: "{{ config_map_managed_values_content.content | b64decode | from_yaml }}"
   when: config_map_managed_values_file.stat.exists
   no_log: "{{ hide_password }}"
 


### PR DESCRIPTION
## Summary

`reconcile_config_map_values.yml` (added in #921 / CSPL-5085) always fails once a host's
ConfigMap-owned state file exists, in any topology where the Ansible control node and the
managed host are different machines.

## Root cause

The "Load previous ConfigMap-owned values" task uses `include_vars`, which is a
control-node-local action (`_requires_connection = False` in
`ansible/plugins/action/include_vars.py`) — it reads its `file:` argument off the **control
node's** filesystem, never the managed host. This task passes it an absolute path that only
exists on the **target**, e.g.
`{{ conf_directory }}/.{{ conf_file }}.splunk-ansible-managed.yml`.

- **First convergence**: the preceding `stat` task (which correctly runs on the remote host via
  `become_user: "{{ splunk.user }}"`) finds nothing, so `include_vars` is skipped by its `when:`
  guard — this is why the bug doesn't show up on a fresh host.
- **Second+ convergence**: the state file now exists on the remote host (the `copy` task that
  writes it runs remotely, correctly), the guard flips true, `include_vars` looks for that same
  path on the control node, fails, and the failure is swallowed by
  `no_log: "{{ hide_password }}"`.

#921's own testing was done entirely inside Splunk Operator for Kubernetes pods
(`IndexerCluster` + `ClusterManager` + `LicenseManager`), where the control node and the managed
host share one filesystem — the one topology where this bug is invisible. Any bare-metal or
AWX-style deployment (control node and target on different machines, connecting over SSH) hits
it on the second run.

## Fix

Swap `include_vars` for `slurp` + `b64decode | from_yaml`, which actually reads the file from
the managed host, using the same `become_user` the `stat` task already uses.

## Testing

- Live-verified against a real bare-metal host (Ansible connecting over SSH): first convergence
  succeeds, second convergence — previously a hard failure — now completes and applies the
  reconciliation correctly.
- `ansible-lint` on the changed file: no new findings (only pre-existing stylistic ones shared by
  the rest of the file — short module names, non-role-prefixed var names — left as-is to match
  surrounding style).
- `tests/small/test_hec_receiver.py::test_config_map_reconciliation_*` (3 tests): unaffected,
  still pass. Worth noting these only exercise the stanza-removal logic in pure Python and never
  exercised the load path, which is part of why this went uncaught.

## Note for reviewers

While verifying this fix I also noticed the second convergence isn't fully idempotent (a small
`changed` count even when config content is unchanged) — this looks like a separate, pre-existing
property of the reconcile feature (it appears to unconditionally remove-then-reapply every
ConfigMap-owned key rather than diffing first) rather than something introduced or fixed here.
Not addressed in this PR; happy to file separately if useful.
