### PR TITLE
fix: relabel Splunk install dir after unarchive, only when SELinux is enabled

### DIFF
--- a/roles/splunk_common/tasks/install_splunk_tgz.yml
+++ b/roles/splunk_common/tasks/install_splunk_tgz.yml
@@ -63,3 +63,10 @@
   delay: "{{ retry_delay }}"
   become: yes
   become_user: "{{ privileged_user }}"
+
+- name: Apply SELinux file context to Splunk install dir
+  ansible.builtin.command: "restorecon -irv {{ splunk.home }}"
+  when: ansible_facts.selinux.status | default('disabled') == 'enabled'
+  changed_when: false
+  become: yes
+  become_user: "{{ privileged_user }}"


### PR DESCRIPTION
## Why

`unarchive` extracts files with the extracting process's own default SELinux context, which on an SELinux-enforcing host can mismatch the context splunkd's policy expects under `$SPLUNK_HOME` — `restorecon` corrects that after install.

## What

Adds a `restorecon -irv {{ splunk.home }}` step after the unarchive task in `install_splunk_tgz.yml`, gated on `ansible_facts.selinux.status == 'enabled'`. Without the gate this would hard-fail on any host with no SELinux userland at all (e.g. Debian/Ubuntu, where the `restorecon` binary doesn't exist), rather than being a no-op there. `changed_when: false` since relabeling isn't state this playbook should report as "changed".

## Verified

`ansible_facts.selinux` is a core-gathered fact (no extra `gather_subset` needed); `status` is `'enabled'`/`'disabled'` on hosts with the SELinux userland present, and the key is absent entirely on hosts without it, hence the `| default('disabled')` fallback.
