### PR TITLE
fix: don't require splunk.s2s.password when splunktcp-ssl is enabled

### DIFF
--- a/roles/splunk_common/tasks/s2s/configure_splunktcp_ssl.yml
+++ b/roles/splunk_common/tasks/s2s/configure_splunktcp_ssl.yml
@@ -37,6 +37,7 @@
     value: "{{ splunk.s2s.password }}"
     owner: "{{ splunk.user }}"
     group: "{{ splunk.group }}"
+  when: "'password' in splunk.s2s"
   register: splunktcp_ssl_pass_configured
 
 - name: Configure SSL root CA


### PR DESCRIPTION
## Why

`docs/advanced/default.yml.spec.md` documents `splunk.s2s.password` as optional — "Coupled with the `ssl` parameter above", default `null` — because splunktcp-ssl can be configured with a certificate and no password (e.g. an unencrypted private key). But the "Configure SSL password" task in `s2s/configure_splunktcp_ssl.yml` writes `splunk.s2s.password` unconditionally, so templating that value fails with an undefined-variable error the moment `s2s.ssl` is true and the deployment simply omits the `password` key from `splunk.s2s`, rather than falling back to the documented no-password case.

## What

Guard the task on the key actually being present:

```yaml
when: "'password' in splunk.s2s"
```

Matches the optionality the docs already describe, and leaves every other behavior (enabling the SSL input, cert path, root CA, restart trigger) unchanged.

## Verified

Read against the current `docs/advanced/default.yml.spec.md` s2s spec (`password: <str>`, default `null`) and the task's own caller (`enable_s2s.yml`), which only gates on `s2s.ssl`, not on `password` being set — confirming the crash is reachable from a documented, valid configuration.
